### PR TITLE
Hydrate match player names and avatars from their user profile

### DIFF
--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -1415,6 +1415,7 @@ impl Api {
                     .map_err(dao_internal)?;
                 let mut m = match_from_records(&agg.match_, &agg.sides, &agg.players, i_liked);
                 sign_match_headers(assets, &mut m);
+                self.hydrate_match_player_profiles(dao, &mut m).await?;
                 items.push(FeedItem::Match(m));
             }
         }
@@ -1517,6 +1518,7 @@ impl Api {
                     .map_err(dao_internal)?;
                 let mut m = match_from_records(&agg.match_, &agg.sides, &agg.players, i_liked);
                 sign_match_headers(assets, &mut m);
+                self.hydrate_match_player_profiles(dao, &mut m).await?;
                 items.push(m);
             }
         }
@@ -1784,6 +1786,7 @@ impl Api {
 
         let mut m = match_from_records(&match_record, &side_records, &player_records, false);
         sign_match_headers(assets, &mut m);
+        self.hydrate_match_player_profiles(dao, &mut m).await?;
         Ok(CreateMatchResponse::Match(Json(m)))
     }
 
@@ -1811,6 +1814,7 @@ impl Api {
             .map_err(dao_internal)?;
         let mut m = match_from_records(&agg.match_, &agg.sides, &agg.players, i_liked);
         sign_match_headers(assets, &mut m);
+        self.hydrate_match_player_profiles(dao, &mut m).await?;
         Ok(GetMatchResponse::Match(Json(m)))
     }
 
@@ -2003,6 +2007,7 @@ impl Api {
             .map_err(dao_internal)?;
         let mut m = match_from_records(&agg.match_, &agg.sides, &agg.players, i_liked);
         sign_match_headers(assets, &mut m);
+        self.hydrate_match_player_profiles(dao, &mut m).await?;
         Ok(UpdateMatchResponse::Match(Json(m)))
     }
 
@@ -3462,6 +3467,33 @@ impl Api {
         Ok(profiles)
     }
 
+    /// Fill in each `User` match player's `name`/`avatar_url` from their
+    /// account, via one batch read for the whole roster (external players
+    /// already carry their display name inline, so are left alone).
+    async fn hydrate_match_player_profiles(&self, dao: &dao::Dao, m: &mut Match) -> Result<()> {
+        let ids: Vec<String> = m
+            .players
+            .iter()
+            .filter_map(|p| match &p.member {
+                Member::User(u) => Some(u.user_id.clone()),
+                Member::External(_) => None,
+            })
+            .collect();
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let records = dao.batch_get_users(&ids).await.map_err(dao_internal)?;
+        for player in &mut m.players {
+            if let Member::User(u) = &mut player.member
+                && let Some(record) = records.get(&u.user_id)
+            {
+                u.name = record.name.clone();
+                u.avatar_url = record.profile_image_url.clone();
+            }
+        }
+        Ok(())
+    }
+
     /// Fetch a single user's public profile, or `None` if absent. Used to embed
     /// an author/actor inline. (N+1 in list contexts — batch later.)
     async fn try_user_profile(&self, dao: &dao::Dao, user_id: &str) -> Result<Option<UserProfile>> {
@@ -3833,6 +3865,8 @@ fn mock_match(id: String) -> Match {
                     id: String::from("player_red_1"),
                     user_id: String::from("user_1"),
                     invitation: None,
+                    name: String::from("Alex Kim"),
+                    avatar_url: None,
                 }),
                 side_id: Some(String::from("side_red")),
                 is_member_of_team: Some(true),
@@ -3842,6 +3876,8 @@ fn mock_match(id: String) -> Match {
                     id: String::from("player_red_2"),
                     user_id: String::from("user_2"),
                     invitation: None,
+                    name: String::from("Jordan Lee"),
+                    avatar_url: None,
                 }),
                 side_id: Some(String::from("side_red")),
                 is_member_of_team: Some(true),
@@ -3851,6 +3887,8 @@ fn mock_match(id: String) -> Match {
                     id: String::from("player_blue_1"),
                     user_id: String::from("user_3"),
                     invitation: None,
+                    name: String::from("Sam Rivera"),
+                    avatar_url: None,
                 }),
                 side_id: Some(String::from("side_blue")),
                 is_member_of_team: Some(true),
@@ -4173,6 +4211,8 @@ fn mock_team(id: String, name: String) -> Team {
                             invited_user_id: String::from("user_1"),
                         }),
                     }),
+                    name: String::from("Alex Kim"),
+                    avatar_url: None,
                 }),
                 role: TeamRole::Admin,
             },

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -368,7 +368,9 @@ pub fn invitation_from_embedded(rec: &EmbeddedInvitationRecord) -> Invitation {
 
 /// Build the shared `Member` union from the fields common to a team member /
 /// match player record: a linked user id or an external display name, plus an
-/// optional embedded invitation.
+/// optional embedded invitation. A linked user's `name`/`avatar_url` are left
+/// blank here — callers that need them hydrated (e.g. a match roster) fill
+/// them in afterwards with a batch profile lookup.
 pub fn member_from_parts(
     membership_id: &str,
     user_id: Option<&str>,
@@ -381,6 +383,8 @@ pub fn member_from_parts(
             id: membership_id.to_string(),
             user_id: uid.to_string(),
             invitation,
+            name: String::new(),
+            avatar_url: None,
         }),
         None => Member::External(ExternalMember {
             id: membership_id.to_string(),

--- a/agon_service/src/membership.rs
+++ b/agon_service/src/membership.rs
@@ -24,6 +24,11 @@ pub struct UserMember {
     /// The invitation to this context. Pending until the user accepts (which
     /// they can do in-app). None only if added without an invite.
     pub invitation: Option<Invitation>,
+    /// The linked account's display name, hydrated at read time from the
+    /// user profile. Empty if the account could no longer be found.
+    pub name: String,
+    /// The linked account's profile image, if they've set one.
+    pub avatar_url: Option<String>,
 }
 
 #[derive(Object)]

--- a/agon_ui/src/lib/members.ts
+++ b/agon_ui/src/lib/members.ts
@@ -96,16 +96,16 @@ export function isParticipant(
 }
 
 /**
- * Display name for a match player. A linked Agon user's name is resolved from
- * their account (not present on the member itself yet), so until profiles are
- * hydrated we fall back to a short id; an external player carries a display name
- * directly.
+ * Display name for a match player: a linked Agon user's name is hydrated onto
+ * the member server-side, an external player carries a display name directly.
  */
 export function memberName(member: Member): string {
-  if (member.type === 'External') return member.display_name
-  // UserMember has only user_id here; the display name comes from the account.
-  // Callers that have the resolved profile should pass its name instead.
-  return 'Player'
+  return member.type === 'External' ? member.display_name : member.name
+}
+
+/** Avatar image for a match player, if the linked Agon user has one set. */
+export function memberAvatarUrl(member: Member): string | undefined {
+  return member.type === 'User' ? member.avatar_url : undefined
 }
 
 /** Initials for an avatar, from a display name (e.g. "Sofia Lindqvist" → "SL"). */

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -15,6 +15,7 @@ import { useCurrentUserId } from '@/hooks/useCurrentUserId'
 import { displayScore, headlineBySide, headlineLabel, setLine } from '@/lib/score'
 import {
   isParticipant,
+  memberAvatarUrl,
   memberInviteToken,
   memberName,
   myPendingInvitation,
@@ -469,6 +470,7 @@ function SideRoster({ title, players }: { title: string; players: MatchPlayer[] 
         )}
         {players.map((p, i) => {
           const name = memberName(p.member)
+          const avatarUrl = memberAvatarUrl(p.member)
           const pending =
             p.member.invitation && p.member.invitation.status === 'pending'
           // Token-invited (external) players have a shareable link; offer to
@@ -476,7 +478,7 @@ function SideRoster({ title, players }: { title: string; players: MatchPlayer[] 
           const inviteToken = memberInviteToken(p.member)
           return (
             <div key={i} className="flex items-center gap-2">
-              <Avatar name={name} size="md" />
+              <Avatar name={name} imageUrl={avatarUrl} size="md" />
               <span className="flex-1 truncate text-sm">{name}</span>
               {inviteToken ? (
                 <CopyInviteButton token={inviteToken} />


### PR DESCRIPTION
UserMember previously carried only a bare user_id, so the match detail
roster always fell back to the literal string "Player". Add name and
avatar_url to UserMember, populated via one batch_get_users read per
match (mirroring hydrate_user_profiles), and wire the frontend to
render the real name/avatar instead of the placeholder.