### PR TITLE
Gate the match detail page's score prompt on having joined

### DIFF
--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -208,16 +208,19 @@ function MatchDetail({
         />
       )}
 
-      {/* Invitation banner: the viewer has a pending invite to this match. */}
-      <InviteBanner match={match} currentUserId={currentUserId} />
-
-      {/* Confirm / dispute (only when the viewer's side owes a response) */}
-      {match.pending_score && (
-        <ScoreConfirmationBar
-          match={match}
-          currentUserId={currentUserId}
-          variant="detail"
-        />
+      {/* Respond to a pending invite first; only once joined does the score
+          confirm/dispute prompt apply — the two are mutually exclusive (same
+          logic as the feed/profile match card). */}
+      {myPendingInvitation(match, currentUserId) ? (
+        <InviteBanner match={match} currentUserId={currentUserId} />
+      ) : (
+        match.pending_score && (
+          <ScoreConfirmationBar
+            match={match}
+            currentUserId={currentUserId}
+            variant="detail"
+          />
+        )
       )}
 
       {/* Rosters, one column per side */}


### PR DESCRIPTION
## Summary

Follow-up to #19. That PR fixed the feed/profile match card, which had the same bug: the invite banner and the score confirm/dispute bar were shown unconditionally and independently, so an invitee who hadn't accepted their invite yet saw both prompts on the match detail page at once.

Makes them mutually exclusive here too, matching the card's logic — respond to the invite first, and only once joined does confirming a still-pending score apply.

## Test plan

- [x] `tsc -b` and `eslint` on `agon_ui`
- [ ] Manual click-through against a running backend (not done in this sandbox — no live DynamoDB/Meilisearch instance available)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZATQ1snbFPnHrqFJ4ERhs)_