### PR TITLE
Redesign mobile layout with bottom nav and reorganize match card

### DIFF
--- a/agon_ui/index.html
+++ b/agon_ui/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,400..600;1,400..600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Agon</title>
   </head>
   <body>
     <div id="root"></div>

--- a/agon_ui/src/App.tsx
+++ b/agon_ui/src/App.tsx
@@ -4,20 +4,21 @@ import {
   Routes,
   Route,
   Navigate,
+  Link,
   useLocation,
 } from 'react-router-dom'
+import { Bell, Search } from 'lucide-react'
 import { AuthProvider, useAuth } from '@/hooks/useAuth'
 import { LoginForm } from '@/components/auth/LoginForm'
 import { CreateProfileForm } from '@/components/auth/CreateProfileForm'
 import { InvitePreviewBanner } from '@/components/auth/InvitePreviewBanner'
 import { AppSidebar } from '@/components/AppSidebar'
+import { MobileBottomNav } from '@/components/MobileBottomNav'
+import { Logo } from '@/components/agon/Logo'
 import { Button } from '@/components/ui/button'
-import {
-  SidebarInset,
-  SidebarProvider,
-  SidebarTrigger,
-} from '@/components/ui/sidebar'
+import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
 import { ThemeProvider } from '@/hooks/useTheme'
+import { useUnreadNotificationsCount } from '@/hooks/useUnreadCount'
 import { useQuery } from '@tanstack/react-query'
 import { fetchClient } from '@/lib/api-client'
 import { FeedPage } from '@/pages/FeedPage'
@@ -50,21 +51,43 @@ function ComingSoon({ title }: { title: string }) {
   )
 }
 
-/** The signed-in chrome: a responsive sidebar (off-canvas on mobile) + routed
- *  content. A slim top bar carries the sidebar trigger on mobile. */
+/** The signed-in chrome: a fixed sidebar on desktop, a top bar + bottom tab
+ *  bar on mobile, wrapping the routed content. */
 function AppShell({ email, onSignOut }: { email: string; onSignOut: () => void }) {
+  const { data: unread } = useUnreadNotificationsCount()
+
   return (
     <SidebarProvider>
       <AppSidebar email={email} onSignOut={onSignOut} />
       <SidebarInset>
-        {/* Mobile top bar: hamburger to open the nav sheet. Hidden on desktop,
-            where the sidebar is always visible. */}
-        <header className="flex h-14 items-center gap-2 border-b px-4 md:hidden">
-          <SidebarTrigger />
-          <span className="text-lg font-bold">Agon</span>
+        {/* Mobile top bar: brand + quick links to the two nav destinations
+            that don't fit the bottom tab bar. Hidden on desktop, where the
+            sidebar carries the full nav. */}
+        <header className="sticky top-0 z-10 flex h-16 items-center justify-between border-b bg-background/95 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:hidden">
+          <Logo />
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="icon" className="rounded-full bg-card" asChild>
+              <Link to="/search" aria-label="Find people">
+                <Search className="size-5" />
+              </Link>
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative rounded-full bg-card"
+              asChild
+            >
+              <Link to="/notifications" aria-label="Notifications">
+                <Bell className="size-5" />
+                {!!unread && unread > 0 && (
+                  <span className="absolute right-2 top-2 size-2 rounded-full bg-primary" />
+                )}
+              </Link>
+            </Button>
+          </div>
         </header>
 
-        <main className="container mx-auto px-4 py-8">
+        <main className="container mx-auto px-4 py-8 pb-28 md:pb-8">
           <Routes>
           <Route path="/" element={<HomeRedirect />} />
           <Route path="/feed" element={<FeedPage />} />
@@ -89,6 +112,8 @@ function AppShell({ email, onSignOut }: { email: string; onSignOut: () => void }
           <Route path="*" element={<HomeRedirect />} />
           </Routes>
         </main>
+
+        <MobileBottomNav />
       </SidebarInset>
     </SidebarProvider>
   )

--- a/agon_ui/src/components/AppSidebar.tsx
+++ b/agon_ui/src/components/AppSidebar.tsx
@@ -1,5 +1,4 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
 import {
   Bell,
   LogOut,
@@ -9,9 +8,10 @@ import {
   User,
   Users,
 } from 'lucide-react'
-import { fetchClient } from '@/lib/api-client'
+import { useUnreadNotificationsCount } from '@/hooks/useUnreadCount'
 import { Button } from '@/components/ui/button'
 import { ThemeToggle } from '@/components/ThemeToggle'
+import { Logo } from '@/components/agon/Logo'
 import {
   Sidebar,
   SidebarContent,
@@ -58,15 +58,8 @@ export function AppSidebar({
   const navigate = useNavigate()
   const { isMobile, setOpenMobile } = useSidebar()
 
-  // Live unread-notification count for the nav badge. Shares the query key the
-  // notifications page invalidates, so acting on notifications updates it.
-  const { data: unread } = useQuery({
-    queryKey: ['notifications-unread-count'],
-    queryFn: async (): Promise<number> => {
-      const { data } = await fetchClient.GET('/notifications/unread-count')
-      return data?.unread_count ?? 0
-    },
-  })
+  // Live unread-notification count for the nav badge.
+  const { data: unread } = useUnreadNotificationsCount()
 
   /** Close the mobile sheet after navigating, so it doesn't cover the page. */
   const closeOnMobile = () => {
@@ -80,7 +73,7 @@ export function AppSidebar({
   return (
     <Sidebar>
       <SidebarHeader className="gap-3 p-4">
-        <h1 className="text-2xl font-bold">Agon</h1>
+        <Logo />
         <Button
           className="w-full justify-start gap-2"
           onClick={() => {

--- a/agon_ui/src/components/MobileBottomNav.tsx
+++ b/agon_ui/src/components/MobileBottomNav.tsx
@@ -1,0 +1,58 @@
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { Home, Plus, User } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+/**
+ * The mobile navigation: a fixed bottom tab bar replacing the sidebar sheet
+ * on small screens, where a slide-in panel is an awkward reach. Three stops —
+ * Feed, a floating "log a match" action, and Profile — everything else
+ * (search, notifications, teams, sign out) lives behind the icons in the
+ * mobile top bar or on the profile page itself. Hidden at the `md` breakpoint,
+ * where the fixed sidebar takes over.
+ */
+export function MobileBottomNav() {
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  const isActive = (to: string) => location.pathname === to
+
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-20 border-t bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 md:hidden">
+      <div
+        className="mx-auto flex max-w-xl items-center justify-around px-6"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        <Link
+          to="/feed"
+          className={cn(
+            'flex flex-1 flex-col items-center gap-0.5 py-2 text-[11px] font-medium',
+            isActive('/feed') ? 'text-primary' : 'text-muted-foreground',
+          )}
+        >
+          <Home className="size-5" />
+          Feed
+        </Link>
+
+        <button
+          type="button"
+          onClick={() => navigate('/matches/new')}
+          aria-label="Log a match"
+          className="-mt-6 flex size-14 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg ring-4 ring-background transition-transform active:scale-95"
+        >
+          <Plus className="size-6" />
+        </button>
+
+        <Link
+          to="/profile"
+          className={cn(
+            'flex flex-1 flex-col items-center gap-0.5 py-2 text-[11px] font-medium',
+            isActive('/profile') ? 'text-primary' : 'text-muted-foreground',
+          )}
+        >
+          <User className="size-5" />
+          Profile
+        </Link>
+      </div>
+    </nav>
+  )
+}

--- a/agon_ui/src/components/agon/Logo.tsx
+++ b/agon_ui/src/components/agon/Logo.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/utils'
+
+/**
+ * The Agon wordmark: a small blue ring beside the italic serif brand name.
+ * Shared by the desktop sidebar header and the mobile top bar so the two
+ * chrome surfaces read as one brand.
+ */
+export function Logo({ className }: { className?: string }) {
+  return (
+    <span className={cn('inline-flex items-center gap-2', className)}>
+      <span className="size-4 shrink-0 rounded-full border-[3px] border-primary" />
+      <span className="font-serif text-2xl font-semibold italic leading-none">
+        Agon
+      </span>
+    </span>
+  )
+}

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -2,10 +2,12 @@ import { Flame, MailOpen, MessageCircle, Share2 } from 'lucide-react'
 import type { components } from '@/types/api'
 import { cn } from '@/lib/utils'
 import { useToggleLike } from '@/hooks/useToggleLike'
+import { relativeTime } from '@/lib/datetime'
 import { Avatar } from './Avatar'
 import { SportBadge } from './SportBadge'
 import { StatusBadge, matchBadgeStatus } from './StatusBadge'
 import { ScoreConfirmationBar } from './ScoreConfirmationBar'
+import { MatchHeaderCarousel } from './MatchHeaderCarousel'
 import {
   displayScore,
   headlineBySide,
@@ -80,7 +82,7 @@ export function MatchCard({
       )}
       {...props}
     >
-      {/* Header: who beat who + sport */}
+      {/* Header: who beat who + when + sport */}
       <button
         type="button"
         onClick={onOpen}
@@ -88,20 +90,33 @@ export function MatchCard({
       >
         <div className="flex items-start gap-2.5">
           <Avatar name={nameA} size="lg" ring={aWon ? 'winner' : 'none'} />
-          <div className="min-w-0">
-            <p className="text-sm leading-snug">
-              <span className={cn(aWon && 'font-medium')}>{nameA}</span>
-              <span className="text-primary">
-                {' '}
-                {scoreInfo?.winnerSideId ? 'beat' : 'vs'}{' '}
-              </span>
-              <span className={cn(bWon && 'font-medium')}>{nameB}</span>
-            </p>
-            <p className="mt-0.5 text-xs text-muted-foreground">{match.name}</p>
-          </div>
+          <p className="text-sm leading-snug">
+            <span className={cn(aWon && 'font-medium')}>{nameA}</span>
+            <span className="text-primary">
+              {' '}
+              {scoreInfo?.winnerSideId ? 'beat' : 'vs'}{' '}
+            </span>
+            <span className={cn(bWon && 'font-medium')}>{nameB}</span>
+            <span className="text-muted-foreground"> · {relativeTime(match.starts_at)}</span>
+          </p>
         </div>
-        <SportBadge sport={match.match_type} />
+        <div className="flex shrink-0 flex-col items-end gap-1.5">
+          <SportBadge sport={match.match_type} />
+          <InvitedBadge match={match} currentUserId={currentUserId} />
+        </div>
       </button>
+
+      {/* Title + description */}
+      {(match.name || match.description) && (
+        <div className="px-3.5 pb-3">
+          {match.name && <p className="font-medium leading-snug">{match.name}</p>}
+          {match.description && (
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {match.description}
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Score block */}
       {scoreInfo && (
@@ -139,11 +154,12 @@ export function MatchCard({
         </div>
       )}
 
-      {/* Meta: lifecycle / confirmation state, and the viewer's invite state */}
-      <div className="flex flex-wrap items-center gap-3 px-3.5 py-2.5">
-        <StatusBadge status={matchBadgeStatus(match)} />
-        <InvitedBadge match={match} currentUserId={currentUserId} />
-      </div>
+      {/* Header photo, when the match has one. */}
+      {match.header_photos.length > 0 && (
+        <div className="px-3.5 pb-3 pt-3">
+          <MatchHeaderCarousel photos={match.header_photos} />
+        </div>
+      )}
 
       {/* Confirm/dispute prompt when the viewer's side owes a response. */}
       {match.pending_score && (
@@ -156,36 +172,36 @@ export function MatchCard({
         </div>
       )}
 
-      {/* Actions */}
-      <div className="flex items-center gap-4 border-t px-3.5 py-2 text-muted-foreground">
+      {/* Footer: kudos + comments on the left, lifecycle/confirmation state on the right. */}
+      <div className="flex items-center gap-4 border-t px-3.5 py-2.5 text-muted-foreground">
         <button
           type="button"
           onClick={() => toggleLike.mutate(!i_liked)}
           aria-pressed={i_liked}
-          aria-label={i_liked ? 'Unlike match' : 'Like match'}
+          aria-label={i_liked ? 'Remove kudos' : 'Give kudos'}
           className={cn(
             'flex items-center gap-1.5 text-xs transition-colors hover:text-primary',
             i_liked && 'text-primary',
           )}
         >
           <Flame className={cn('size-3.5', i_liked && 'fill-current')} />{' '}
-          {like_count} {like_count === 1 ? 'like' : 'likes'}
+          {like_count} kudos
         </button>
         <button
           type="button"
           onClick={onOpen}
           className="flex items-center gap-1.5 text-xs transition-colors hover:text-primary"
         >
-          <MessageCircle className="size-3.5" /> {comment_count}{' '}
-          {comment_count === 1 ? 'comment' : 'comments'}
+          <MessageCircle className="size-3.5" /> {comment_count}
         </button>
         <button
           type="button"
-          className="ml-auto flex items-center transition-colors hover:text-primary"
+          className="flex items-center transition-colors hover:text-primary"
           aria-label="Share match"
         >
           <Share2 className="size-3.5" />
         </button>
+        <StatusBadge status={matchBadgeStatus(match)} className="ml-auto" />
       </div>
     </div>
   )

--- a/agon_ui/src/hooks/useUnreadCount.ts
+++ b/agon_ui/src/hooks/useUnreadCount.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchClient } from '@/lib/api-client'
+
+/**
+ * Live unread-notification count, shared by every nav surface (desktop
+ * sidebar, mobile header). Shares the query key the notifications page
+ * invalidates, so acting on notifications updates it everywhere at once.
+ */
+export function useUnreadNotificationsCount() {
+  return useQuery({
+    queryKey: ['notifications-unread-count'],
+    queryFn: async (): Promise<number> => {
+      const { data } = await fetchClient.GET('/notifications/unread-count')
+      return data?.unread_count ?? 0
+    },
+  })
+}

--- a/agon_ui/src/index.css
+++ b/agon_ui/src/index.css
@@ -47,11 +47,13 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+  --font-serif: "Newsreader", ui-serif, Georgia, Cambria, "Times New Roman", serif;
 }
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  /* Warm neutral (not pure white) background; cards stay white so they lift off it. */
+  --background: oklch(0.975 0.006 75);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -62,7 +64,7 @@
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
+  --muted: oklch(0.965 0.008 75);
   --muted-foreground: oklch(0.556 0 0);
   /* Tinted accent (#EEF2FF-ish) for the blue-on-light chips/avatars in the UI. */
   --accent: oklch(0.962 0.018 264.5);
@@ -92,18 +94,19 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  /* Warm dark neutral (not pure black-gray), mirroring the light theme's tint. */
+  --background: oklch(0.16 0.006 75);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(0.21 0.006 75);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
+  --popover: oklch(0.21 0.006 75);
   --popover-foreground: oklch(0.985 0 0);
   /* Lifted Agon blue so it reads on the dark surface. */
   --primary: oklch(0.62 0.19 262.88);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
+  --muted: oklch(0.28 0.008 75);
   --muted-foreground: oklch(0.708 0 0);
   /* Muted blue-tinted accent for chips/avatars on dark. */
   --accent: oklch(0.32 0.06 262.88);

--- a/agon_ui/src/lib/datetime.ts
+++ b/agon_ui/src/lib/datetime.ts
@@ -44,3 +44,33 @@ export function relativeTime(iso: string): string {
     day: 'numeric',
   })
 }
+
+/** Whether two dates fall on the same local calendar day. */
+function isSameDay(a: Date, b: Date): boolean {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  )
+}
+
+/**
+ * A day-grouping label for an ISO instant: "Today" / "Yesterday", else a
+ * localized date (with the year only when it isn't the current one). Used to
+ * group the feed into date sections.
+ */
+export function dayLabel(iso: string): string {
+  const date = new Date(iso)
+  const now = new Date()
+  if (isSameDay(date, now)) return 'Today'
+
+  const yesterday = new Date(now)
+  yesterday.setDate(now.getDate() - 1)
+  if (isSameDay(date, yesterday)) return 'Yesterday'
+
+  return date.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: date.getFullYear() === now.getFullYear() ? undefined : 'numeric',
+  })
+}

--- a/agon_ui/src/lib/score.ts
+++ b/agon_ui/src/lib/score.ts
@@ -75,7 +75,7 @@ export function setLine(score: Score, sides: MatchSide[]): string[] {
   return lines
 }
 
-/** Short label for the headline unit, e.g. "sets" for racket sports, "FT" otherwise. */
+/** Short label for the headline unit, e.g. "sets" for racket sports, "full time" otherwise. */
 export function headlineLabel(score: Score): string {
-  return score.type === 'Sets' ? 'sets' : 'FT'
+  return score.type === 'Sets' ? 'sets' : 'full time'
 }

--- a/agon_ui/src/pages/FeedPage.tsx
+++ b/agon_ui/src/pages/FeedPage.tsx
@@ -6,6 +6,7 @@ import { MatchCard } from '@/components/agon/MatchCard'
 import { Button } from '@/components/ui/button'
 import { useNavigate } from 'react-router-dom'
 import { useCurrentUserId } from '@/hooks/useCurrentUserId'
+import { dayLabel } from '@/lib/datetime'
 import {
   usePendingMatches,
   prunePendingMatches,
@@ -94,15 +95,24 @@ export function FeedPage() {
     )
   }
 
+  const sections = groupByDay(items)
+
   return (
-    <div className="mx-auto flex max-w-xl flex-col gap-3">
-      {items.map((item) => (
-        <MatchCard
-          key={item.id}
-          match={item}
-          currentUserId={currentUserId}
-          onOpen={() => navigate(`/matches/${item.id}`)}
-        />
+    <div className="mx-auto flex max-w-xl flex-col gap-6">
+      {sections.map((section) => (
+        <div key={section.label} className="flex flex-col gap-3">
+          <h2 className="font-serif text-lg italic text-muted-foreground">
+            {section.label}
+          </h2>
+          {section.items.map((item) => (
+            <MatchCard
+              key={item.id}
+              match={item}
+              currentUserId={currentUserId}
+              onOpen={() => navigate(`/matches/${item.id}`)}
+            />
+          ))}
+        </div>
       ))}
 
       {query.hasNextPage && (
@@ -117,6 +127,26 @@ export function FeedPage() {
       )}
     </div>
   )
+}
+
+/**
+ * Bucket feed items into day-labelled sections ("Today", "Yesterday", …),
+ * preserving the feed's existing newest-first order — items already arrive
+ * sorted by `starts_at`, so this only needs to notice when the label changes,
+ * not re-sort anything.
+ */
+function groupByDay(items: FeedItem[]): { label: string; items: FeedItem[] }[] {
+  const sections: { label: string; items: FeedItem[] }[] = []
+  for (const item of items) {
+    const label = dayLabel(item.starts_at)
+    const last = sections[sections.length - 1]
+    if (last && last.label === label) {
+      last.items.push(item)
+    } else {
+      sections.push({ label, items: [item] })
+    }
+  }
+  return sections
 }
 
 /** Placeholder cards while the first page loads. */

--- a/agon_ui/src/pages/ProfilePage.tsx
+++ b/agon_ui/src/pages/ProfilePage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { useNavigate, useParams } from 'react-router-dom'
-import { ChevronRight, Pencil } from 'lucide-react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { ChevronRight, LogOut, Pencil, Users } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { ProfileHeader } from '@/components/agon/ProfileHeader'
@@ -10,6 +10,8 @@ import { FollowButton } from '@/components/agon/FollowButton'
 import { SportStatsTable } from '@/components/agon/SportStatsTable'
 import { MatchCard } from '@/components/agon/MatchCard'
 import { Button } from '@/components/ui/button'
+import { ThemeToggle } from '@/components/ThemeToggle'
+import { useAuth } from '@/hooks/useAuth'
 import { useCurrentUserId } from '@/hooks/useCurrentUserId'
 
 type UserProfile = components['schemas']['UserProfile']
@@ -135,7 +137,38 @@ export function ProfilePage() {
           currentUserId={currentUserId}
         />
       </section>
+
+      {/* Account settings live here rather than in a nav item — on mobile the
+          bottom tab bar only has Feed / Create / Profile, so this is the one
+          reachable place for them. Desktop still has the sidebar too. */}
+      {isOwnProfile && <AccountSettings />}
     </div>
+  )
+}
+
+/** Sign-out, theme, and the (mobile-only) Teams link — see the comment above. */
+function AccountSettings() {
+  const { signOut } = useAuth()
+  return (
+    <section className="flex flex-col gap-2">
+      <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Account
+      </h2>
+      <div className="flex flex-col gap-2 rounded-xl border bg-card p-3 md:hidden">
+        <Button variant="ghost" className="justify-start gap-2" asChild>
+          <Link to="/teams">
+            <Users className="size-4" /> Teams
+          </Link>
+        </Button>
+      </div>
+      <div className="flex items-center justify-between gap-2 rounded-xl border bg-card p-3">
+        <span className="text-sm text-muted-foreground">Appearance</span>
+        <ThemeToggle />
+      </div>
+      <Button variant="outline" className="w-full gap-2" onClick={signOut}>
+        <LogOut className="size-4" /> Sign out
+      </Button>
+    </section>
   )
 }
 


### PR DESCRIPTION
## Summary
Restructures the mobile UI to use a fixed bottom tab bar for primary navigation (Feed, Create Match, Profile) instead of a slide-out sidebar, improving mobile UX. Reorganizes the match card layout to surface match timing and photos more prominently, and consolidates account settings on the profile page.

## Key Changes

**Mobile Navigation & Layout**
- Added `MobileBottomNav` component: a fixed bottom tab bar with three primary destinations (Feed, floating "log match" button, Profile), hidden at `md` breakpoint where desktop sidebar takes over
- Updated `App.tsx` mobile header to show brand logo + quick links (Search, Notifications) instead of hamburger menu
- Added bottom padding to main content on mobile (`pb-28`) to prevent overlap with tab bar
- Extracted unread notification count logic into reusable `useUnreadNotificationsCount` hook

**Match Card Redesign**
- Moved match timing (`relativeTime`) inline with player names in header, separated by bullet
- Moved sport badge and invited status to top-right corner of header
- Extracted match name/description into a dedicated section below header
- Moved header photos (carousel) to a new section above score confirmation prompt
- Reorganized footer: kudos + comments on left, status badge on right (was in separate meta section)
- Updated terminology: "likes" → "kudos", "Like match" → "Give kudos", removed comment count label

**Feed Page**
- Added day-based grouping with section headers ("Today", "Yesterday", localized dates)
- Implemented `groupByDay` helper to bucket items while preserving feed order
- Added `dayLabel` utility to generate human-readable day labels

**Profile Page**
- Added `AccountSettings` section visible only on own profile
- Moved theme toggle and sign-out to profile page (mobile-only Teams link also here)
- Consolidates account controls in one reachable place on mobile

**Branding & Styling**
- Created shared `Logo` component (blue ring + italic serif wordmark) used by sidebar and mobile header
- Added Newsreader serif font import for brand typography
- Refined color palette: warmer neutral backgrounds (light: `oklch(0.975 0.006 75)`, dark: `oklch(0.16 0.006 75)`) with subtle warm tint
- Updated muted colors to match warm theme

**Utilities**
- Added `dayLabel` function to `datetime.ts` for feed section headers
- Updated score label: "FT" → "full time" for clarity

https://claude.ai/code/session_01UHajeu2kE8F9SsmojZSYXt