### PR TITLE
Add live football match scoring UI and event recording

### DIFF
--- a/agon_ui/src/App.tsx
+++ b/agon_ui/src/App.tsx
@@ -25,6 +25,8 @@ import { FeedPage } from '@/pages/FeedPage'
 import { ProfilePage } from '@/pages/ProfilePage'
 import { LogMatchPage } from '@/pages/LogMatchPage'
 import { MatchDetailPage } from '@/pages/MatchDetailPage'
+import { LiveScoringSetupPage } from '@/pages/LiveScoringSetupPage'
+import { LiveScoringPage } from '@/pages/LiveScoringPage'
 import { NotificationsPage } from '@/pages/NotificationsPage'
 import { UserSearchPage } from '@/pages/UserSearchPage'
 import { FollowListPage } from '@/pages/FollowListPage'
@@ -93,6 +95,8 @@ function AppShell({ email, onSignOut }: { email: string; onSignOut: () => void }
           <Route path="/feed" element={<FeedPage />} />
           <Route path="/matches/new" element={<LogMatchPage />} />
           <Route path="/matches/:matchId" element={<MatchDetailPage />} />
+          <Route path="/matches/:matchId/live/setup" element={<LiveScoringSetupPage />} />
+          <Route path="/matches/:matchId/live" element={<LiveScoringPage />} />
           <Route path="/teams" element={<ComingSoon title="Teams" />} />
           <Route path="/teams/:teamId" element={<ComingSoon title="Team" />} />
           <Route path="/notifications" element={<NotificationsPage />} />

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -13,6 +13,10 @@ import { StatusBadge, matchBadgeStatus } from './StatusBadge'
 import { ScoreConfirmationBar } from './ScoreConfirmationBar'
 import { MatchHeaderCarousel } from './MatchHeaderCarousel'
 import { InvitationResponseDialog } from './InvitationResponseDialog'
+import { LiveMatchBlock } from './live/LiveMatchBlock'
+import { LiveIndicator } from './live/LiveIndicator'
+import { useLiveScore } from '@/hooks/useLiveScore'
+import { footballLiveState } from '@/lib/liveScore'
 import {
   displayScore,
   headlineBySide,
@@ -189,6 +193,12 @@ export function MatchCard({
   const aWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideA?.id
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
 
+  const live = useLiveScore(match.id, {
+    enabled: match.match_type === 'football' && match.status === 'in_progress',
+    refetchInterval: 20000,
+  })
+  const liveState = footballLiveState(live.data)
+
   const { like_count, comment_count, i_liked } = match.social
   const toggleLike = useToggleLike(match)
 
@@ -232,40 +242,47 @@ export function MatchCard({
         </div>
       )}
 
-      {/* Score block */}
-      {scoreInfo && (
-        <div className="mx-3.5 mb-3 rounded-lg bg-muted/50 px-3.5 py-3">
-          <div className="flex items-center justify-between">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
-              <Avatar name={nameA} size="md" ring={aWon ? 'winner' : 'none'} />
-              <span className="truncate text-xs font-medium">{nameA}</span>
-            </div>
-            <div className="px-3 text-center">
-              <div className="text-2xl font-medium leading-none tracking-tight">
-                {headline[sideA?.id ?? ''] ?? 0}
-                <span className="text-muted-foreground">–</span>
-                {headline[sideB?.id ?? ''] ?? 0}
-              </div>
-              <div className="mt-0.5 text-[9px] uppercase tracking-widest text-muted-foreground">
-                {headlineLabel(scoreInfo.score)}
-              </div>
-            </div>
-            <div className="flex min-w-0 flex-1 flex-row-reverse items-center gap-2 text-right">
-              <Avatar name={nameB} size="md" ring={bWon ? 'winner' : 'none'} />
-              <span className="truncate text-xs font-medium">{nameB}</span>
-            </div>
-          </div>
-          {sets.length > 0 && (
-            <div className="mt-2 border-t pt-2 text-center text-[11px] text-muted-foreground">
-              {sets.map((s, i) => (
-                <span key={i}>
-                  {i > 0 && <span className="mx-1.5 text-border">·</span>}
-                  Set {i + 1} <span className="font-medium text-foreground">{s}</span>
-                </span>
-              ))}
-            </div>
-          )}
+      {/* Score block — a live-scored football match shows the mini-ticker
+          instead of the usual confirmed/pending result. */}
+      {liveState ? (
+        <div className="mx-3.5 mb-3">
+          <LiveMatchBlock match={match} state={liveState} />
         </div>
+      ) : (
+        scoreInfo && (
+          <div className="mx-3.5 mb-3 rounded-lg bg-muted/50 px-3.5 py-3">
+            <div className="flex items-center justify-between">
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <Avatar name={nameA} size="md" ring={aWon ? 'winner' : 'none'} />
+                <span className="truncate text-xs font-medium">{nameA}</span>
+              </div>
+              <div className="px-3 text-center">
+                <div className="text-2xl font-medium leading-none tracking-tight">
+                  {headline[sideA?.id ?? ''] ?? 0}
+                  <span className="text-muted-foreground">–</span>
+                  {headline[sideB?.id ?? ''] ?? 0}
+                </div>
+                <div className="mt-0.5 text-[9px] uppercase tracking-widest text-muted-foreground">
+                  {headlineLabel(scoreInfo.score)}
+                </div>
+              </div>
+              <div className="flex min-w-0 flex-1 flex-row-reverse items-center gap-2 text-right">
+                <Avatar name={nameB} size="md" ring={bWon ? 'winner' : 'none'} />
+                <span className="truncate text-xs font-medium">{nameB}</span>
+              </div>
+            </div>
+            {sets.length > 0 && (
+              <div className="mt-2 border-t pt-2 text-center text-[11px] text-muted-foreground">
+                {sets.map((s, i) => (
+                  <span key={i}>
+                    {i > 0 && <span className="mx-1.5 text-border">·</span>}
+                    Set {i + 1} <span className="font-medium text-foreground">{s}</span>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        )
       )}
 
       {/* Header photo, when the match has one. The gap above comes from the
@@ -318,7 +335,11 @@ export function MatchCard({
           <MessageCircle className="size-3.5" /> {comment_count}
         </button>
         <ShareMatchButton match={match} />
-        <StatusBadge status={matchBadgeStatus(match)} className="ml-auto" />
+        {liveState ? (
+          <LiveIndicator className="ml-auto" />
+        ) : (
+          <StatusBadge status={matchBadgeStatus(match)} className="ml-auto" />
+        )}
       </div>
     </div>
   )

--- a/agon_ui/src/components/agon/live/LiveIndicator.tsx
+++ b/agon_ui/src/components/agon/live/LiveIndicator.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/lib/utils'
+
+/** Pulsing "LIVE" pill — used in place of `StatusBadge` wherever a football
+ *  match is in progress and being scored live. An optional prefix (e.g. a
+ *  minute label) renders before "LIVE", as in "63' LIVE". */
+export function LiveIndicator({
+  className,
+  children,
+}: {
+  className?: string
+  children?: React.ReactNode
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive',
+        className,
+      )}
+    >
+      <span className="relative flex size-1.5">
+        <span className="absolute inline-flex size-full animate-ping rounded-full bg-destructive opacity-75" />
+        <span className="relative inline-flex size-1.5 rounded-full bg-destructive" />
+      </span>
+      {children ? <>{children} LIVE</> : 'LIVE'}
+    </span>
+  )
+}

--- a/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
@@ -1,0 +1,85 @@
+import type { components } from '@/types/api'
+import { Avatar } from '@/components/agon/Avatar'
+import { LiveIndicator } from './LiveIndicator'
+import {
+  describeEvent,
+  eventEmoji,
+  latestMinuteLabel,
+  recentEvents,
+  type FootballLiveState,
+} from '@/lib/liveScore'
+
+type Match = components['schemas']['Match']
+type MatchSide = components['schemas']['MatchSide']
+
+function sideName(side: MatchSide | undefined, fallback: string): string {
+  return side?.name?.trim() || fallback
+}
+
+/**
+ * The score block + mini-ticker for a football match being scored live
+ * (mockup "Mini-ticker — last events under the score"). Presentational: the
+ * caller fetches the live snapshot (`useLiveScore`) and passes the derived
+ * football state down, so `MatchCard` and `MatchDetailPage` can each decide
+ * when to show this instead of their normal (confirmed/pending score) block.
+ */
+export function LiveMatchBlock({
+  match,
+  state,
+  tickerLimit = 2,
+}: {
+  match: Match
+  state: FootballLiveState
+  /** How many recent events to show under the score. */
+  tickerLimit?: number
+}) {
+  const [sideA, sideB] = match.sides
+  const nameA = sideName(sideA, 'Side A')
+  const nameB = sideName(sideB, 'Side B')
+  const goalsFor = (sideId: string | undefined) =>
+    state.score.find((s) => s.side_id === sideId)?.goals ?? 0
+
+  const events = recentEvents(state, tickerLimit)
+
+  return (
+    <div className="rounded-lg bg-muted/50 px-3.5 py-3">
+      <div className="flex items-center justify-between">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Avatar name={nameA} size="md" />
+          <span className="truncate text-xs font-medium">{nameA}</span>
+        </div>
+        <div className="px-3 text-center">
+          <div className="text-2xl font-medium leading-none tracking-tight">
+            {goalsFor(sideA?.id)}
+            <span className="text-muted-foreground">–</span>
+            {goalsFor(sideB?.id)}
+          </div>
+          <div className="mt-1 flex items-center justify-center">
+            {(() => {
+              const minute = latestMinuteLabel(state)
+              return <LiveIndicator>{minute === 'LIVE' ? undefined : minute}</LiveIndicator>
+            })()}
+          </div>
+        </div>
+        <div className="flex min-w-0 flex-1 flex-row-reverse items-center gap-2 text-right">
+          <Avatar name={nameB} size="md" />
+          <span className="truncate text-xs font-medium">{nameB}</span>
+        </div>
+      </div>
+
+      {events.length > 0 && (
+        <div className="mt-2.5 space-y-1 border-t pt-2">
+          {events.map((event, i) => (
+            <p key={i} className="truncate text-xs text-muted-foreground">
+              <span aria-hidden>{eventEmoji(event.kind)}</span>{' '}
+              {event.minute !== undefined && (
+                <span className="font-medium text-foreground">{event.minute}' </span>
+              )}
+              {describeEvent(event, match)}
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/live/RecordEventDialog.tsx
+++ b/agon_ui/src/components/agon/live/RecordEventDialog.tsx
@@ -1,0 +1,392 @@
+import { useEffect, useState } from 'react'
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Avatar } from '@/components/agon/Avatar'
+import { memberName, playerId, playersOnSide } from '@/lib/members'
+
+type Match = components['schemas']['Match']
+type MatchSide = components['schemas']['MatchSide']
+type MatchPlayer = components['schemas']['MatchPlayer']
+type FootballLiveEvent = components['schemas']['FootballLiveEvent']
+
+export type EventKind = 'goal' | 'card' | 'substitution'
+
+function sideName(side: MatchSide, fallback: string): string {
+  return side.name?.trim() || fallback
+}
+
+/** A row of tappable side tiles — the first step for every event kind. */
+function SidePicker({
+  sides,
+  value,
+  onChange,
+}: {
+  sides: MatchSide[]
+  value: string | undefined
+  onChange: (sideId: string) => void
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {sides.map((side, i) => (
+        <button
+          key={side.id}
+          type="button"
+          aria-pressed={value === side.id}
+          onClick={() => onChange(side.id)}
+          className={cn(
+            'rounded-lg border p-3 text-sm font-medium transition-colors',
+            value === side.id
+              ? 'border-primary bg-accent text-accent-foreground'
+              : 'text-muted-foreground hover:bg-muted',
+          )}
+        >
+          {sideName(side, i === 0 ? 'Side A' : 'Side B')}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** A vertical list of tappable player rows for one side's roster. */
+function PlayerPicker({
+  players,
+  value,
+  onChange,
+  exclude,
+  emptyLabel = 'No players on this side yet.',
+}: {
+  players: MatchPlayer[]
+  value: string | undefined
+  onChange: (playerId: string) => void
+  exclude?: string
+  emptyLabel?: string
+}) {
+  const options = players.filter((p) => playerId(p) !== exclude)
+  if (options.length === 0) {
+    return <p className="text-xs text-muted-foreground">{emptyLabel}</p>
+  }
+  return (
+    <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+      {options.map((p) => {
+        const id = playerId(p)
+        const name = memberName(p.member)
+        return (
+          <button
+            key={id}
+            type="button"
+            aria-pressed={value === id}
+            onClick={() => onChange(id)}
+            className={cn(
+              'flex items-center gap-2 rounded-lg border px-2.5 py-2 text-left text-sm transition-colors',
+              value === id
+                ? 'border-primary bg-accent text-accent-foreground'
+                : 'hover:bg-muted',
+            )}
+          >
+            <Avatar name={name} size="sm" />
+            <span className="truncate">{name}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+function MinuteField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex items-center gap-2">
+      <Label htmlFor="event-minute" className="shrink-0 text-xs text-muted-foreground">
+        Minute
+      </Label>
+      <Input
+        id="event-minute"
+        type="number"
+        min={0}
+        inputMode="numeric"
+        className="h-8 w-20"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  )
+}
+
+interface DraftBase {
+  side_id?: string
+  minute: string
+}
+
+interface GoalDraft extends DraftBase {
+  scorer_player_id?: string
+  assist_player_id?: string
+  own_goal: boolean
+  penalty: boolean
+}
+
+interface CardDraft extends DraftBase {
+  player_id?: string
+  color?: 'yellow' | 'red'
+}
+
+interface SubDraft extends DraftBase {
+  player_out_id?: string
+  player_in_id?: string
+}
+
+function toMinute(minute: string): number | undefined {
+  const n = Number(minute)
+  return minute !== '' && Number.isFinite(n) && n >= 0 ? n : undefined
+}
+
+/**
+ * The event-entry dialog opened from a quick-action tap on the live scoring
+ * screen. One component covers all three recordable football event kinds
+ * (goal / card / substitution) since they share the same side→details shape;
+ * `kind` picks which fields step 2 asks for.
+ */
+export function RecordEventDialog({
+  open,
+  kind,
+  match,
+  initialMinute,
+  onOpenChange,
+  onSubmit,
+  submitting,
+}: {
+  open: boolean
+  kind: EventKind | null
+  match: Match
+  initialMinute: number
+  onOpenChange: (open: boolean) => void
+  onSubmit: (event: FootballLiveEvent) => void
+  submitting: boolean
+}) {
+  const [goal, setGoal] = useState<GoalDraft>({ minute: '', own_goal: false, penalty: false })
+  const [card, setCard] = useState<CardDraft>({ minute: '' })
+  const [sub, setSub] = useState<SubDraft>({ minute: '' })
+
+  // Reset to a fresh draft (minute prefilled from the live clock) every time
+  // the dialog is opened for a new event.
+  useEffect(() => {
+    if (!open) return
+    const minute = String(initialMinute)
+    setGoal({ minute, own_goal: false, penalty: false })
+    setCard({ minute })
+    setSub({ minute })
+  }, [open, initialMinute, kind])
+
+  if (!kind) return null
+
+  const side = match.sides.find(
+    (s) => s.id === (kind === 'goal' ? goal.side_id : kind === 'card' ? card.side_id : sub.side_id),
+  )
+  const roster = side ? playersOnSide(match.players, side) : []
+
+  const title = kind === 'goal' ? 'Goal' : kind === 'card' ? 'Card' : 'Substitution'
+
+  const canSubmit =
+    kind === 'goal'
+      ? !!goal.side_id && (goal.own_goal || !!goal.scorer_player_id)
+      : kind === 'card'
+        ? !!card.side_id && !!card.player_id && !!card.color
+        : !!sub.side_id && !!sub.player_out_id && !!sub.player_in_id
+
+  const submit = () => {
+    if (kind === 'goal' && goal.side_id) {
+      onSubmit({
+        kind: 'Goal',
+        side_id: goal.side_id,
+        scorer_player_id: goal.own_goal ? undefined : goal.scorer_player_id,
+        assist_player_id: goal.own_goal ? undefined : goal.assist_player_id,
+        own_goal: goal.own_goal,
+        penalty: goal.penalty,
+        minute: toMinute(goal.minute),
+      } as FootballLiveEvent)
+    } else if (kind === 'card' && card.side_id && card.player_id && card.color) {
+      onSubmit({
+        kind: 'Card',
+        side_id: card.side_id,
+        player_id: card.player_id,
+        color: card.color,
+        minute: toMinute(card.minute),
+      } as FootballLiveEvent)
+    } else if (kind === 'substitution' && sub.side_id && sub.player_out_id && sub.player_in_id) {
+      onSubmit({
+        kind: 'Substitution',
+        side_id: sub.side_id,
+        player_in_id: sub.player_in_id,
+        player_out_id: sub.player_out_id,
+        minute: toMinute(sub.minute),
+      } as FootballLiveEvent)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Side
+            </p>
+            <SidePicker
+              sides={match.sides}
+              value={kind === 'goal' ? goal.side_id : kind === 'card' ? card.side_id : sub.side_id}
+              onChange={(sideId) => {
+                if (kind === 'goal') setGoal((d) => ({ ...d, side_id: sideId, scorer_player_id: undefined, assist_player_id: undefined }))
+                else if (kind === 'card') setCard((d) => ({ ...d, side_id: sideId, player_id: undefined }))
+                else setSub((d) => ({ ...d, side_id: sideId, player_out_id: undefined, player_in_id: undefined }))
+              }}
+            />
+          </div>
+
+          {side && kind === 'goal' && (
+            <>
+              <div className="flex items-center gap-4">
+                <label className="flex items-center gap-1.5 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={goal.own_goal}
+                    onChange={(e) => setGoal((d) => ({ ...d, own_goal: e.target.checked }))}
+                  />
+                  Own goal
+                </label>
+                <label className="flex items-center gap-1.5 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={goal.penalty}
+                    disabled={goal.own_goal}
+                    onChange={(e) => setGoal((d) => ({ ...d, penalty: e.target.checked }))}
+                  />
+                  Penalty
+                </label>
+              </div>
+              {!goal.own_goal && (
+                <div>
+                  <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Scorer
+                  </p>
+                  <PlayerPicker
+                    players={roster}
+                    value={goal.scorer_player_id}
+                    onChange={(id) => setGoal((d) => ({ ...d, scorer_player_id: id }))}
+                  />
+                </div>
+              )}
+              {!goal.own_goal && goal.scorer_player_id && roster.length > 1 && (
+                <div>
+                  <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Assist (optional)
+                  </p>
+                  <PlayerPicker
+                    players={roster}
+                    value={goal.assist_player_id}
+                    exclude={goal.scorer_player_id}
+                    onChange={(id) =>
+                      setGoal((d) => ({
+                        ...d,
+                        assist_player_id: d.assist_player_id === id ? undefined : id,
+                      }))
+                    }
+                  />
+                </div>
+              )}
+            </>
+          )}
+
+          {side && kind === 'card' && (
+            <>
+              <div>
+                <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Player
+                </p>
+                <PlayerPicker
+                  players={roster}
+                  value={card.player_id}
+                  onChange={(id) => setCard((d) => ({ ...d, player_id: id }))}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                {(['yellow', 'red'] as const).map((color) => (
+                  <button
+                    key={color}
+                    type="button"
+                    aria-pressed={card.color === color}
+                    onClick={() => setCard((d) => ({ ...d, color }))}
+                    className={cn(
+                      'flex items-center justify-center gap-2 rounded-lg border p-2.5 text-sm font-medium capitalize transition-colors',
+                      card.color === color
+                        ? 'border-primary bg-accent text-accent-foreground'
+                        : 'text-muted-foreground hover:bg-muted',
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'size-3 rounded-sm',
+                        color === 'yellow' ? 'bg-yellow-400' : 'bg-red-600',
+                      )}
+                    />
+                    {color}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          {side && kind === 'substitution' && (
+            <>
+              <div>
+                <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Coming off
+                </p>
+                <PlayerPicker
+                  players={roster}
+                  value={sub.player_out_id}
+                  exclude={sub.player_in_id}
+                  onChange={(id) => setSub((d) => ({ ...d, player_out_id: id }))}
+                />
+              </div>
+              <div>
+                <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Going on
+                </p>
+                <PlayerPicker
+                  players={roster}
+                  value={sub.player_in_id}
+                  exclude={sub.player_out_id}
+                  onChange={(id) => setSub((d) => ({ ...d, player_in_id: id }))}
+                />
+              </div>
+            </>
+          )}
+
+          <MinuteField
+            value={kind === 'goal' ? goal.minute : kind === 'card' ? card.minute : sub.minute}
+            onChange={(v) => {
+              if (kind === 'goal') setGoal((d) => ({ ...d, minute: v }))
+              else if (kind === 'card') setCard((d) => ({ ...d, minute: v }))
+              else setSub((d) => ({ ...d, minute: v }))
+            }}
+          />
+
+          <Button disabled={!canSubmit || submitting} onClick={submit}>
+            {submitting ? 'Saving…' : `Add ${title.toLowerCase()}`}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -1,0 +1,68 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { fetchClient } from '@/lib/api-client'
+import type { components } from '@/types/api'
+
+type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
+type NewLiveEventInput = components['schemas']['NewLiveEventInput']
+type FootballLiveEvent = components['schemas']['FootballLiveEvent']
+
+export function liveScoreQueryKey(matchId: string | undefined) {
+  return ['live', matchId] as const
+}
+
+/**
+ * A match's derived live-scoring snapshot. `null` (not `undefined`) means the
+ * match has no live events recorded yet — a normal state (scoring hasn't
+ * started), distinct from "still loading" or "failed to load".
+ */
+export function useLiveScore(
+  matchId: string | undefined,
+  options?: { enabled?: boolean; refetchInterval?: number | false },
+) {
+  return useQuery({
+    queryKey: liveScoreQueryKey(matchId),
+    enabled: !!matchId && (options?.enabled ?? true),
+    refetchInterval: options?.refetchInterval,
+    queryFn: async (): Promise<LiveScoreSnapshot | null> => {
+      const { data, response } = await fetchClient.GET('/matches/{match_id}/live', {
+        params: { path: { match_id: matchId! } },
+      })
+      if (response.status === 404) return null
+      if (!data) throw new Error('Failed to load live score')
+      return data
+    },
+  })
+}
+
+/**
+ * Appends one football live event to a match's log. Reads `expected_last_seq`
+ * off the current cached snapshot (0 if scoring hasn't started yet) so the
+ * server can detect a lost update; on success the returned snapshot replaces
+ * the cache directly (cheaper and more current than invalidating + refetching).
+ */
+export function useAppendFootballEvent(matchId: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (event: FootballLiveEvent) => {
+      const key = liveScoreQueryKey(matchId)
+      const current = queryClient.getQueryData<LiveScoreSnapshot | null>(key)
+      const input: NewLiveEventInput = {
+        occurred_at: new Date().toISOString(),
+        event: { sport: 'Football', ...event } as NewLiveEventInput['event'],
+      }
+      const { data, error } = await fetchClient.POST('/matches/{match_id}/live/events', {
+        params: { path: { match_id: matchId } },
+        body: {
+          expected_last_seq: current?.last_seq ?? 0,
+          events: [input],
+        },
+      })
+      if (error || !data) throw new Error('Failed to record event')
+      return data
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(liveScoreQueryKey(matchId), data)
+    },
+  })
+}

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -1,0 +1,309 @@
+import type { components } from '@/types/api'
+import { memberName } from './members'
+
+export type FootballEventKind = components['schemas']['FootballEventKind']
+export type FootballEvent = components['schemas']['FootballEvent']
+export type FootballPeriod = components['schemas']['FootballPeriod']
+export type FootballLiveState = components['schemas']['FootballLiveState']
+type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
+type Match = components['schemas']['Match']
+
+/** Narrows a live-score snapshot to its football state, or `null` when there's
+ *  no snapshot yet or it's for a different sport. */
+export function footballLiveState(
+  snapshot: LiveScoreSnapshot | null | undefined,
+): FootballLiveState | null {
+  if (!snapshot || snapshot.state.sport !== 'Football') return null
+  return snapshot.state
+}
+
+/** Label + emoji for each football live-event kind, for the event log/ticker. */
+const EVENT_LABEL: Record<FootballEventKind, string> = {
+  goal: 'Goal',
+  own_goal: 'Own goal',
+  penalty: 'Penalty',
+  yellow_card: 'Yellow card',
+  red_card: 'Red card',
+  substitution: 'Sub',
+}
+
+const EVENT_EMOJI: Record<FootballEventKind, string> = {
+  goal: '⚽',
+  own_goal: '⚽',
+  penalty: '⚽',
+  yellow_card: '🟨',
+  red_card: '🟥',
+  substitution: '🔁',
+}
+
+export function eventLabel(kind: FootballEventKind): string {
+  return EVENT_LABEL[kind]
+}
+
+export function eventEmoji(kind: FootballEventKind): string {
+  return EVENT_EMOJI[kind]
+}
+
+/** "63'" for a recorded minute, else a blank string. */
+export function minuteLabel(minute: number | undefined): string {
+  return minute === undefined ? '' : `${minute}'`
+}
+
+const PERIOD_LABEL: Record<FootballPeriod, string> = {
+  half_time: 'Half-time',
+  full_time: 'Full-time',
+  extra_time_half_time: 'Extra time: half-time',
+  extra_time_full_time: 'Extra time: full-time',
+  penalties_complete: 'Penalties complete',
+}
+
+export function periodLabel(period: FootballPeriod): string {
+  return PERIOD_LABEL[period]
+}
+
+/**
+ * A short clock label for read-only viewers (feed card, match detail) who
+ * have no local clock of their own — just the scorer's device does (see
+ * below). Derived from what's actually on the log: the last period marker if
+ * the match is between/after halves, else the latest recorded event minute,
+ * else a plain "LIVE".
+ */
+export function latestMinuteLabel(state: FootballLiveState): string {
+  if (state.period === 'half_time') return 'HT'
+  if (state.period === 'full_time') return 'FT'
+  if (state.period === 'extra_time_half_time') return 'ET · HT'
+  if (state.period === 'extra_time_full_time') return 'ET · FT'
+  if (state.period === 'penalties_complete') return 'Pens'
+  const minutes = state.events.map((e) => e.minute).filter((m): m is number => m !== undefined)
+  if (minutes.length === 0) return 'LIVE'
+  return `${Math.max(...minutes)}'`
+}
+
+/** The most recent events first, capped to `limit` — for a mini-ticker. */
+export function recentEvents(state: FootballLiveState, limit: number): FootballEvent[] {
+  return [...state.events].reverse().slice(0, limit)
+}
+
+/** Side display name for an event, falling back to a neutral label. */
+function sideNameFor(match: Pick<Match, 'sides'>, sideId: string): string {
+  return match.sides.find((s) => s.id === sideId)?.name?.trim() || 'This side'
+}
+
+/** Player display name for a member id, if it's on the roster. */
+function playerNameFor(match: Pick<Match, 'players'>, playerId: string | undefined): string | null {
+  if (!playerId) return null
+  const player = match.players.find((p) => p.member.id === playerId)
+  return player ? memberName(player.member) : null
+}
+
+/** One-line human description of a football event, e.g. "Goal — J. Alvarez
+ *  (Riverside)" or "Sub — Moreno on for Khan (Oak Park)" — used by the event
+ *  log and mini-ticker. */
+export function describeEvent(
+  event: FootballEvent,
+  match: Pick<Match, 'sides' | 'players'>,
+): string {
+  const side = sideNameFor(match, event.side_id)
+  const scorer = playerNameFor(match, event.player_id)
+
+  switch (event.kind) {
+    case 'goal':
+    case 'penalty':
+      return scorer ? `${eventLabel(event.kind)} — ${scorer} (${side})` : `${eventLabel(event.kind)} (${side})`
+    case 'own_goal':
+      return `Own goal — ${side}`
+    case 'yellow_card':
+    case 'red_card':
+      return scorer
+        ? `${eventLabel(event.kind)} — ${scorer} (${side})`
+        : `${eventLabel(event.kind)} — ${side}`
+    case 'substitution': {
+      const out = playerNameFor(match, event.substituted_player_id)
+      if (scorer && out) return `Sub — ${scorer} on for ${out} (${side})`
+      return `Substitution (${side})`
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Track preferences — which quick actions the scorer wants on the live
+// scoring screen. Client-only: the backend's football live-event vocabulary
+// only covers goals/cards/subs/period markers (see
+// `agon_service::live_score::football`), so "shots & saves" and "corners &
+// fouls" from the setup mockup have nowhere to be recorded yet and are shown
+// as disabled "coming soon" toggles rather than persisted here.
+// ---------------------------------------------------------------------------
+
+export interface TrackPrefs {
+  cards: boolean
+  substitutions: boolean
+}
+
+const DEFAULT_PREFS: TrackPrefs = { cards: true, substitutions: true }
+
+function prefsKey(matchId: string): string {
+  return `agon:live-track-prefs:${matchId}`
+}
+
+export function loadTrackPrefs(matchId: string): TrackPrefs {
+  try {
+    const raw = localStorage.getItem(prefsKey(matchId))
+    if (!raw) return { ...DEFAULT_PREFS }
+    const parsed = JSON.parse(raw)
+    return {
+      cards: typeof parsed.cards === 'boolean' ? parsed.cards : DEFAULT_PREFS.cards,
+      substitutions:
+        typeof parsed.substitutions === 'boolean'
+          ? parsed.substitutions
+          : DEFAULT_PREFS.substitutions,
+    }
+  } catch {
+    return { ...DEFAULT_PREFS }
+  }
+}
+
+export function saveTrackPrefs(matchId: string, prefs: TrackPrefs): void {
+  try {
+    localStorage.setItem(prefsKey(matchId), JSON.stringify(prefs))
+  } catch {
+    // Best-effort — a private-browsing/full-storage failure just means the
+    // toggles reset to defaults next visit, not worth surfacing.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local match clock — the backend's live-event log has no notion of kickoff
+// time or a running clock, only discrete events (optionally minute-stamped)
+// plus a "last period marker seen" (`FootballLiveState.period`). The running
+// 63'-style clock shown while scoring is purely a client-side stopwatch, kept
+// in localStorage so it survives a refresh on the scorer's device; other
+// viewers just see the discrete event log/derived score, not this clock.
+// ---------------------------------------------------------------------------
+
+export type ClockPhase = 'first_half' | 'half_time' | 'second_half' | 'full_time'
+
+export interface ClockState {
+  phase: ClockPhase
+  /** ISO timestamp the current running phase started, null while paused. */
+  runningSince: string | null
+  /** Match minutes already elapsed before `runningSince` (frozen carry-over). */
+  baseMinutes: number
+}
+
+function clockKey(matchId: string): string {
+  return `agon:live-clock:${matchId}`
+}
+
+function freshClock(): ClockState {
+  return { phase: 'first_half', runningSince: new Date().toISOString(), baseMinutes: 0 }
+}
+
+export function loadClock(matchId: string): ClockState {
+  try {
+    const raw = localStorage.getItem(clockKey(matchId))
+    if (!raw) return freshClock()
+    const parsed = JSON.parse(raw)
+    if (
+      typeof parsed.phase === 'string' &&
+      typeof parsed.baseMinutes === 'number' &&
+      (parsed.runningSince === null || typeof parsed.runningSince === 'string')
+    ) {
+      return parsed as ClockState
+    }
+    return freshClock()
+  } catch {
+    return freshClock()
+  }
+}
+
+function saveClock(matchId: string, clock: ClockState): void {
+  try {
+    localStorage.setItem(clockKey(matchId), JSON.stringify(clock))
+  } catch {
+    // Best-effort, as above.
+  }
+}
+
+/** Minutes elapsed in the running phase (0 while paused). */
+function runningMinutes(clock: ClockState, now: Date): number {
+  if (!clock.runningSince) return 0
+  const ms = now.getTime() - new Date(clock.runningSince).getTime()
+  return Math.max(0, Math.floor(ms / 60_000))
+}
+
+/** The current display minute, e.g. for prefilling an event's minute field. */
+export function currentMinute(clock: ClockState, now: Date = new Date()): number {
+  return clock.baseMinutes + runningMinutes(clock, now)
+}
+
+/** Human label for the current phase, e.g. "2nd half" / "Half-time". */
+export function phaseLabel(phase: ClockPhase): string {
+  switch (phase) {
+    case 'first_half':
+      return '1st half'
+    case 'half_time':
+      return 'Half-time'
+    case 'second_half':
+      return '2nd half'
+    case 'full_time':
+      return 'Full-time'
+  }
+}
+
+/**
+ * Advances the clock to its next phase, returning the new state and — when
+ * the transition corresponds to a real period marker (end of a half) — the
+ * `FootballPeriod` to record on the server. The half-time → second-half
+ * transition has no backend marker (kickoff isn't modelled), so it advances
+ * the local clock only.
+ */
+export function advanceClock(
+  matchId: string,
+  clock: ClockState,
+  now: Date = new Date(),
+): { clock: ClockState; period: FootballPeriod | null } {
+  let next: ClockState
+  let period: FootballPeriod | null = null
+
+  switch (clock.phase) {
+    case 'first_half':
+      next = {
+        phase: 'half_time',
+        runningSince: null,
+        baseMinutes: currentMinute(clock, now),
+      }
+      period = 'half_time'
+      break
+    case 'half_time':
+      next = { phase: 'second_half', runningSince: now.toISOString(), baseMinutes: 45 }
+      break
+    case 'second_half':
+      next = {
+        phase: 'full_time',
+        runningSince: null,
+        baseMinutes: currentMinute(clock, now),
+      }
+      period = 'full_time'
+      break
+    case 'full_time':
+      next = clock
+      break
+  }
+
+  saveClock(matchId, next)
+  return { clock: next, period }
+}
+
+/** Label for the clock's quick-action button, contextual to the current phase. */
+export function nextPhaseActionLabel(phase: ClockPhase): string {
+  switch (phase) {
+    case 'first_half':
+      return 'End 1st half'
+    case 'half_time':
+      return 'Start 2nd half'
+    case 'second_half':
+      return 'End match'
+    case 'full_time':
+      return 'Full-time'
+  }
+}

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useParams, Link } from 'react-router-dom'
+import { ChevronLeft, CircleDot, Flag, Repeat2, TimerReset } from 'lucide-react'
+import { fetchClient } from '@/lib/api-client'
+import type { components } from '@/types/api'
+import { Button } from '@/components/ui/button'
+import { useLiveScore, useAppendFootballEvent } from '@/hooks/useLiveScore'
+import { RecordEventDialog, type EventKind } from '@/components/agon/live/RecordEventDialog'
+import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
+import {
+  advanceClock,
+  currentMinute,
+  describeEvent,
+  eventEmoji,
+  footballLiveState,
+  loadClock,
+  loadTrackPrefs,
+  nextPhaseActionLabel,
+  phaseLabel,
+  type ClockState,
+} from '@/lib/liveScore'
+
+type Match = components['schemas']['Match']
+
+function sideName(match: Match, index: number, fallback: string): string {
+  return match.sides[index]?.name?.trim() || fallback
+}
+
+/** How often the on-screen clock re-renders while a half is running. */
+const CLOCK_TICK_MS = 15_000
+
+/**
+ * The live scoring screen: quick actions to log goals/cards/subs as they
+ * happen, a running clock, and the event log so far. The clock is a local
+ * stopwatch (see `lib/liveScore`) — the backend only stores discrete,
+ * optionally minute-stamped events, not a running kickoff time.
+ */
+export function LiveScoringPage() {
+  const { matchId } = useParams()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const matchQuery = useQuery({
+    queryKey: ['match', matchId],
+    enabled: !!matchId,
+    queryFn: async (): Promise<Match> => {
+      const { data, error } = await fetchClient.GET('/matches/{match_id}', {
+        params: { path: { match_id: matchId! } },
+      })
+      if (error || !data) throw new Error('Failed to load match')
+      return data
+    },
+  })
+
+  const live = useLiveScore(matchId, { refetchInterval: 8000 })
+  const append = useAppendFootballEvent(matchId ?? '')
+
+  const [clock, setClock] = useState<ClockState>(() => loadClock(matchId ?? ''))
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), CLOCK_TICK_MS)
+    return () => clearInterval(id)
+  }, [])
+
+  const prefs = loadTrackPrefs(matchId ?? '')
+  const [dialogKind, setDialogKind] = useState<EventKind | null>(null)
+
+  if (matchQuery.isLoading || live.isLoading) {
+    return (
+      <div className="mx-auto max-w-xl">
+        <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
+      </div>
+    )
+  }
+
+  if (matchQuery.isError || !matchQuery.data) {
+    return (
+      <div className="py-16 text-center">
+        <p className="mb-4 text-muted-foreground">Couldn't load this match.</p>
+        <Button variant="outline" onClick={() => matchQuery.refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  const match = matchQuery.data
+  const nameA = sideName(match, 0, 'Side A')
+  const nameB = sideName(match, 1, 'Side B')
+  const state = footballLiveState(live.data)
+  const goalsFor = (sideId: string | undefined) =>
+    state?.score.find((s) => s.side_id === sideId)?.goals ?? 0
+
+  const minute = currentMinute(clock, now)
+
+  const handleHalfFt = () => {
+    if (!matchId) return
+    const { clock: nextClock, period } = advanceClock(matchId, clock, new Date())
+    setClock(nextClock)
+    if (period) {
+      append.mutate({ kind: 'Period', period })
+    }
+  }
+
+  const actions: {
+    key: EventKind | 'half_ft'
+    label: string
+    icon: React.ReactNode
+    onClick: () => void
+    disabled?: boolean
+  }[] = [
+    { key: 'goal', label: 'Goal', icon: <CircleDot className="size-5" />, onClick: () => setDialogKind('goal') },
+    ...(prefs.cards
+      ? [{ key: 'card' as const, label: 'Card', icon: <Flag className="size-5" />, onClick: () => setDialogKind('card') }]
+      : []),
+    ...(prefs.substitutions
+      ? [
+          {
+            key: 'substitution' as const,
+            label: 'Sub',
+            icon: <Repeat2 className="size-5" />,
+            onClick: () => setDialogKind('substitution'),
+          },
+        ]
+      : []),
+    {
+      key: 'half_ft',
+      label: nextPhaseActionLabel(clock.phase),
+      icon: <TimerReset className="size-5" />,
+      onClick: handleHalfFt,
+      disabled: clock.phase === 'full_time',
+    },
+  ]
+
+  const events = state ? [...state.events].reverse() : []
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${matchId}`)}>
+          <ChevronLeft className="size-4" /> Back
+        </Button>
+        <LiveIndicator />
+      </div>
+
+      <div>
+        <h1 className="text-lg font-semibold">
+          {nameA} vs {nameB}
+        </h1>
+        <p className="text-sm text-muted-foreground">You're scoring this match</p>
+      </div>
+
+      <div className="rounded-xl border bg-card p-4">
+        <div className="flex items-center justify-between">
+          <p className="flex-1 truncate text-sm font-medium">{nameA}</p>
+          <div className="px-3 text-center">
+            <div className="text-3xl font-medium tracking-tight">
+              {goalsFor(match.sides[0]?.id)}
+              <span className="text-muted-foreground">–</span>
+              {goalsFor(match.sides[1]?.id)}
+            </div>
+            <div className="mt-0.5 text-xs text-primary">
+              {minute}' · {phaseLabel(clock.phase)}
+            </div>
+          </div>
+          <p className="flex-1 truncate text-right text-sm font-medium">{nameB}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        {actions.map((a) => (
+          <button
+            key={a.key}
+            type="button"
+            disabled={a.disabled}
+            onClick={a.onClick}
+            className="flex flex-col items-center gap-1.5 rounded-xl border bg-card p-5 text-sm font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {a.icon}
+            {a.label}
+          </button>
+        ))}
+      </div>
+
+      <Link
+        to={`/matches/${matchId}/live/setup`}
+        className="text-center text-sm text-primary hover:underline"
+      >
+        + Track more (cards, subs)
+      </Link>
+
+      <div className="border-t pt-3">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Match events
+        </p>
+        {events.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No events recorded yet.</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {events.map((event, i) => (
+              <div key={i} className="flex items-baseline gap-2 text-sm">
+                <span className="w-8 shrink-0 text-xs text-muted-foreground">
+                  {event.minute !== undefined ? `${event.minute}'` : ''}
+                </span>
+                <span aria-hidden>{eventEmoji(event.kind)}</span>
+                <span className="min-w-0 truncate">{describeEvent(event, match)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {append.isError && (
+        <p className="text-center text-xs text-destructive">
+          Failed to record that event — try again.
+        </p>
+      )}
+
+      <RecordEventDialog
+        open={dialogKind !== null}
+        kind={dialogKind}
+        match={match}
+        initialMinute={minute}
+        onOpenChange={(open) => !open && setDialogKind(null)}
+        submitting={append.isPending}
+        onSubmit={(event) => {
+          append.mutate(event, {
+            onSuccess: () => {
+              setDialogKind(null)
+              queryClient.invalidateQueries({ queryKey: ['feed'] })
+            },
+          })
+        }}
+      />
+    </div>
+  )
+}

--- a/agon_ui/src/pages/LiveScoringSetupPage.tsx
+++ b/agon_ui/src/pages/LiveScoringSetupPage.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ChevronLeft } from 'lucide-react'
+import { fetchClient } from '@/lib/api-client'
+import type { components } from '@/types/api'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { loadTrackPrefs, saveTrackPrefs, type TrackPrefs } from '@/lib/liveScore'
+
+type Match = components['schemas']['Match']
+
+function sideName(match: Match, index: number, fallback: string): string {
+  return match.sides[index]?.name?.trim() || fallback
+}
+
+/** One row in the "track during the match" list — either a real toggle backed
+ *  by a track preference, or a disabled "coming soon" row for event kinds the
+ *  backend doesn't record yet (shots/saves, corners/fouls). */
+function TrackRow({
+  title,
+  subtitle,
+  checked,
+  disabled,
+  onChange,
+}: {
+  title: string
+  subtitle: string
+  checked: boolean
+  disabled?: boolean
+  onChange?: (checked: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b p-4 last:border-b-0">
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{title}</p>
+        <p className="text-xs text-muted-foreground">{subtitle}</p>
+      </div>
+      <Switch
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onChange}
+        aria-label={title}
+      />
+    </div>
+  )
+}
+
+/**
+ * "Set up scoring" — what to track during a live football match. Goals are
+ * always recorded; cards and substitutions are real toggles that decide which
+ * quick-action buttons `LiveScoringPage` shows, persisted per-device
+ * (`localStorage`, see `lib/liveScore`) since they're just a display
+ * preference, not something the server needs to know. Shots/saves and
+ * corners/fouls are shown but disabled: the live-scoring API
+ * (`agon_service::live_score::football`) only models goals, cards, subs and
+ * period markers today, so there's nowhere for those events to go yet.
+ */
+export function LiveScoringSetupPage() {
+  const { matchId } = useParams()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const query = useQuery({
+    queryKey: ['match', matchId],
+    enabled: !!matchId,
+    queryFn: async (): Promise<Match> => {
+      const { data, error } = await fetchClient.GET('/matches/{match_id}', {
+        params: { path: { match_id: matchId! } },
+      })
+      if (error || !data) throw new Error('Failed to load match')
+      return data
+    },
+  })
+
+  const [prefs, setPrefs] = useState<TrackPrefs>(() => loadTrackPrefs(matchId ?? ''))
+
+  const setPref = (key: keyof TrackPrefs, value: boolean) => {
+    setPrefs((prev) => {
+      const next = { ...prev, [key]: value }
+      if (matchId) saveTrackPrefs(matchId, next)
+      return next
+    })
+  }
+
+  const start = useMutation({
+    mutationFn: async () => {
+      if (!matchId || !query.data) return
+      if (query.data.status !== 'in_progress') {
+        const { error } = await fetchClient.PATCH('/matches/{match_id}', {
+          params: { path: { match_id: matchId } },
+          body: { status: 'in_progress' },
+        })
+        if (error) throw new Error('Failed to start the match')
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['match', matchId] })
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
+      navigate(`/matches/${matchId}/live`, { replace: true })
+    },
+  })
+
+  if (query.isLoading) {
+    return (
+      <div className="mx-auto max-w-xl">
+        <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
+      </div>
+    )
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <div className="py-16 text-center">
+        <p className="mb-4 text-muted-foreground">Couldn't load this match.</p>
+        <Button variant="outline" onClick={() => query.refetch()}>
+          Retry
+        </Button>
+      </div>
+    )
+  }
+
+  const match = query.data
+  const nameA = sideName(match, 0, 'Side A')
+  const nameB = sideName(match, 1, 'Side B')
+  const alreadyStarted = match.status === 'in_progress'
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${matchId}`)}>
+          <ChevronLeft className="size-4" /> Back
+        </Button>
+      </div>
+
+      <div>
+        <h1 className="text-lg font-semibold">Set up scoring</h1>
+        <p className="text-sm text-muted-foreground">
+          {nameA} vs {nameB} · Football
+        </p>
+      </div>
+
+      <div>
+        <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Track during the match
+        </p>
+        <div className="overflow-hidden rounded-xl border bg-card">
+          <TrackRow title="Goals" subtitle="Always on" checked disabled />
+          <TrackRow
+            title="Cards"
+            subtitle="Yellow / red"
+            checked={prefs.cards}
+            onChange={(v) => setPref('cards', v)}
+          />
+          <TrackRow
+            title="Substitutions"
+            subtitle=""
+            checked={prefs.substitutions}
+            onChange={(v) => setPref('substitutions', v)}
+          />
+          <TrackRow
+            title="Shots & saves"
+            subtitle="Coming soon"
+            checked={false}
+            disabled
+          />
+          <TrackRow title="Corners & fouls" subtitle="Coming soon" checked={false} disabled />
+        </div>
+      </div>
+
+      <p className="text-center text-xs text-muted-foreground">
+        Turn more on anytime — even mid-match
+      </p>
+
+      {start.isError && (
+        <p className="text-center text-xs text-destructive">
+          {(start.error as Error).message}
+        </p>
+      )}
+
+      <Button size="lg" disabled={start.isPending} onClick={() => start.mutate()}>
+        {start.isPending
+          ? 'Starting…'
+          : alreadyStarted
+            ? 'Continue scoring'
+            : 'Start scoring'}
+      </Button>
+    </div>
+  )
+}

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { useNavigate, useParams } from 'react-router-dom'
-import { ChevronLeft, Flame, MailOpen, Pencil, UserPlus } from 'lucide-react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { ChevronLeft, Flame, MailOpen, Pencil, Radio, UserPlus } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { cn } from '@/lib/utils'
@@ -11,6 +11,10 @@ import { MatchHeaderCarousel } from '@/components/agon/MatchHeaderCarousel'
 import { SportBadge } from '@/components/agon/SportBadge'
 import { StatusBadge, matchBadgeStatus } from '@/components/agon/StatusBadge'
 import { ScoreConfirmationBar } from '@/components/agon/ScoreConfirmationBar'
+import { LiveMatchBlock } from '@/components/agon/live/LiveMatchBlock'
+import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
+import { useLiveScore } from '@/hooks/useLiveScore'
+import { footballLiveState } from '@/lib/liveScore'
 import { useCurrentUserId } from '@/hooks/useCurrentUserId'
 import { displayScore, headlineBySide, headlineLabel, setLine } from '@/lib/score'
 import {
@@ -101,6 +105,7 @@ function MatchDetail({
 
   const canEdit = isParticipant(match, currentUserId)
   const cancelled = match.status === 'cancelled'
+  const isLiveSport = match.match_type === 'football'
 
   const [sideA, sideB] = match.sides
   const nameA = sideName(sideA, 'Side A')
@@ -111,6 +116,16 @@ function MatchDetail({
   const sets = scoreInfo ? setLine(scoreInfo.score, match.sides) : []
   const aWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideA?.id
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
+
+  // Live-scoring state, when this is a football match currently being scored
+  // live — takes over the score block below (and the entry button becomes
+  // "Continue scoring"). Not fetched for other sports/statuses, which don't
+  // have a live event log to speak of.
+  const live = useLiveScore(match.id, {
+    enabled: isLiveSport && match.status === 'in_progress',
+    refetchInterval: 15000,
+  })
+  const liveState = footballLiveState(live.data)
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">
@@ -146,8 +161,14 @@ function MatchDetail({
             )}
           </div>
 
-          {/* Score header */}
-          {scoreInfo ? (
+          {/* Score header — the live block (score + mini-ticker) takes over
+              while a football match is being scored live; otherwise the
+              usual confirmed/pending result. */}
+          {liveState ? (
+            <div className="mt-3">
+              <LiveMatchBlock match={match} state={liveState} tickerLimit={3} />
+            </div>
+          ) : scoreInfo ? (
             <div className="mt-3 flex items-center justify-between">
               <div className="flex-1">
                 <p className={cn('text-sm', aWon && 'font-medium')}>{nameA}</p>
@@ -185,17 +206,26 @@ function MatchDetail({
           )}
 
           <div className="mt-3 flex items-center justify-between">
-            <StatusBadge status={matchBadgeStatus(match)} />
-            {canEdit && !cancelled && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 px-2 text-xs text-muted-foreground"
-                onClick={() => setEditingResult(true)}
-              >
-                {scoreInfo ? 'Edit result' : 'Add result'}
-              </Button>
-            )}
+            {liveState ? <LiveIndicator /> : <StatusBadge status={matchBadgeStatus(match)} />}
+            <div className="flex items-center gap-1">
+              {canEdit && isLiveSport && !cancelled && match.status !== 'completed' && (
+                <Button asChild variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs text-primary">
+                  <Link to={`/matches/${match.id}/live/setup`}>
+                    <Radio className="size-3" /> {liveState ? 'Continue scoring' : 'Score live'}
+                  </Link>
+                </Button>
+              )}
+              {canEdit && !cancelled && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs text-muted-foreground"
+                  onClick={() => setEditingResult(true)}
+                >
+                  {scoreInfo ? 'Edit result' : 'Add result'}
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
Implements the live scoring interface for football matches, allowing scorers to record goals, cards, and substitutions in real-time with a running clock and event log. Includes setup flow, event dialog, and integration with existing match cards and detail pages.

## Key Changes

### New Pages
- **LiveScoringPage** (`src/pages/LiveScoringPage.tsx`): Main scoring screen with running clock, quick-action buttons (goal/card/sub), score display, and event log. Clock is a local stopwatch persisted to localStorage so it survives page refreshes on the scorer's device.
- **LiveScoringSetupPage** (`src/pages/LiveScoringSetupPage.tsx`): Pre-match configuration to toggle which event types to track (cards, substitutions) and start the match. Preferences are stored per-device in localStorage.

### New Components
- **RecordEventDialog** (`src/components/agon/live/RecordEventDialog.tsx`): Unified modal for recording all three event kinds (goal/card/substitution). Implements a two-step flow: side selection → event-specific details (scorer/assist for goals, player/color for cards, player in/out for subs). Minute field is prefilled from the running clock.
- **LiveMatchBlock** (`src/components/agon/live/LiveMatchBlock.tsx`): Score display with mini-ticker showing recent events, used in place of the normal confirmed/pending score block when a football match is being scored live.
- **LiveIndicator** (`src/components/agon/live/LiveIndicator.tsx`): Pulsing "LIVE" badge with optional minute prefix (e.g. "63' LIVE").

### New Hooks & Utilities
- **useLiveScore** (`src/hooks/useLiveScore.ts`): Query hook to fetch live-score snapshots and mutation hook to append football events. Handles optimistic cache updates with sequence number conflict detection.
- **liveScore.ts** (`src/lib/liveScore.ts`): Core utilities for live scoring:
  - Clock state management (phase tracking, running/paused stopwatch, localStorage persistence)
  - Event description generation for the log/ticker
  - Track preferences (cards/subs toggles, localStorage-backed)
  - Period/minute/event label formatting

### Integration with Existing Components
- **MatchCard** and **MatchDetailPage**: Now fetch live-score snapshots when a football match is `in_progress`. If live state exists, display `LiveMatchBlock` instead of the normal score block, and show a "Continue scoring" button instead of edit/confirm actions.
- **App.tsx**: Added routes for `/matches/:matchId/live` (scoring) and `/matches/:matchId/live/setup` (configuration).

## Notable Implementation Details

- **Clock Design**: The running clock is purely client-side (a stopwatch), not derived from server timestamps. It's persisted to localStorage so the scorer can refresh without losing time. Other viewers see only the discrete event log and derived score, not this clock.
- **Event Recording**: The `RecordEventDialog` unifies all three event kinds (goal/card/sub) in one component, using conditional rendering based on the `kind` prop to show event-specific fields. State is reset each time the dialog opens, with the minute field prefilled from the current clock.
- **Optimistic Updates**: `useAppendFootballEvent` reads the current cached snapshot to extract `expected_last_seq` for conflict detection, then updates the cache directly on success rather than invalidating and refetching.
- **Preferences**: Track preferences (which event types to show) are stored per-device in localStorage, not on the server, since they're a display preference, not match data. The backend's live-event API only models goals, cards, subs, and period markers; shots/saves and corners/fouls are shown as disabled "coming soon" toggles.

https://claude.ai/code/session_01Lyd6AiV1R9ff1sJJC5Bn8e