### PR TITLE
Require confirmation again when a score is resubmitted after a dispute

### DIFF
--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -1873,8 +1873,15 @@ impl Api {
         // A supplied score creates a new submission only when it differs from
         // the current confirmed score. For a not-yet-played match, a new score
         // also completes it.
-        let mut confirmed_score: Option<dao::records::ConfirmedScoreRecord> = None;
         let mut status_override: Option<&str> = input.status.as_ref().map(match_status_str);
+
+        // A score submitted here is a PENDING submission, not a confirmed one:
+        // it awaits the other side(s)' confirmation via
+        // `POST /matches/:id/score-submissions/:sid/respond`, exactly like a
+        // create-time score (mirrors `create_match`/`respond_to_score_submission`).
+        // This is what makes a resubmission after a dispute require fresh
+        // approval instead of silently overriding the rejection.
+        let mut pending_score: Option<dao::records::PendingScoreRecord> = None;
 
         if let Some(score) = &input.score {
             // Validate every scored side exists on the match.
@@ -1897,25 +1904,62 @@ impl Api {
                 .unwrap_or(true);
 
             if differs {
-                // Record a score submission (history) attributed to the caller.
+                // The submission is attributed to the caller's own player/side
+                // (needed so their side can be pre-confirmed, same as at
+                // create time), so the caller must be an assigned participant.
+                let caller_player = agg
+                    .players
+                    .iter()
+                    .find(|p| p.user_id.as_deref() == Some(uid.as_str()));
+                let (caller_player_id, caller_side_id) = match caller_player.and_then(|p| {
+                    p.side_id
+                        .as_ref()
+                        .map(|sid| (p.player_id.clone(), sid.clone()))
+                }) {
+                    Some(pair) => pair,
+                    None => {
+                        return Ok(UpdateMatchResponse::ValidationError(PlainText(
+                            "a score can only be submitted by a participant assigned \
+                             to a side"
+                                .into(),
+                        )));
+                    }
+                };
+
+                let submission_id = new_id();
                 let submitted_at = now_iso();
-                let submission = dao::records::ScoreSubmissionRecord {
-                    submission_id: new_id(),
+                let confirmation = dao::records::ScoreConfirmationRecord {
+                    side_id: caller_side_id.clone(),
+                    confirmed_by_player_id: caller_player_id.clone(),
+                    confirmed_at: submitted_at.clone(),
+                };
+                let pending = dao::records::PendingScoreRecord {
+                    submission_id: submission_id.clone(),
                     score: new_record.clone(),
                     winner_side_id: input.winner_side_id.clone(),
-                    status: String::from("confirmed"),
-                    submitted_by_player_id: uid.clone(),
-                    submitted_at,
-                    responses: Vec::new(),
+                    confirmations: vec![confirmation],
+                };
+                let submission = dao::records::ScoreSubmissionRecord {
+                    submission_id,
+                    score: new_record,
+                    winner_side_id: input.winner_side_id.clone(),
+                    status: String::from("pending"),
+                    submitted_by_player_id: caller_player_id.clone(),
+                    submitted_at: submitted_at.clone(),
+                    // Seed the submitter's side as confirmed, so once the other
+                    // side(s) confirm, the submission becomes fully confirmed.
+                    responses: vec![dao::records::ScoreResponseRecord {
+                        side_id: caller_side_id,
+                        responded_by_player_id: caller_player_id,
+                        response: String::from("confirm"),
+                        responded_at: submitted_at,
+                    }],
                 };
                 dao.put_score_submission(&match_id, &submission)
                     .await
                     .map_err(dao_internal)?;
 
-                confirmed_score = Some(dao::records::ConfirmedScoreRecord {
-                    score: new_record,
-                    winner_side_id: input.winner_side_id.clone(),
-                });
+                pending_score = Some(pending);
 
                 // A not-yet-played match becomes Completed when first scored.
                 if status_override.is_none() && agg.match_.status != "completed" {
@@ -1942,8 +1986,8 @@ impl Api {
                 .starts_at
                 .map(|d| d.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
                 .as_deref(),
-            confirmed_score,
             None,
+            pending_score.map(Some),
             header_photo_urls,
         )
         .await

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -1454,6 +1454,19 @@ fn simple_score(side_a: &str, side_b: &str, a: i32, b: i32) -> models::Score {
     }))
 }
 
+/// Extract `(side_id, points)` pairs from a simple score, for asserting on the
+/// value of a `confirmed_score`/`pending_score`/submission's score.
+fn simple_score_points(score: &models::Score) -> Vec<(String, i32)> {
+    match score {
+        models::Score::Simple(s) => s
+            .entries
+            .iter()
+            .map(|e| (e.side_id.clone(), e.points))
+            .collect(),
+        models::Score::Sets(_) => panic!("expected a simple score"),
+    }
+}
+
 #[tokio::test]
 async fn scoring_a_match_completes_it_and_records_a_pending_submission() {
     let (config, _owner) = new_user().await;
@@ -1612,6 +1625,198 @@ async fn rejecting_a_score_and_resubmitting_requires_approval_again() {
         .confirmed_score
         .expect("resubmitted score is confirmed after opponent approves");
     assert_eq!(confirmed.winner_side_id.as_deref(), Some(side_a.as_str()));
+}
+
+/// Sets up a match with a confirmed score (owner on side "a", opponent on side
+/// "b", 6-3 to the owner), for tests that edit an already-confirmed score.
+/// Returns (owner_config, owner, opponent_config, opponent, match, side_a, side_b).
+async fn match_with_a_confirmed_score() -> (
+    Configuration,
+    models::User,
+    Configuration,
+    models::User,
+    models::Match,
+    String,
+    String,
+) {
+    let (owner_config, owner) = new_user().await;
+    let (opponent_config, opponent) = new_user().await;
+
+    let mut input = create_match_input(&opponent.profile.id);
+    input.invites = vec![models::CreateMatchInviteInput {
+        side_client_id: Some("b".to_string()),
+        invited_user_ids: vec![opponent.profile.id.clone()],
+        invited_external_names: vec![],
+    }];
+    input.starts_at = iso_offset_hours(-2);
+    input.creator_side_client_id = Some("a".to_string());
+    input.score = Some(Box::new(simple_score("a", "b", 6, 3)));
+    input.winner_side_id = Some("a".to_string());
+
+    let created = matches_post(&owner_config, input)
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+    let side_b = created.sides[1].id.clone();
+    let first_submission_id = created
+        .pending_score
+        .as_ref()
+        .expect("pending at create time")
+        .submission_id
+        .clone();
+
+    matches_match_id_score_submissions_submission_id_respond_post(
+        &opponent_config,
+        &created.id,
+        &first_submission_id,
+        models::RespondToScoreInput {
+            response: models::ScoreResponseKind::Confirm,
+        },
+    )
+    .await
+    .expect("confirm original score");
+
+    let confirmed = matches_match_id_get(&owner_config, &created.id)
+        .await
+        .expect("get match");
+    assert!(confirmed.confirmed_score.is_some(), "setup: score confirmed");
+
+    (
+        owner_config,
+        owner,
+        opponent_config,
+        opponent,
+        confirmed,
+        side_a,
+        side_b,
+    )
+}
+
+#[tokio::test]
+async fn editing_a_confirmed_score_stays_pending_until_the_other_side_confirms() {
+    let (owner_config, _owner, opponent_config, _opponent, created, side_a, side_b) =
+        match_with_a_confirmed_score().await;
+
+    // The owner edits the match with a new, different score.
+    let edited = matches_match_id_patch(
+        &owner_config,
+        &created.id,
+        models::UpdateMatchInput {
+            score: Some(Box::new(simple_score(&side_a, &side_b, 6, 4))),
+            winner_side_id: Some(side_a.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("patch edited score");
+
+    // The old confirmed score is untouched; the new one shows up as pending.
+    let still_confirmed = edited
+        .confirmed_score
+        .expect("confirmed score is unaffected by an unapproved edit");
+    assert_eq!(
+        simple_score_points(&still_confirmed.score),
+        vec![(side_a.clone(), 6), (side_b.clone(), 3)],
+        "the previously-confirmed score must not change until the edit is approved"
+    );
+    let pending = edited
+        .pending_score
+        .expect("the edit is pending, not applied immediately");
+    assert_eq!(
+        simple_score_points(&pending.score),
+        vec![(side_a.clone(), 6), (side_b.clone(), 4)]
+    );
+
+    // History now has the confirmed original plus the new pending edit.
+    let submissions = matches_match_id_score_submissions_get(&owner_config, &created.id)
+        .await
+        .expect("list submissions");
+    assert_eq!(submissions.len(), 2);
+
+    // The opponent confirms the edit, promoting it to the confirmed score.
+    matches_match_id_score_submissions_submission_id_respond_post(
+        &opponent_config,
+        &created.id,
+        &pending.submission_id,
+        models::RespondToScoreInput {
+            response: models::ScoreResponseKind::Confirm,
+        },
+    )
+    .await
+    .expect("confirm edited score");
+
+    let final_match = matches_match_id_get(&owner_config, &created.id)
+        .await
+        .expect("get match");
+    let final_confirmed = final_match
+        .confirmed_score
+        .expect("edited score is confirmed");
+    assert_eq!(
+        simple_score_points(&final_confirmed.score),
+        vec![(side_a.clone(), 6), (side_b.clone(), 4)]
+    );
+    assert!(final_match.pending_score.is_none());
+}
+
+#[tokio::test]
+async fn disputing_an_edit_to_a_confirmed_score_leaves_the_original_confirmed_score_intact() {
+    let (owner_config, _owner, opponent_config, _opponent, created, side_a, side_b) =
+        match_with_a_confirmed_score().await;
+
+    let edited = matches_match_id_patch(
+        &owner_config,
+        &created.id,
+        models::UpdateMatchInput {
+            score: Some(Box::new(simple_score(&side_a, &side_b, 6, 4))),
+            winner_side_id: Some(side_a.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("patch edited score");
+    let pending = edited.pending_score.expect("the edit is pending");
+
+    // The opponent disputes the edit.
+    matches_match_id_score_submissions_submission_id_respond_post(
+        &opponent_config,
+        &created.id,
+        &pending.submission_id,
+        models::RespondToScoreInput {
+            response: models::ScoreResponseKind::Dispute,
+        },
+    )
+    .await
+    .expect("dispute edited score");
+
+    let after_dispute = matches_match_id_get(&owner_config, &created.id)
+        .await
+        .expect("get match");
+    assert!(
+        after_dispute.pending_score.is_none(),
+        "a disputed edit clears the pending score"
+    );
+    let confirmed = after_dispute
+        .confirmed_score
+        .expect("the original confirmed score still stands");
+    assert_eq!(
+        simple_score_points(&confirmed.score),
+        vec![(side_a.clone(), 6), (side_b.clone(), 3)],
+        "a disputed edit must not change the previously-confirmed score"
+    );
+
+    // History has the original confirmed submission and the disputed edit.
+    let submissions = matches_match_id_score_submissions_get(&owner_config, &created.id)
+        .await
+        .expect("list submissions");
+    assert_eq!(submissions.len(), 2);
+    let disputed_submission = submissions
+        .iter()
+        .find(|s| s.id == pending.submission_id)
+        .expect("edited submission present in history");
+    assert!(matches!(
+        disputed_submission.status,
+        models::ScoreSubmissionStatus::Disputed
+    ));
 }
 
 #[tokio::test]

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -1455,18 +1455,21 @@ fn simple_score(side_a: &str, side_b: &str, a: i32, b: i32) -> models::Score {
 }
 
 #[tokio::test]
-async fn scoring_a_match_completes_it_and_records_a_submission() {
+async fn scoring_a_match_completes_it_and_records_a_pending_submission() {
     let (config, _owner) = new_user().await;
     let (_invitee_config, invitee) = new_user().await;
 
-    let created = matches_post(&config, create_match_input(&invitee.profile.id))
-        .await
-        .expect("create match");
+    // The scorer must be an assigned participant, so put the owner on side "a".
+    let mut input = create_match_input(&invitee.profile.id);
+    input.creator_side_client_id = Some("a".to_string());
+    let created = matches_post(&config, input).await.expect("create match");
     assert!(matches!(created.status, models::MatchStatus::Scheduled));
     let side_a = created.sides[0].id.clone();
     let side_b = created.sides[1].id.clone();
 
-    // PATCH a score: this both completes the match and records a submission.
+    // PATCH a score: this completes the match and records a submission, but the
+    // score itself is PENDING (not confirmed) until the other side confirms it —
+    // same as a create-time score.
     let updated = matches_match_id_patch(
         &config,
         &created.id,
@@ -1479,13 +1482,136 @@ async fn scoring_a_match_completes_it_and_records_a_submission() {
     .await
     .expect("patch score");
     assert!(matches!(updated.status, models::MatchStatus::Completed));
-    assert!(updated.confirmed_score.is_some());
+    assert!(
+        updated.confirmed_score.is_none(),
+        "a PATCHed score awaits the other side's confirmation, not confirmed immediately"
+    );
+    assert!(updated.pending_score.is_some());
 
-    // The submission is visible in the match's submission history.
+    // The submission is visible in the match's submission history, as pending.
     let submissions = matches_match_id_score_submissions_get(&config, &created.id)
         .await
         .expect("list submissions");
-    assert!(!submissions.is_empty(), "a submission was recorded");
+    assert_eq!(submissions.len(), 1, "a submission was recorded");
+    assert!(matches!(
+        submissions[0].status,
+        models::ScoreSubmissionStatus::Pending
+    ));
+}
+
+#[tokio::test]
+async fn rejecting_a_score_and_resubmitting_requires_approval_again() {
+    let (owner_config, owner) = new_user().await;
+    let (opponent_config, opponent) = new_user().await;
+
+    // Owner plays on side "a", opponent is invited (and accepts) onto side "b".
+    let mut input = create_match_input(&opponent.profile.id);
+    input.invites = vec![models::CreateMatchInviteInput {
+        side_client_id: Some("b".to_string()),
+        invited_user_ids: vec![opponent.profile.id.clone()],
+        invited_external_names: vec![],
+    }];
+    input.starts_at = iso_offset_hours(-2);
+    input.creator_side_client_id = Some("a".to_string());
+    input.score = Some(Box::new(simple_score("a", "b", 6, 3)));
+    input.winner_side_id = Some("a".to_string());
+
+    let created = matches_post(&owner_config, input)
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+    let side_b = created.sides[1].id.clone();
+    assert!(created.confirmed_score.is_none(), "score starts pending");
+
+    let first_submission_id = created
+        .pending_score
+        .as_ref()
+        .expect("a pending score was recorded at create time")
+        .submission_id
+        .clone();
+
+    // The opponent rejects (disputes) the submitted score.
+    matches_match_id_score_submissions_submission_id_respond_post(
+        &opponent_config,
+        &created.id,
+        &first_submission_id,
+        models::RespondToScoreInput {
+            response: models::ScoreResponseKind::Dispute,
+        },
+    )
+    .await
+    .expect("dispute score");
+
+    let after_dispute = matches_match_id_get(&owner_config, &created.id)
+        .await
+        .expect("get match");
+    assert!(after_dispute.confirmed_score.is_none());
+    assert!(
+        after_dispute.pending_score.is_none(),
+        "a disputed submission clears the pending score"
+    );
+
+    // The owner submits a new score via PATCH. It must NOT show up as confirmed
+    // immediately — the opponent still has to approve/reject it, just like the
+    // first submission.
+    let resubmitted = matches_match_id_patch(
+        &owner_config,
+        &created.id,
+        models::UpdateMatchInput {
+            score: Some(Box::new(simple_score(&side_a, &side_b, 6, 4))),
+            winner_side_id: Some(side_a.clone()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("patch new score");
+    assert!(
+        resubmitted.confirmed_score.is_none(),
+        "a resubmitted score must await confirmation, not appear confirmed immediately"
+    );
+    let pending = resubmitted
+        .pending_score
+        .expect("the resubmission is pending");
+    assert_ne!(
+        pending.submission_id, first_submission_id,
+        "the resubmission is a fresh submission, not the disputed one"
+    );
+
+    // The submission history now has both the disputed original and the new
+    // pending one.
+    let submissions = matches_match_id_score_submissions_get(&owner_config, &created.id)
+        .await
+        .expect("list submissions");
+    assert_eq!(submissions.len(), 2);
+    let new_submission = submissions
+        .iter()
+        .find(|s| s.id == pending.submission_id)
+        .expect("new submission present in history");
+    assert!(matches!(
+        new_submission.status,
+        models::ScoreSubmissionStatus::Pending
+    ));
+
+    // The opponent can now confirm the resubmitted score, which finally
+    // promotes it to the match's confirmed score.
+    matches_match_id_score_submissions_submission_id_respond_post(
+        &opponent_config,
+        &created.id,
+        &pending.submission_id,
+        models::RespondToScoreInput {
+            response: models::ScoreResponseKind::Confirm,
+        },
+    )
+    .await
+    .expect("confirm resubmitted score");
+
+    let final_match = matches_match_id_get(&owner_config, &created.id)
+        .await
+        .expect("get match");
+    let confirmed = final_match
+        .confirmed_score
+        .expect("resubmitted score is confirmed after opponent approves");
+    assert_eq!(confirmed.winner_side_id.as_deref(), Some(side_a.as_str()));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `PATCH /matches/:id` (`update_match`) wrote every scored update straight to `confirmed_score`, with the submission hardcoded to `status: "confirmed"` — bypassing the approval flow entirely. So rejecting a score and then submitting a new one showed the new score as confirmed immediately, with no chance for the other side to approve/reject it.
- `update_match` now builds a **pending** submission the same way `create_match` does: it attributes the submission to the caller's own side, pre-confirms only that side, and leaves `confirmed_score` untouched until the other side(s) respond via `POST /matches/:id/score-submissions/:id/respond`.
- Submitting a score through `PATCH` now requires the caller to be an assigned participant (matching the existing create-time requirement), since a side is needed to attribute the pending confirmation to.

## Test plan

- [x] `cargo build -p agon_core` / `cargo build -p agon_service` — clean
- [x] `cargo fmt` — clean
- [x] Updated `scoring_a_match_completes_it_and_records_a_submission` (renamed to `..._pending_submission`), which previously asserted the buggy "confirmed immediately" behavior, to assert the score stays pending until confirmed.
- [x] Added `rejecting_a_score_and_resubmitting_requires_approval_again`, covering the reported scenario end-to-end: submit → dispute → resubmit via PATCH → still pending (not silently confirmed) → other side confirms → now confirmed.
- [ ] Integration tests (`agon_tests`) not run in this environment — they require a generated `openapi_client` (via `openapi-generator-cli`) and live DynamoDB/Meilisearch, neither available in the sandbox this PR was authored in.


---
_Generated by [Claude Code](https://claude.ai/code/session_019piN8J5sNsmnJ9N1eMUBD4)_