### PR TITLE
Move user stats onto the profile item, wire up match card share button

### DIFF
--- a/agon_core/src/dao/keys.rs
+++ b/agon_core/src/dao/keys.rs
@@ -144,8 +144,6 @@ pub enum Sk {
     /// Uniqueness guard marker (e.g. under an email guard PK). `#GUARD`
     Guard,
 
-    /// Per-sport stats for a user. `STATS#<sport>`
-    Stats(String),
     /// A follower edge (who follows this user/team). `FOLLOWER#<followerUid>`
     Follower(String),
     /// A team membership. `MEMBER#<membershipId>`
@@ -176,9 +174,9 @@ pub enum Sk {
     /// (`{ played, won }`), in the match's partition. `STATCONTRIB#<userId>`.
     /// The async stats reconciler diffs the desired contribution (from the
     /// match's current state) against this stored one and applies the delta to
-    /// the user's `STATS#<sport>` item in the same transaction — so re-scores,
-    /// roster changes and cancellations all self-correct, and redelivery is a
-    /// no-op (same state → zero delta).
+    /// the user's profile item (`stats.<sport>`) in the same transaction — so
+    /// re-scores, roster changes and cancellations all self-correct, and
+    /// redelivery is a no-op (same state → zero delta).
     StatContribution(String),
     /// A fan-out feed entry, ordered by match start time. `FEED#<starts_at>#<mid>`
     /// (only ever listed, never addressed by id — keeps ts in the key).
@@ -194,7 +192,6 @@ impl Sk {
             Sk::Profile => "#PROFILE",
             Sk::Meta => "#META",
             Sk::Guard => "#GUARD",
-            Sk::Stats(_) => "STATS",
             Sk::Follower(_) => "FOLLOWER",
             Sk::Member(_) => "MEMBER",
             Sk::Side(_) => "SIDE",
@@ -218,8 +215,7 @@ impl fmt::Display for Sk {
             Sk::Profile | Sk::Meta | Sk::Guard => write!(f, "{}", self.prefix()),
 
             // Single-value keys.
-            Sk::Stats(v)
-            | Sk::Follower(v)
+            Sk::Follower(v)
             | Sk::Member(v)
             | Sk::Side(v)
             | Sk::Player(v)
@@ -269,7 +265,6 @@ impl FromStr for Sk {
         };
 
         match prefix {
-            "STATS" => Ok(Sk::Stats(rest.into())),
             "FOLLOWER" => Ok(Sk::Follower(rest.into())),
             "MEMBER" => Ok(Sk::Member(rest.into())),
             "SIDE" => Ok(Sk::Side(rest.into())),
@@ -339,7 +334,6 @@ mod tests {
 
     #[test]
     fn sk_single_value_variants_roundtrip() {
-        sk_roundtrip(Sk::Stats("tennis".into()), "STATS#tennis");
         sk_roundtrip(Sk::Follower("u2".into()), "FOLLOWER#u2");
         sk_roundtrip(Sk::Member("mem1".into()), "MEMBER#mem1");
         sk_roundtrip(Sk::Side("side_red".into()), "SIDE#side_red");

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -144,11 +144,10 @@ pub struct AuthGuardRecord {
 ///
 /// Counts are denormalized and maintained via atomic `ADD` (see follow ops).
 /// `email` is duplicated here for reads; uniqueness is enforced by a separate
-/// `EMAIL#<email>` guard item. `stats` is kept inline (rather than its own
-/// `STATS#<sport>` item per sport) so a profile read/batch-read returns
-/// everything in one point read — always present (an empty map for a brand
-/// new user) so the stats reconciler's nested-attribute updates always have a
-/// map to write into.
+/// `EMAIL#<email>` guard item. `stats` holds per-sport aggregates inline, so a
+/// profile read/batch-read returns everything in one point read — always
+/// present (an empty map for a brand new user) so the stats reconciler's
+/// nested-attribute updates always have a map to write into.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserRecord {
     pub id: String,

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -4,6 +4,8 @@
 //! persistence shape and the API layer maps to/from these. Records hold data
 //! fields only; keys/GSI attributes are stamped by the `item` layer.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 // ===========================================================================
@@ -142,7 +144,11 @@ pub struct AuthGuardRecord {
 ///
 /// Counts are denormalized and maintained via atomic `ADD` (see follow ops).
 /// `email` is duplicated here for reads; uniqueness is enforced by a separate
-/// `EMAIL#<email>` guard item.
+/// `EMAIL#<email>` guard item. `stats` is kept inline (rather than its own
+/// `STATS#<sport>` item per sport) so a profile read/batch-read returns
+/// everything in one point read — always present (an empty map for a brand
+/// new user) so the stats reconciler's nested-attribute updates always have a
+/// map to write into.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct UserRecord {
     pub id: String,
@@ -156,6 +162,8 @@ pub struct UserRecord {
     pub following_count: u64,
     #[serde(default)]
     pub unread_count: u64,
+    #[serde(default)]
+    pub stats: HashMap<String, UserSportStatsRecord>,
     pub created_at: String,
 }
 
@@ -507,11 +515,11 @@ pub struct FeedItemRecord {
     pub created_at: String,
 }
 
-/// `USER#<uid>` / `STATS#<sport>` — per-sport aggregate stats for a user.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// Aggregate stats for one sport, stored inline on `UserRecord::stats` keyed
+/// by sport tag (e.g. "tennis") — the key carries the sport, so it isn't
+/// duplicated in the value.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct UserSportStatsRecord {
-    /// Sport tag, e.g. "tennis".
-    pub match_type: String,
     pub matches_played: u64,
     pub wins: u64,
     // Win percentage is derived (wins / matches_played) at the API layer.
@@ -526,7 +534,7 @@ pub struct UserSportStatsRecord {
 pub struct StatContributionRecord {
     /// Sport the contribution counted under (matches the match's type at the
     /// time it was applied). Kept so a sport change can move the counts to the
-    /// right `STATS#<sport>` item.
+    /// right sport's counters in `UserRecord::stats`.
     pub match_type: String,
     /// 1 while the match is completed and the user played; 0 otherwise.
     pub played: u64,

--- a/agon_core/src/dao/stats.rs
+++ b/agon_core/src/dao/stats.rs
@@ -1,4 +1,7 @@
-//! Per-user, per-sport stats: list, and reconcile from a match's current state.
+//! Per-user, per-sport stats (stored inline on the user's profile item) and
+//! reconciling them from a match's current state.
+
+use std::collections::HashMap;
 
 use aws_sdk_dynamodb::types::{AttributeValue, Delete, Put, TransactWriteItem, Update};
 
@@ -6,37 +9,12 @@ use super::client::Dao;
 use super::error::{DaoError, DaoResult};
 use super::item::{ATTR_PK, ATTR_SK, from_item, item_sk, s, to_item};
 use super::keys::{Pk, Sk};
-use super::records::{StatContributionRecord, UserSportStatsRecord};
+use super::records::StatContributionRecord;
 
 /// Type tag for the per-match stat-contribution item.
 pub const TYPE_STAT_CONTRIBUTION: &str = "stat_contribution";
 
 impl Dao {
-    /// List all of a user's per-sport stats (one item per sport). Unpaginated —
-    /// a user only has a handful of sports.
-    pub async fn list_user_stats(&self, user_id: &str) -> DaoResult<Vec<UserSportStatsRecord>> {
-        let out = self
-            .client
-            .query()
-            .table_name(self.table())
-            .key_condition_expression("#pk = :pk AND begins_with(SK, :sk)")
-            .expression_attribute_names("#pk", ATTR_PK)
-            .expression_attribute_values(":pk", s(Pk::User(user_id.into()).to_string()))
-            .expression_attribute_values(":sk", s(Sk::Stats(String::new()).prefix()))
-            .send()
-            .await
-            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
-
-        let mut stats = Vec::new();
-        for item in out.items.unwrap_or_default() {
-            // Every item under this range is a stats item, but guard anyway.
-            if let Sk::Stats(_) = item_sk(&item)? {
-                stats.push(from_item(item)?);
-            }
-        }
-        Ok(stats)
-    }
-
     /// User ids that currently have a stored stat contribution for this match.
     /// The reconciler unions these with the match's current participants so a
     /// player removed from the roster still gets their contribution backed out.
@@ -68,7 +46,7 @@ impl Dao {
     /// now (`played` = completed && the user played; `won` = their side is the
     /// confirmed winner). This is diffed against the contribution we last stored
     /// for `(match, user)` and only the delta is applied to the user's
-    /// `STATS#<sport>` counters — so the same call is:
+    /// `stats.<sport>` counters on their profile item — so the same call is:
     ///
     /// - **idempotent**: unchanged state → zero delta → no write (safe under
     ///   at-least-once delivery and the match-meta events fired by every
@@ -171,22 +149,27 @@ impl Dao {
         //    contribution out of the old sport and add the new one; otherwise
         //    apply the net delta on the single sport.
         if old_sport != sport {
-            if let Some(u) =
-                self.stats_delta(user_id, &old_sport, -(old_played as i64), -(old_won as i64))?
+            if let Some(u) = self
+                .stats_delta(user_id, &old_sport, -(old_played as i64), -(old_won as i64))
+                .await?
             {
                 tx.push(TransactWriteItem::builder().update(u).build());
             }
-            if let Some(u) =
-                self.stats_delta(user_id, sport, desired_played as i64, desired_won as i64)?
+            if let Some(u) = self
+                .stats_delta(user_id, sport, desired_played as i64, desired_won as i64)
+                .await?
             {
                 tx.push(TransactWriteItem::builder().update(u).build());
             }
-        } else if let Some(u) = self.stats_delta(
-            user_id,
-            sport,
-            desired_played as i64 - old_played as i64,
-            desired_won as i64 - old_won as i64,
-        )? {
+        } else if let Some(u) = self
+            .stats_delta(
+                user_id,
+                sport,
+                desired_played as i64 - old_played as i64,
+                desired_won as i64 - old_won as i64,
+            )
+            .await?
+        {
             tx.push(TransactWriteItem::builder().update(u).build());
         }
 
@@ -208,10 +191,14 @@ impl Dao {
         }
     }
 
-    /// An `ADD matches_played/wins` update on `STATS#<sport>`, or `None` when both
-    /// deltas are zero. Stamps `match_type` so a freshly-created item carries its
-    /// sport.
-    fn stats_delta(
+    /// An `ADD stats.<sport>.matches_played/wins` update on the user's profile
+    /// item, or `None` when both deltas are zero. `stats.<sport>` must already
+    /// be a map for a nested `ADD` to resolve, so this first ensures it exists
+    /// (a separate, unconditionally idempotent call — `TransactWriteItems`
+    /// can't touch the profile item twice in the one transaction below it
+    /// joins). That extra round trip only happens on a real stats change
+    /// (a completed match, a re-score, ...), which is rare per user.
+    async fn stats_delta(
         &self,
         user_id: &str,
         sport: &str,
@@ -221,17 +208,44 @@ impl Dao {
         if played_delta == 0 && won_delta == 0 {
             return Ok(None);
         }
+        self.ensure_stats_sport(user_id, sport).await?;
         let u = Update::builder()
             .table_name(self.table())
             .key(ATTR_PK, s(Pk::User(user_id.into()).to_string()))
-            .key(ATTR_SK, s(Sk::Stats(sport.into()).to_string()))
-            .update_expression("ADD matches_played :p, wins :w SET match_type = :mt")
+            .key(ATTR_SK, s(Sk::Profile.to_string()))
+            .update_expression("ADD stats.#sport.matches_played :p, stats.#sport.wins :w")
+            .expression_attribute_names("#sport", sport)
             .expression_attribute_values(":p", AttributeValue::N(played_delta.to_string()))
             .expression_attribute_values(":w", AttributeValue::N(won_delta.to_string()))
-            .expression_attribute_values(":mt", s(sport))
             .build()
             .map_err(|e| DaoError::Dynamo(e.to_string()))?;
         Ok(Some(u))
+    }
+
+    /// Make sure `stats.<sport>` exists as a `{matches_played, wins}` map on
+    /// the user's profile item, so the nested `ADD` in [`Self::stats_delta`]
+    /// always has a map to resolve into. A no-op if it's already there
+    /// (`if_not_exists`), so safe to call unconditionally on every real delta.
+    async fn ensure_stats_sport(&self, user_id: &str, sport: &str) -> DaoResult<()> {
+        let empty_sport_stats = AttributeValue::M(HashMap::from([
+            (
+                "matches_played".to_string(),
+                AttributeValue::N("0".to_string()),
+            ),
+            ("wins".to_string(), AttributeValue::N("0".to_string())),
+        ]));
+        self.client
+            .update_item()
+            .table_name(self.table())
+            .key(ATTR_PK, s(Pk::User(user_id.into()).to_string()))
+            .key(ATTR_SK, s(Sk::Profile.to_string()))
+            .update_expression("SET stats.#sport = if_not_exists(stats.#sport, :empty)")
+            .expression_attribute_names("#sport", sport)
+            .expression_attribute_values(":empty", empty_sport_stats)
+            .send()
+            .await
+            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+        Ok(())
     }
 }
 

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -1108,9 +1108,8 @@ impl Api {
                 )));
             }
         };
-        let stats = dao.list_user_stats(&uid).await.map_err(dao_internal)?;
         // Own profile: not "followed by me".
-        let profile = user_profile_from_record(&record, &stats, false);
+        let profile = user_profile_from_record(&record, false);
         Ok(GetUserResponse::User(Json(User {
             email: record.email,
             profile,
@@ -1163,8 +1162,7 @@ impl Api {
             .await
             .map_err(dao_internal)?
             .ok_or_else(|| Error::from_string("user not found", StatusCode::NOT_FOUND))?;
-        let stats = dao.list_user_stats(&uid).await.map_err(dao_internal)?;
-        let profile = user_profile_from_record(&record, &stats, false);
+        let profile = user_profile_from_record(&record, false);
         Ok(UpdateUserResponse::User(Json(User {
             email: record.email,
             profile,
@@ -1257,7 +1255,6 @@ impl Api {
                 )));
             }
         };
-        let stats = dao.list_user_stats(&user_id).await.map_err(dao_internal)?;
         let caller_uid = self.require_uid(dao, &jwt_data).await?;
         let is_followed = if caller_uid == user_id {
             false
@@ -1267,7 +1264,7 @@ impl Api {
                 .map_err(dao_internal)?
         };
         Ok(GetUserProfileResponse::User(Json(
-            user_profile_from_record(&record, &stats, is_followed),
+            user_profile_from_record(&record, is_followed),
         )))
     }
 
@@ -1302,6 +1299,7 @@ impl Api {
             follower_count: 0,
             following_count: 0,
             unread_count: 0,
+            stats: std::collections::HashMap::new(),
             created_at: now_iso(),
         };
         match dao.create_user(&jwt_data.sub, &record).await {
@@ -1313,7 +1311,7 @@ impl Api {
             }
             Err(e) => return Err(dao_internal(e)),
         }
-        let profile = user_profile_from_record(&record, &[], false);
+        let profile = user_profile_from_record(&record, false);
         Ok(CreateUserResponse::User(Json(User {
             email: record.email,
             profile,
@@ -3049,9 +3047,9 @@ impl Api {
                             follower_count: 0,
                             following_count: 0,
                             unread_count: 0,
+                            stats: std::collections::HashMap::new(),
                             created_at: String::new(),
                         },
-                        &[],
                         false,
                     )
                 });
@@ -3472,20 +3470,19 @@ impl Api {
         })))
     }
 
-    /// Hydrate a list of user ids into `UserProfile`s. TODO: batch these with
-    /// BatchGetItem; currently a per-id fetch (N+1). Missing users are skipped.
-    /// `is_followed_by_me` is left false here (a follow-list view rarely needs
-    /// it per-row); compute it if a screen requires it.
+    /// Hydrate a list of user ids into `UserProfile`s via two batched
+    /// exact-key reads across the whole page (the profile items, and — for a
+    /// signed-in viewer — which of them the viewer follows); stats live inline
+    /// on the profile item, so there's no per-user query left to N+1 on.
+    /// Missing users are skipped. `is_followed_by_me` is left false when
+    /// there's no viewer (a follow-list view rarely needs it per-row);
+    /// compute it if a screen requires it.
     async fn hydrate_user_profiles(
         &self,
         dao: &dao::Dao,
         ids: &[String],
         viewer_uid: Option<&str>,
     ) -> Result<Vec<UserProfile>> {
-        // Batch the two exact-key point reads across the whole page: the profile
-        // items, and (for a signed-in viewer) which of these the viewer follows.
-        // Per-user stats stay a per-user query — they're a `begins_with(STATS)`
-        // range read per partition, which BatchGetItem can't express.
         let records = dao.batch_get_users(ids).await.map_err(dao_internal)?;
         let followed = match viewer_uid {
             Some(viewer) => dao
@@ -3500,12 +3497,7 @@ impl Api {
         let mut profiles = Vec::with_capacity(ids.len());
         for id in ids {
             if let Some(record) = records.get(id) {
-                let stats = dao.list_user_stats(id).await.map_err(dao_internal)?;
-                profiles.push(user_profile_from_record(
-                    record,
-                    &stats,
-                    followed.contains(id),
-                ));
+                profiles.push(user_profile_from_record(record, followed.contains(id)));
             }
         }
         Ok(profiles)
@@ -3542,10 +3534,7 @@ impl Api {
     /// an author/actor inline. (N+1 in list contexts — batch later.)
     async fn try_user_profile(&self, dao: &dao::Dao, user_id: &str) -> Result<Option<UserProfile>> {
         match dao.get_user(user_id).await.map_err(dao_internal)? {
-            Some(record) => {
-                let stats = dao.list_user_stats(user_id).await.map_err(dao_internal)?;
-                Ok(Some(user_profile_from_record(&record, &stats, false)))
-            }
+            Some(record) => Ok(Some(user_profile_from_record(&record, false))),
             None => Ok(None),
         }
     }

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -3471,12 +3471,11 @@ impl Api {
     }
 
     /// Hydrate a list of user ids into `UserProfile`s via two batched
-    /// exact-key reads across the whole page (the profile items, and — for a
-    /// signed-in viewer — which of them the viewer follows); stats live inline
-    /// on the profile item, so there's no per-user query left to N+1 on.
-    /// Missing users are skipped. `is_followed_by_me` is left false when
-    /// there's no viewer (a follow-list view rarely needs it per-row);
-    /// compute it if a screen requires it.
+    /// exact-key reads across the whole page: the profile items, and — for a
+    /// signed-in viewer — which of them the viewer follows. Missing users are
+    /// skipped. `is_followed_by_me` is left false when there's no viewer (a
+    /// follow-list view rarely needs it per-row); compute it if a screen
+    /// requires it.
     async fn hydrate_user_profiles(
         &self,
         dao: &dao::Dao,

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -79,20 +79,24 @@ pub fn match_type_tag(mt: &MatchType) -> &'static str {
     }
 }
 
-/// Build the public `UserProfile` from a stored user record, its per-sport
-/// stats, and the viewer-relative follow flag.
-pub fn user_profile_from_record(
-    user: &UserRecord,
-    stats: &[UserSportStatsRecord],
-    is_followed_by_me: bool,
-) -> UserProfile {
+/// Build the public `UserProfile` from a stored user record (its inline
+/// per-sport `stats` map) and the viewer-relative follow flag.
+pub fn user_profile_from_record(user: &UserRecord, is_followed_by_me: bool) -> UserProfile {
+    // Sort by sport tag for a deterministic response order (a `HashMap`'s
+    // iteration order isn't).
+    let mut entries: Vec<(&String, &UserSportStatsRecord)> = user.stats.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+
     UserProfile {
         id: user.id.clone(),
         name: user.name.clone(),
         profile_image: user.profile_image_url.as_ref().map(|url| Photo {
             image_url: url.clone(),
         }),
-        stats: stats.iter().map(sport_stats_from_record).collect(),
+        stats: entries
+            .into_iter()
+            .map(|(sport, rec)| sport_stats_from_record(sport, rec))
+            .collect(),
         follower_count: user.follower_count as u32,
         following_count: user.following_count as u32,
         is_followed_by_me,
@@ -100,14 +104,14 @@ pub fn user_profile_from_record(
 }
 
 /// Map a stored per-sport stats record to the API model, deriving win %.
-pub fn sport_stats_from_record(rec: &UserSportStatsRecord) -> UserSportStats {
+pub fn sport_stats_from_record(sport: &str, rec: &UserSportStatsRecord) -> UserSportStats {
     let win_percentage = if rec.matches_played == 0 {
         0.0
     } else {
         (rec.wins as f32 / rec.matches_played as f32) * 100.0
     };
     UserSportStats {
-        match_type: match_type_from_tag(&rec.match_type),
+        match_type: match_type_from_tag(sport),
         matches_played: rec.matches_played as i32,
         win_percentage,
     }

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -1,4 +1,5 @@
-import { Flame, MailOpen, MessageCircle, Share2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Check, Flame, MailOpen, MessageCircle, Share2 } from 'lucide-react'
 import type { components } from '@/types/api'
 import { cn } from '@/lib/utils'
 import { useToggleLike } from '@/hooks/useToggleLike'
@@ -46,6 +47,57 @@ function InvitedBadge({
     <span className="inline-flex items-center gap-1 rounded border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
       <MailOpen className="size-3" /> You're invited
     </span>
+  )
+}
+
+/**
+ * Shares a match's detail link via the native share sheet, falling back to a
+ * clipboard copy (then a manual prompt) where that's unavailable — mirrors
+ * `CopyInviteButton`'s fallback chain, with a transient checkmark standing in
+ * for its "Copied!" label since this is an icon-only button.
+ */
+function ShareMatchButton({ match }: { match: Match }) {
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (!copied) return
+    const id = setTimeout(() => setCopied(false), 2000)
+    return () => clearTimeout(id)
+  }, [copied])
+
+  const share = async () => {
+    const url = `${window.location.origin}/matches/${match.id}`
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: match.name, url })
+        return
+      } catch {
+        // User dismissed the sheet, or share failed — fall through to copy.
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+    } catch {
+      // Clipboard blocked (e.g. insecure context) — surface the link so the
+      // user can copy it manually rather than failing silently.
+      window.prompt('Copy this match link:', url)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={share}
+      className="flex items-center transition-colors hover:text-primary"
+      aria-label="Share match"
+    >
+      {copied ? (
+        <Check className="size-3.5 text-primary" />
+      ) : (
+        <Share2 className="size-3.5" />
+      )}
+    </button>
   )
 }
 
@@ -194,13 +246,7 @@ export function MatchCard({
         >
           <MessageCircle className="size-3.5" /> {comment_count}
         </button>
-        <button
-          type="button"
-          className="flex items-center transition-colors hover:text-primary"
-          aria-label="Share match"
-        >
-          <Share2 className="size-3.5" />
-        </button>
+        <ShareMatchButton match={match} />
         <StatusBadge status={matchBadgeStatus(match)} className="ml-auto" />
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Fold the separate `STATS#<sport>` items into a `stats` map on the user's profile item, so a profile read (or batch read) returns everything in one point read instead of `get_user` + a per-user `begins_with(STATS)` query. The stats reconciler now `ADD`s into `stats.<sport>` on the profile item, first ensuring that sub-map exists via an idempotent `if_not_exists` update (needed since `TransactWriteItems` can't touch the profile item twice in the same transaction as the counter increment). No migration path — existing table data needs wiping for this to take effect cleanly.
- Wire up the match card's `Share2` button, which had no `onClick` at all. It now builds the match's detail link and shares it via the native share sheet, falling back to a clipboard copy (then a manual prompt) where that's unavailable — mirroring the fallback chain `CopyInviteButton` already uses for invite links.

## Test plan

- [x] `cargo build -p agon_core -p agon_service` — clean
- [x] `cargo clippy -p agon_core -p agon_service` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo test -p agon_core --lib` — passing
- [x] `tsc -b` / `eslint` on the frontend — clean
- [ ] No live end-to-end test of the share button in a browser (this sandbox has no configured Supabase credentials to sign in with) — verified by code review against the already-shipped `CopyInviteButton` pattern instead


---
_Generated by [Claude Code](https://claude.ai/code/session_0169E7ETZH5FjtL7vzHE7xiU)_