### PR TITLE
Redesign feed page and add mobile bottom navigation

### DIFF
--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -169,7 +169,7 @@ export function MatchCard({
 
       {/* Score block */}
       {scoreInfo && (
-        <div className="mx-3.5 rounded-lg bg-muted/50 px-3.5 py-3">
+        <div className="mx-3.5 mb-3 rounded-lg bg-muted/50 px-3.5 py-3">
           <div className="flex items-center justify-between">
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <Avatar name={nameA} size="md" ring={aWon ? 'winner' : 'none'} />
@@ -203,9 +203,11 @@ export function MatchCard({
         </div>
       )}
 
-      {/* Header photo, when the match has one. */}
+      {/* Header photo, when the match has one. The gap above comes from the
+          preceding block's own bottom margin (score box / title), so this
+          only needs to provide the gap below itself. */}
       {match.header_photos.length > 0 && (
-        <div className="px-3.5 pb-3 pt-3">
+        <div className="px-3.5 pb-3">
           <MatchHeaderCarousel photos={match.header_photos} />
         </div>
       )}

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -140,18 +140,15 @@ export function MatchCard({
         onClick={onOpen}
         className="flex w-full items-start justify-between gap-3 p-3.5 text-left"
       >
-        <div className="flex items-start gap-2.5">
-          <Avatar name={nameA} size="lg" ring={aWon ? 'winner' : 'none'} />
-          <p className="text-sm leading-snug">
-            <span className={cn(aWon && 'font-medium')}>{nameA}</span>
-            <span className="text-primary">
-              {' '}
-              {scoreInfo?.winnerSideId ? 'beat' : 'vs'}{' '}
-            </span>
-            <span className={cn(bWon && 'font-medium')}>{nameB}</span>
-            <span className="text-muted-foreground"> · {relativeTime(match.starts_at)}</span>
-          </p>
-        </div>
+        <p className="text-sm leading-snug">
+          <span className={cn(aWon && 'font-medium')}>{nameA}</span>
+          <span className="text-primary">
+            {' '}
+            {scoreInfo?.winnerSideId ? 'beat' : 'vs'}{' '}
+          </span>
+          <span className={cn(bWon && 'font-medium')}>{nameB}</span>
+          <span className="text-muted-foreground"> · {relativeTime(match.starts_at)}</span>
+        </p>
         <div className="flex shrink-0 flex-col items-end gap-1.5">
           <SportBadge sport={match.match_type} />
           <InvitedBadge match={match} currentUserId={currentUserId} />

--- a/agon_ui/src/components/agon/SportBadge.tsx
+++ b/agon_ui/src/components/agon/SportBadge.tsx
@@ -1,29 +1,21 @@
 import { cn } from '@/lib/utils'
-import { sportIcon, sportLabel, type MatchType } from '@/lib/sports'
+import { sportEmoji, sportLabel, type MatchType } from '@/lib/sports'
 
 export interface SportBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   sport: MatchType
-  /** Show the sport's icon alongside the label. Off by default (pill is text-only). */
-  withIcon?: boolean
 }
 
-/** The blue sport pill (e.g. "TENNIS") used on match cards and detail headers. */
-export function SportBadge({
-  sport,
-  withIcon = false,
-  className,
-  ...props
-}: SportBadgeProps) {
-  const Icon = sportIcon(sport)
+/** The sport pill (e.g. "🎾 Tennis") used on match cards and detail headers. */
+export function SportBadge({ sport, className, ...props }: SportBadgeProps) {
   return (
     <span
       className={cn(
-        'inline-flex shrink-0 items-center gap-1 rounded bg-accent px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-accent-foreground',
+        'inline-flex shrink-0 items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-foreground',
         className,
       )}
       {...props}
     >
-      {withIcon && <Icon className="size-3" />}
+      <span aria-hidden>{sportEmoji(sport)}</span>
       {sportLabel(sport)}
     </span>
   )

--- a/agon_ui/src/lib/sports.ts
+++ b/agon_ui/src/lib/sports.ts
@@ -45,6 +45,21 @@ export function sportIcon(type: MatchType): LucideIcon {
   return SPORT_ICONS[type] ?? Circle
 }
 
+/** Emoji for a sport, used by the compact sport pill (feed cards, match detail). */
+const SPORT_EMOJI: Record<MatchType, string> = {
+  tennis: '🎾',
+  badminton: '🏸',
+  squash: '🎾',
+  table_tennis: '🏓',
+  football: '⚽',
+  cricket: '🏏',
+  other: '🏅',
+}
+
+export function sportEmoji(type: MatchType): string {
+  return SPORT_EMOJI[type] ?? SPORT_EMOJI.other
+}
+
 /** Racket sports are scored by sets; everything else by a single points total. */
 export function isSetsSport(sport: MatchType): boolean {
   return (


### PR DESCRIPTION
## Summary

Follow-up to #14 (merged, then superseded by later work on `main`), plus two mockup-fidelity fixes made after review:

- Match card header is now text-only — the avatar that used to sit next to "Sofia beat Alex" is removed, since avatars already appear in the score box below and the mockup's card header has no avatar.
- `SportBadge` now renders an emoji + normal-case label (🎾 Tennis, ⚽ Football, 🏸 Badminton, 🏓 Table Tennis, 🏏 Cricket, 🏅 Other) instead of an uppercase text-only pill, matching the mockup.
- Fixed the score box touching the footer divider when a card has no photo or pending-score prompt: the gap used to come from whichever block followed the score box (e.g. the photo carousel's `pt-3`), so it disappeared when nothing followed. The score box now carries its own bottom margin.

## Test plan

- `npx tsc -b --noEmit` — clean
- `npm run lint` — no new warnings/errors
- Visually verified via a local fixture harness (mobile + desktop, light + dark) against the original mockup — not part of this diff


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHajeu2kE8F9SsmojZSYXt)_