### PR TITLE
Swap hand-rolled Meilisearch client for the official SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,11 +16,11 @@ dependencies = [
  "aws-sdk-dynamodb",
  "base64 0.22.1",
  "chrono",
+ "meilisearch-sdk",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "reqwest 0.12.15",
  "serde",
  "serde_dynamo",
  "serde_json",
@@ -42,13 +42,13 @@ dependencies = [
  "chrono",
  "clap",
  "cron",
- "jsonwebtoken",
+ "jsonwebtoken 9.3.1",
  "openssl",
  "opentelemetry",
  "poem",
  "poem-openapi",
  "rand 0.9.1",
- "reqwest 0.12.15",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -66,7 +66,7 @@ dependencies = [
  "aws-sdk-sqs",
  "chrono",
  "futures",
- "reqwest 0.12.15",
+ "reqwest 0.12.28",
  "serde",
  "serde_dynamo",
  "serde_json",
@@ -894,6 +894,15 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -1091,6 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1129,7 +1139,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1207,7 +1217,7 @@ dependencies = [
  "der",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -1215,6 +1225,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -2077,6 +2090,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "iso8601"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a0559b45528cf0732d911524974977a5749f477d7dd99652830ffdaf53c4d1"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2173,6 +2195,21 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.2.16",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature 2.2.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2274,6 +2311,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "meilisearch-index-setting-macro"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93b5b21df781c820a9cc387b808d4128cbc164dd28d67ac6ed666a00996f8f15"
+dependencies = [
+ "convert_case 0.8.0",
+ "proc-macro2",
+ "quote",
+ "structmeta",
+ "syn",
+]
+
+[[package]]
+name = "meilisearch-sdk"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e6e3646ba2a9a306296c1edf4a050508a408c1b59ca456d9ad4965ec6e91e9"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "iso8601",
+ "jsonwebtoken 10.4.0",
+ "log",
+ "meilisearch-index-setting-macro",
+ "pin-project-lite",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "time",
+ "tokio",
+ "uuid",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yaup",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +2446,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2627,7 +2716,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3278,30 +3367,27 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
  "hyper-rustls 0.27.5",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls 0.23.28",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3309,14 +3395,16 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.2",
+ "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.11",
- "windows-registry",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3464,7 +3552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe 0.1.6",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "schannel",
  "security-framework 2.11.1",
 ]
@@ -3488,15 +3576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -3804,6 +3883,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3922,6 +4010,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,9 +4040,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4802,6 +4913,7 @@ checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4954,6 +5066,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5155,17 +5280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result 0.3.2",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5181,15 +5295,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -5216,7 +5321,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5225,7 +5330,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5243,30 +5348,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5285,22 +5374,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5309,22 +5386,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5333,22 +5398,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5357,22 +5410,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -5516,6 +5557,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "yaup"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0144f1a16a199846cb21024da74edd930b43443463292f536b7110b4855b5c6"
+dependencies = [
+ "form_urlencoded",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,9 +5634,23 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerovec"

--- a/agon_core/Cargo.toml
+++ b/agon_core/Cargo.toml
@@ -18,7 +18,7 @@ aws-sdk-dynamodb = "1"
 # Only the timer, for backoff between DynamoDB batch-retry attempts.
 tokio = { version = "1", features = ["time"] }
 serde_dynamo = { version = "4", features = ["aws-sdk-dynamodb+1"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+meilisearch-sdk = { version = "0.33", default-features = false, features = ["reqwest", "tls"] }
 
 # Observability: OTLP export of logs, traces and metrics. `telemetry::init`
 # wires the `tracing` ecosystem to an OTLP collector (Grafana Alloy in prod);

--- a/agon_core/src/search.rs
+++ b/agon_core/src/search.rs
@@ -1,17 +1,20 @@
-//! Minimal Meilisearch client over its REST API.
+//! Meilisearch client, built on the official `meilisearch-sdk` crate.
 //!
 //! Shared by the worker (which keeps the indexes in sync via idempotent
 //! upsert/delete off the DynamoDB stream) and the API (which queries the indexes
-//! to serve discovery endpoints). We talk to Meilisearch directly with `reqwest`
-//! rather than pulling in the official SDK: the surface we need is small —
-//! upsert a document, delete one by id, and run a filtered search — so a thin
-//! client keeps the dependency footprint (and version churn) down.
+//! to serve discovery endpoints). This module exposes only the slice of the SDK
+//! we actually use — upsert a document, delete one by id, run a filtered
+//! search, and declare index settings — so callers don't reach into the SDK
+//! directly.
 //!
 //! Write operations are idempotent (a replayed upsert/delete has no visible
 //! effect), which is exactly what the worker's at-least-once delivery needs.
 //! Search returns only document ids: the API hydrates full entities from
 //! DynamoDB, since the indexes store only what's needed to match and rank.
 
+use meilisearch_sdk::client::Client;
+use meilisearch_sdk::search::Selectors;
+use meilisearch_sdk::settings::Settings;
 use serde::{Deserialize, Serialize};
 
 use crate::error::SearchError;
@@ -86,12 +89,11 @@ pub struct SearchQuery {
     pub limit: u32,
 }
 
-/// A thin Meilisearch REST client. Cheap to clone (wraps an `Arc` internally).
+/// A Meilisearch client wrapping the official SDK. Cheap to clone (the SDK's
+/// `Client` wraps its `reqwest::Client` internally).
 #[derive(Clone)]
 pub struct SearchClient {
-    http: reqwest::Client,
-    base_url: String,
-    api_key: String,
+    client: Client,
 }
 
 /// Only the `id` field is read back from search hits; everything else is
@@ -101,100 +103,72 @@ struct IdOnly {
     id: String,
 }
 
-#[derive(Deserialize)]
-struct SearchResponse {
-    hits: Vec<IdOnly>,
-    #[serde(rename = "estimatedTotalHits")]
-    estimated_total_hits: u32,
-}
-
 impl SearchClient {
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
-        Self {
-            http: reqwest::Client::new(),
-            // Trim a trailing slash so URL joins are predictable.
-            base_url: base_url.into().trim_end_matches('/').to_string(),
-            api_key: api_key.into(),
-        }
+        // Trim a trailing slash so URL joins are predictable.
+        let base_url = base_url.into().trim_end_matches('/').to_string();
+        // Only fails if the api key can't be encoded as an HTTP header value,
+        // which never happens for the keys this service is configured with.
+        let client = Client::new(base_url, Some(api_key.into()))
+            .expect("invalid meilisearch client configuration");
+        Self { client }
     }
 
     /// Upsert one document into an index. Meilisearch replaces any existing
     /// document with the same primary key (`id`), so this is idempotent.
-    pub async fn upsert<T: Serialize>(&self, index: Index, doc: &T) -> SearchResult<()> {
-        let url = format!("{}/indexes/{}/documents", self.base_url, index.name());
-        let resp = self
-            .http
-            .post(&url)
-            .bearer_auth(&self.api_key)
-            .json(&[doc])
-            .send()
+    pub async fn upsert<T: Serialize + Send + Sync>(
+        &self,
+        index: Index,
+        doc: &T,
+    ) -> SearchResult<()> {
+        self.client
+            .index(index.name())
+            .add_documents(std::slice::from_ref(doc), Some("id"))
             .await
             .map_err(|e| SearchError(e.to_string()))?;
-        Self::check(resp, "upsert").await
+        Ok(())
     }
 
     /// Delete one document by id from an index. Deleting a missing document is a
     /// no-op in Meilisearch, so this is idempotent.
     pub async fn delete(&self, index: Index, id: &str) -> SearchResult<()> {
-        let url = format!(
-            "{}/indexes/{}/documents/{}",
-            self.base_url,
-            index.name(),
-            id
-        );
-        let resp = self
-            .http
-            .delete(&url)
-            .bearer_auth(&self.api_key)
-            .send()
+        self.client
+            .index(index.name())
+            .delete_document(id)
             .await
             .map_err(|e| SearchError(e.to_string()))?;
-        Self::check(resp, "delete").await
+        Ok(())
     }
 
     /// Run a search against an index, returning ranked document ids and a
     /// next-page offset. The caller hydrates full entities from DynamoDB.
     pub async fn search(&self, index: Index, query: &SearchQuery) -> SearchResult<SearchHits> {
-        let url = format!("{}/indexes/{}/search", self.base_url, index.name());
-
-        let mut body = serde_json::json!({
-            "q": query.q,
-            "offset": query.offset,
-            "limit": query.limit,
+        let idx = self.client.index(index.name());
+        let mut builder = idx.search();
+        builder
+            .with_query(&query.q)
+            .with_offset(query.offset as usize)
+            .with_limit(query.limit as usize)
             // Only the primary key comes back; entities are hydrated from Dynamo.
-            "attributesToRetrieve": ["id"],
-        });
+            .with_attributes_to_retrieve(Selectors::Some(&["id"]));
         if let Some(filter) = &query.filter {
-            body["filter"] = serde_json::json!(filter);
+            builder.with_filter(filter);
         }
-        if !query.sort.is_empty() {
-            body["sort"] = serde_json::json!(query.sort);
+        let sort_refs: Vec<&str> = query.sort.iter().map(String::as_str).collect();
+        if !sort_refs.is_empty() {
+            builder.with_sort(&sort_refs);
         }
 
-        let resp = self
-            .http
-            .post(&url)
-            .bearer_auth(&self.api_key)
-            .json(&body)
-            .send()
+        let results = builder
+            .execute::<IdOnly>()
             .await
             .map_err(|e| SearchError(e.to_string()))?;
 
-        let status = resp.status();
-        if !status.is_success() {
-            let text = resp.text().await.unwrap_or_default();
-            return Err(SearchError(format!("search returned {status}: {text}")));
-        }
-
-        let parsed: SearchResponse = resp
-            .json()
-            .await
-            .map_err(|e| SearchError(format!("bad search response: {e}")))?;
-
-        let ids: Vec<String> = parsed.hits.into_iter().map(|h| h.id).collect();
+        let ids: Vec<String> = results.hits.into_iter().map(|h| h.result.id).collect();
         // If this page reached the estimated total, there is no next page.
         let consumed = query.offset.saturating_add(ids.len() as u32);
-        let next_offset = (consumed < parsed.estimated_total_hits).then_some(consumed);
+        let total = results.estimated_total_hits.unwrap_or(consumed as usize) as u32;
+        let next_offset = (consumed < total).then_some(consumed);
 
         Ok(SearchHits { ids, next_offset })
     }
@@ -204,22 +178,18 @@ impl SearchClient {
     /// treats the settings update as idempotent — re-applying the same settings
     /// is a no-op — so this is safe to run on every worker start.
     ///
-    /// Uses `id` as the primary key to match how documents are upserted.
+    /// Uses `id` as the primary key implicitly: documents are always upserted
+    /// with `id` as the explicit primary key (see `upsert`).
     pub async fn configure_index(&self, index: Index) -> SearchResult<()> {
-        let url = format!("{}/indexes/{}/settings", self.base_url, index.name());
-        let body = serde_json::json!({
-            "filterableAttributes": index.filterable_attributes(),
-            "sortableAttributes": index.sortable_attributes(),
-        });
-        let resp = self
-            .http
-            .patch(&url)
-            .bearer_auth(&self.api_key)
-            .json(&body)
-            .send()
+        let settings = Settings::new()
+            .with_filterable_attributes(index.filterable_attributes().iter().copied())
+            .with_sortable_attributes(index.sortable_attributes().iter().copied());
+        self.client
+            .index(index.name())
+            .set_settings(&settings)
             .await
             .map_err(|e| SearchError(e.to_string()))?;
-        Self::check(resp, "configure_index").await
+        Ok(())
     }
 
     /// Configure every index. Called once on worker startup so a fresh
@@ -230,14 +200,5 @@ impl SearchClient {
             self.configure_index(index).await?;
         }
         Ok(())
-    }
-
-    async fn check(resp: reqwest::Response, op: &str) -> SearchResult<()> {
-        let status = resp.status();
-        if status.is_success() {
-            return Ok(());
-        }
-        let body = resp.text().await.unwrap_or_default();
-        Err(SearchError(format!("{op} returned {status}: {body}")))
     }
 }


### PR DESCRIPTION
## Summary
- `agon_core::search::SearchClient` previously drove the Meilisearch REST API by hand with `reqwest` (upsert/delete/search/configure via raw JSON requests).
- This swaps the internals to use the official `meilisearch-sdk` crate instead, so future Meilisearch API/version changes (task semantics, error formats, pagination) are handled by the maintained SDK rather than by us.
- The public API of the module (`SearchClient`, `Index`, `SearchQuery`, `SearchHits`, `SearchError`) is unchanged, so `agon_service` and `agon_worker` needed no code changes — only `agon_core/Cargo.toml` (reqwest → meilisearch-sdk) and `agon_core/src/search.rs` changed.
- Behavior preserved: `upsert` still does a full-replace upsert keyed on `id` (SDK's `add_documents`, an alias for `add_or_replace`), `delete` is still a no-op on a missing doc, and writes remain fire-and-forget (not waiting on task completion), matching the original idempotent, at-least-once-friendly semantics.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo check --workspace --all-targets` (no warnings)
- [x] `cargo fmt -p agon_core`
- [ ] Manual smoke test against local Meilisearch (`docker compose up -d` + `make run` + search endpoints) — not run in this environment


---
_Generated by [Claude Code](https://claude.ai/code/session_01HZftae8iUH9Us62gSvkLJP)_