### PR TITLE
Fix pr.yml pointing at nonexistent agon_service repo/workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
 
 jobs:
-  build:
-    uses: JElgar/agon_service/.github/workflows/build.yml@main
+  build-service:
+    uses: JElgar/agon/.github/workflows/build-service.yml@main
+    secrets: inherit
+
+  build-ui:
+    uses: JElgar/agon/.github/workflows/build-ui.yml@main
     secrets: inherit


### PR DESCRIPTION
pr.yml called JElgar/agon_service/.github/workflows/build.yml, a repo
and workflow path that don't exist (this is a monorepo, and the real
reusable workflows live at JElgar/agon/.github/workflows/build-service.yml
and build-ui.yml, as release.yml already calls). The bad reference made
every PR check fail immediately with zero jobs.