### PR TITLE
Dedupe the score-submitted notification for a still-pending invitee

### DIFF
--- a/agon_worker/src/handlers/notify.rs
+++ b/agon_worker/src/handlers/notify.rs
@@ -397,11 +397,25 @@ async fn notify_score_submitted(
     // user needs to confirm only if the submission is pending and they're not on
     // the submitter's side; if a user appears on multiple sides, err towards
     // asking them to confirm.
+    //
+    // A player whose invite to the match is still pending is skipped here: their
+    // `MatchInvitation` notification already covers this (accepting offers to
+    // confirm the score in the same step, using whatever's pending at that
+    // point), so a separate "score submitted" notification would just be a
+    // duplicate of the same event. Once they accept, notifications resume as
+    // normal for any later submission.
     let mut recipients: std::collections::BTreeMap<String, bool> =
         std::collections::BTreeMap::new();
     for player in &agg.players {
         let Some(uid) = &player.user_id else { continue };
         if *uid == submitter_user_id {
+            continue;
+        }
+        if player
+            .invitation
+            .as_ref()
+            .is_some_and(|inv| inv.status == "pending")
+        {
             continue;
         }
         let needs = is_pending && player.side_id != submitter_side_id;


### PR DESCRIPTION
## Summary

Being added to a match that already has a score attached (e.g. logging a completed match and inviting the opponent in the same action) currently sends two notifications for what's really one event: a `MatchInvitation` notification and a separate `ScoreSubmitted` ("confirm it?") notification. Since accepting the invite already offers to confirm the pending score in the same step (from #19), the second notification was just duplicate noise.

`agon_worker/src/handlers/notify.rs`'s `notify_score_submitted` now skips any recipient whose invite to the match is still pending — they'll see the score via the invite's accept flow instead. Once they accept, notifications resume as normal for any later submission, so a score submitted/updated after they've joined still notifies them as before.

## Test plan

- [x] `cargo check` / `cargo clippy` on `agon_worker` (built successfully in this sandbox after installing `protobuf-compiler`, which the crate's build script needs — confirmed this file compiles for real, not just past the usual `protoc`-missing blocker)
- [ ] Manual click-through against a running backend (not done in this sandbox — no live DynamoDB/Meilisearch/stream instance available)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZATQ1snbFPnHrqFJ4ERhs)_