### PR TITLE
Add live scoring UX for cricket

### DIFF
--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -14,9 +14,11 @@ import { ScoreConfirmationBar } from './ScoreConfirmationBar'
 import { MatchHeaderCarousel } from './MatchHeaderCarousel'
 import { InvitationResponseDialog } from './InvitationResponseDialog'
 import { LiveMatchBlock } from './live/LiveMatchBlock'
+import { CricketMatchBlock } from './live/CricketMatchBlock'
 import { LiveIndicator } from './live/LiveIndicator'
 import { useLiveScore } from '@/hooks/useLiveScore'
 import { footballLiveState } from '@/lib/liveScore'
+import { cricketLiveState } from '@/lib/cricketScore'
 import {
   displayScore,
   headlineBySide,
@@ -193,11 +195,14 @@ export function MatchCard({
   const aWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideA?.id
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
 
+  const isLiveSport = match.match_type === 'football' || match.match_type === 'cricket'
   const live = useLiveScore(match.id, {
-    enabled: match.match_type === 'football' && match.status === 'in_progress',
+    enabled: isLiveSport && match.status === 'in_progress',
     refetchInterval: 20000,
   })
-  const liveState = footballLiveState(live.data)
+  const footballState = footballLiveState(live.data)
+  const cricketState = cricketLiveState(live.data)
+  const hasLiveState = !!footballState || !!cricketState
 
   const { like_count, comment_count, i_liked } = match.social
   const toggleLike = useToggleLike(match)
@@ -242,11 +247,15 @@ export function MatchCard({
         </div>
       )}
 
-      {/* Score block — a live-scored football match shows the mini-ticker
-          instead of the usual confirmed/pending result. */}
-      {liveState ? (
+      {/* Score block — a live-scored match shows the mini-ticker instead of
+          the usual confirmed/pending result. */}
+      {footballState ? (
         <div className="mx-3.5 mb-3">
-          <LiveMatchBlock match={match} state={liveState} />
+          <LiveMatchBlock match={match} state={footballState} />
+        </div>
+      ) : cricketState ? (
+        <div className="mx-3.5 mb-3">
+          <CricketMatchBlock match={match} state={cricketState} />
         </div>
       ) : (
         scoreInfo && (
@@ -335,7 +344,7 @@ export function MatchCard({
           <MessageCircle className="size-3.5" /> {comment_count}
         </button>
         <ShareMatchButton match={match} />
-        {liveState ? (
+        {hasLiveState ? (
           <LiveIndicator className="ml-auto" />
         ) : (
           <StatusBadge status={matchBadgeStatus(match)} className="ml-auto" />

--- a/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
@@ -1,0 +1,113 @@
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { LiveIndicator } from './LiveIndicator'
+import {
+  battingEntryFor,
+  battingLine,
+  currentInnings,
+  currentOverDeliveries,
+  deliveryChipLabel,
+  isChipHighlighted,
+  nextBallContext,
+  playerNameFor,
+  runRate,
+  type CricketLiveState,
+} from '@/lib/cricketScore'
+
+type Match = components['schemas']['Match']
+
+function sideNameFor(match: Match, sideId: string): string {
+  return match.sides.find((s) => s.id === sideId)?.name?.trim() || 'This side'
+}
+
+/** One ball's chip in the "this over" row (mockup: "1  4  W  ·  2"). */
+function BallChip({ label, kind }: { label: string; kind: 'boundary' | 'wicket' | null }) {
+  return (
+    <span
+      className={cn(
+        'flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold',
+        kind === 'boundary' && 'bg-primary/15 text-primary',
+        kind === 'wicket' && 'bg-destructive/15 text-destructive',
+        kind === null && 'bg-muted text-foreground',
+      )}
+    >
+      {label}
+    </span>
+  )
+}
+
+/**
+ * The score block + "this over" ball row for a cricket match being scored
+ * live (mirrors `LiveMatchBlock`'s role for football). Presentational: the
+ * caller fetches the live snapshot (`useLiveScore`) and passes the derived
+ * cricket state down.
+ */
+export function CricketMatchBlock({ match, state }: { match: Match; state: CricketLiveState }) {
+  const innings = currentInnings(state)
+
+  if (!innings) {
+    // Between innings, or nothing bowled yet — still worth surfacing that
+    // the match is live, just without a score to show.
+    return (
+      <div className="flex items-center justify-between rounded-lg bg-muted/50 px-3.5 py-3">
+        <p className="text-sm text-muted-foreground">Innings break</p>
+        <LiveIndicator />
+      </div>
+    )
+  }
+
+  const battingName = sideNameFor(match, innings.batting_side_id)
+  const bowlingName = sideNameFor(match, innings.bowling_side_id)
+  const next = nextBallContext(innings)
+  const striker = battingEntryFor(innings, next.strikerPlayerId)
+  const nonStriker = battingEntryFor(innings, next.nonStrikerPlayerId)
+  const overBalls = currentOverDeliveries(innings)
+  const crr = runRate(innings.runs, innings.overs)
+
+  return (
+    <div className="rounded-lg bg-muted/50 px-3.5 py-3">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground">{battingName} batting</p>
+          <p className="text-2xl font-medium leading-tight tracking-tight">
+            {innings.runs}/{innings.wickets}
+            <span className="ml-1.5 text-sm font-normal text-muted-foreground">
+              ({innings.overs.toFixed(1)} ov · CRR {crr.toFixed(2)})
+            </span>
+          </p>
+          {(striker || nonStriker) && (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {next.strikerPlayerId && (
+                <>
+                  {playerNameFor(match, next.strikerPlayerId)}* {battingLine(striker)}
+                </>
+              )}
+              {next.strikerPlayerId && next.nonStrikerPlayerId && ' · '}
+              {next.nonStrikerPlayerId && (
+                <>
+                  {playerNameFor(match, next.nonStrikerPlayerId)} {battingLine(nonStriker)}
+                </>
+              )}
+            </p>
+          )}
+        </div>
+        <LiveIndicator />
+      </div>
+
+      {overBalls.length > 0 && (
+        <div className="mt-2.5 border-t pt-2.5">
+          <p className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            This over
+          </p>
+          <div className="flex gap-1.5">
+            {overBalls.map((d, i) => (
+              <BallChip key={i} label={deliveryChipLabel(d)} kind={isChipHighlighted(d)} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      <p className="mt-1.5 text-[11px] text-muted-foreground">vs {bowlingName}</p>
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/live/ExtraRunsDialog.tsx
+++ b/agon_ui/src/components/agon/live/ExtraRunsDialog.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+type CricketExtraKind = components['schemas']['CricketExtraKind']
+
+/**
+ * Picks the run count (and, when there's a choice, the kind) for an extra —
+ * every wide/no-ball/bye/leg-bye carries at least 1 run by definition. The
+ * mockup's quick-action row has a single "Bye" button, so byes vs leg-byes is
+ * folded into this dialog as a toggle rather than a separate grid button.
+ * Capped to a simple 1-4 picker; a rarer 5+ run extra can be corrected later
+ * via the existing delete/amend-by-seq API (no dedicated UI for that yet).
+ */
+export function ExtraRunsDialog({
+  open,
+  title,
+  kinds,
+  onOpenChange,
+  onPick,
+  submitting,
+}: {
+  open: boolean
+  title: string
+  kinds: { value: CricketExtraKind; label: string }[]
+  onOpenChange: (open: boolean) => void
+  onPick: (kind: CricketExtraKind, runs: number) => void
+  submitting: boolean
+}) {
+  const [kind, setKind] = useState<CricketExtraKind | undefined>(kinds[0]?.value)
+
+  useEffect(() => {
+    if (open) setKind(kinds[0]?.value)
+  }, [open, kinds])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xs">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          {kinds.length > 1 && (
+            <div className="grid grid-cols-2 gap-2">
+              {kinds.map((k) => (
+                <button
+                  key={k.value}
+                  type="button"
+                  aria-pressed={kind === k.value}
+                  onClick={() => setKind(k.value)}
+                  className={cn(
+                    'rounded-lg border p-2 text-sm font-medium transition-colors',
+                    kind === k.value
+                      ? 'border-primary bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:bg-muted',
+                  )}
+                >
+                  {k.label}
+                </button>
+              ))}
+            </div>
+          )}
+          <div className="grid grid-cols-4 gap-2">
+            {[1, 2, 3, 4].map((runs) => (
+              <Button
+                key={runs}
+                variant="outline"
+                disabled={submitting || !kind}
+                onClick={() => kind && onPick(kind, runs)}
+              >
+                {runs}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/agon_ui/src/components/agon/live/Pickers.tsx
+++ b/agon_ui/src/components/agon/live/Pickers.tsx
@@ -1,0 +1,94 @@
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { Avatar } from '@/components/agon/Avatar'
+import { memberName, playerId } from '@/lib/members'
+
+type MatchSide = components['schemas']['MatchSide']
+type MatchPlayer = components['schemas']['MatchPlayer']
+
+export function sideName(side: MatchSide, fallback: string): string {
+  return side.name?.trim() || fallback
+}
+
+/** A row of tappable side tiles — the first step for most live-event entry
+ *  flows (football's goal/card/sub dialog, cricket's innings-start panel). */
+export function SidePicker({
+  sides,
+  value,
+  onChange,
+}: {
+  sides: MatchSide[]
+  value: string | undefined
+  onChange: (sideId: string) => void
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {sides.map((side, i) => (
+        <button
+          key={side.id}
+          type="button"
+          aria-pressed={value === side.id}
+          onClick={() => onChange(side.id)}
+          className={cn(
+            'rounded-lg border p-3 text-sm font-medium transition-colors',
+            value === side.id
+              ? 'border-primary bg-accent text-accent-foreground'
+              : 'text-muted-foreground hover:bg-muted',
+          )}
+        >
+          {sideName(side, i === 0 ? 'Side A' : 'Side B')}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/** A vertical list of tappable player rows for one side's roster. `exclude`
+ *  drops one or more player ids already spoken for (e.g. the other batter,
+ *  or the bowler who just finished an over). */
+export function PlayerPicker({
+  players,
+  value,
+  onChange,
+  exclude,
+  emptyLabel = 'No players on this side yet.',
+}: {
+  players: MatchPlayer[]
+  value: string | undefined | null
+  onChange: (playerId: string) => void
+  exclude?: string | (string | null | undefined)[]
+  emptyLabel?: string
+}) {
+  const excluded = new Set(
+    (Array.isArray(exclude) ? exclude : [exclude]).filter((id): id is string => !!id),
+  )
+  const options = players.filter((p) => !excluded.has(playerId(p)))
+  if (options.length === 0) {
+    return <p className="text-xs text-muted-foreground">{emptyLabel}</p>
+  }
+  return (
+    <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+      {options.map((p) => {
+        const id = playerId(p)
+        const name = memberName(p.member)
+        return (
+          <button
+            key={id}
+            type="button"
+            aria-pressed={value === id}
+            onClick={() => onChange(id)}
+            className={cn(
+              'flex items-center gap-2 rounded-lg border px-2.5 py-2 text-left text-sm transition-colors',
+              value === id
+                ? 'border-primary bg-accent text-accent-foreground'
+                : 'hover:bg-muted',
+            )}
+          >
+            <Avatar name={name} size="sm" />
+            <span className="truncate">{name}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/live/RecordEventDialog.tsx
+++ b/agon_ui/src/components/agon/live/RecordEventDialog.tsx
@@ -10,96 +10,13 @@ import {
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Avatar } from '@/components/agon/Avatar'
-import { memberName, playerId, playersOnSide } from '@/lib/members'
+import { playersOnSide } from '@/lib/members'
+import { PlayerPicker, SidePicker } from './Pickers'
 
 type Match = components['schemas']['Match']
-type MatchSide = components['schemas']['MatchSide']
-type MatchPlayer = components['schemas']['MatchPlayer']
 type FootballLiveEvent = components['schemas']['FootballLiveEvent']
 
 export type EventKind = 'goal' | 'card' | 'substitution'
-
-function sideName(side: MatchSide, fallback: string): string {
-  return side.name?.trim() || fallback
-}
-
-/** A row of tappable side tiles — the first step for every event kind. */
-function SidePicker({
-  sides,
-  value,
-  onChange,
-}: {
-  sides: MatchSide[]
-  value: string | undefined
-  onChange: (sideId: string) => void
-}) {
-  return (
-    <div className="grid grid-cols-2 gap-2">
-      {sides.map((side, i) => (
-        <button
-          key={side.id}
-          type="button"
-          aria-pressed={value === side.id}
-          onClick={() => onChange(side.id)}
-          className={cn(
-            'rounded-lg border p-3 text-sm font-medium transition-colors',
-            value === side.id
-              ? 'border-primary bg-accent text-accent-foreground'
-              : 'text-muted-foreground hover:bg-muted',
-          )}
-        >
-          {sideName(side, i === 0 ? 'Side A' : 'Side B')}
-        </button>
-      ))}
-    </div>
-  )
-}
-
-/** A vertical list of tappable player rows for one side's roster. */
-function PlayerPicker({
-  players,
-  value,
-  onChange,
-  exclude,
-  emptyLabel = 'No players on this side yet.',
-}: {
-  players: MatchPlayer[]
-  value: string | undefined
-  onChange: (playerId: string) => void
-  exclude?: string
-  emptyLabel?: string
-}) {
-  const options = players.filter((p) => playerId(p) !== exclude)
-  if (options.length === 0) {
-    return <p className="text-xs text-muted-foreground">{emptyLabel}</p>
-  }
-  return (
-    <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
-      {options.map((p) => {
-        const id = playerId(p)
-        const name = memberName(p.member)
-        return (
-          <button
-            key={id}
-            type="button"
-            aria-pressed={value === id}
-            onClick={() => onChange(id)}
-            className={cn(
-              'flex items-center gap-2 rounded-lg border px-2.5 py-2 text-left text-sm transition-colors',
-              value === id
-                ? 'border-primary bg-accent text-accent-foreground'
-                : 'hover:bg-muted',
-            )}
-          >
-            <Avatar name={name} size="sm" />
-            <span className="truncate">{name}</span>
-          </button>
-        )
-      })}
-    </div>
-  )
-}
 
 function MinuteField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   return (

--- a/agon_ui/src/components/agon/live/WicketDialog.tsx
+++ b/agon_ui/src/components/agon/live/WicketDialog.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from 'react'
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { PlayerPicker } from './Pickers'
+import { creditsBowler, dismissalLabel, type CricketDismissalKind } from '@/lib/cricketScore'
+import { playersOnSide } from '@/lib/members'
+
+type Match = components['schemas']['Match']
+type CricketDeliveryWicket = components['schemas']['CricketDeliveryWicket']
+
+const DISMISSAL_KINDS: CricketDismissalKind[] = [
+  'bowled',
+  'caught',
+  'leg_before_wicket',
+  'run_out',
+  'stumped',
+  'hit_wicket',
+]
+
+/**
+ * Records a wicket: dismissal kind, which batter is out (either end for a
+ * run-out, otherwise always the striker), an optional fielder, and — since a
+ * run-out can happen mid-run — how many runs had already been completed
+ * before the dismissal. Bowler credit follows the backend's own rule
+ * (`creditsBowler`), so it's implicit rather than asked.
+ */
+export function WicketDialog({
+  open,
+  match,
+  battingSideId,
+  strikerPlayerId,
+  nonStrikerPlayerId,
+  onOpenChange,
+  onSubmit,
+  submitting,
+}: {
+  open: boolean
+  match: Match
+  battingSideId: string
+  strikerPlayerId: string
+  nonStrikerPlayerId: string
+  onOpenChange: (open: boolean) => void
+  onSubmit: (wicket: CricketDeliveryWicket, runsBeforeDismissal: number) => void
+  submitting: boolean
+}) {
+  const [kind, setKind] = useState<CricketDismissalKind>('bowled')
+  const [dismissedPlayerId, setDismissedPlayerId] = useState(strikerPlayerId)
+  const [fielderPlayerId, setFielderPlayerId] = useState<string | undefined>(undefined)
+  const [runs, setRuns] = useState('0')
+
+  useEffect(() => {
+    if (!open) return
+    setKind('bowled')
+    setDismissedPlayerId(strikerPlayerId)
+    setFielderPlayerId(undefined)
+    setRuns('0')
+  }, [open, strikerPlayerId])
+
+  const battingSide = match.sides.find((s) => s.id === battingSideId)
+  const fieldingRoster = match.sides
+    .filter((s) => s.id !== battingSideId)
+    .flatMap((s) => playersOnSide(match.players, s))
+  const needsFielder = kind === 'caught' || kind === 'run_out' || kind === 'stumped'
+
+  const submit = () => {
+    onSubmit(
+      {
+        kind,
+        dismissed_player_id: dismissedPlayerId,
+        bowler_player_id: undefined,
+        fielder_player_id: fielderPlayerId,
+      },
+      Number(runs) || 0,
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Wicket</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              How out
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              {DISMISSAL_KINDS.map((k) => (
+                <button
+                  key={k}
+                  type="button"
+                  aria-pressed={kind === k}
+                  onClick={() => setKind(k)}
+                  className={cn(
+                    'rounded-lg border p-2 text-sm font-medium transition-colors',
+                    kind === k
+                      ? 'border-primary bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:bg-muted',
+                  )}
+                >
+                  {dismissalLabel(k)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Batter out
+            </p>
+            {kind === 'run_out' ? (
+              <PlayerPicker
+                players={playersOnSide(match.players, battingSide!).filter((p) =>
+                  [strikerPlayerId, nonStrikerPlayerId].includes(p.member.id),
+                )}
+                value={dismissedPlayerId}
+                onChange={setDismissedPlayerId}
+              />
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Striker — the only batter who can be out this way.
+              </p>
+            )}
+          </div>
+
+          {needsFielder && (
+            <div>
+              <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Fielder (optional)
+              </p>
+              <PlayerPicker
+                players={fieldingRoster}
+                value={fielderPlayerId}
+                onChange={(id) => setFielderPlayerId(fielderPlayerId === id ? undefined : id)}
+              />
+            </div>
+          )}
+
+          {kind === 'run_out' && (
+            <div className="flex items-center gap-2">
+              <Label htmlFor="wicket-runs" className="shrink-0 text-xs text-muted-foreground">
+                Runs completed first
+              </Label>
+              <Input
+                id="wicket-runs"
+                type="number"
+                min={0}
+                inputMode="numeric"
+                className="h-8 w-20"
+                value={runs}
+                onChange={(e) => setRuns(e.target.value)}
+              />
+            </div>
+          )}
+
+          <p className="text-xs text-muted-foreground">
+            {creditsBowler(kind)
+              ? 'Credited to the bowler.'
+              : "Not credited to the bowler's figures."}
+          </p>
+
+          <Button disabled={submitting} onClick={submit}>
+            {submitting ? 'Saving…' : 'Record wicket'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -5,6 +5,7 @@ import type { components } from '@/types/api'
 type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
 type NewLiveEventInput = components['schemas']['NewLiveEventInput']
 type FootballLiveEvent = components['schemas']['FootballLiveEvent']
+type CricketLiveEvent = components['schemas']['CricketLiveEvent']
 
 export function liveScoreQueryKey(matchId: string | undefined) {
   return ['live', matchId] as const
@@ -35,21 +36,26 @@ export function useLiveScore(
 }
 
 /**
- * Appends one football live event to a match's log. Reads `expected_last_seq`
- * off the current cached snapshot (0 if scoring hasn't started yet) so the
- * server can detect a lost update; on success the returned snapshot replaces
- * the cache directly (cheaper and more current than invalidating + refetching).
+ * Appends one sport-tagged live event to a match's log. Reads
+ * `expected_last_seq` off the current cached snapshot (0 if scoring hasn't
+ * started yet) so the server can detect a lost update; on success the
+ * returned snapshot replaces the cache directly (cheaper and more current
+ * than invalidating + refetching). Shared by the per-sport wrappers below —
+ * each just tags its event with the right `sport` discriminator.
  */
-export function useAppendFootballEvent(matchId: string) {
+function useAppendLiveEvent<T extends { kind: string }>(
+  matchId: string,
+  sport: NewLiveEventInput['event']['sport'],
+) {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (event: FootballLiveEvent) => {
+    mutationFn: async (event: T) => {
       const key = liveScoreQueryKey(matchId)
       const current = queryClient.getQueryData<LiveScoreSnapshot | null>(key)
       const input: NewLiveEventInput = {
         occurred_at: new Date().toISOString(),
-        event: { sport: 'Football', ...event } as NewLiveEventInput['event'],
+        event: { sport, ...event } as NewLiveEventInput['event'],
       }
       const { data, error } = await fetchClient.POST('/matches/{match_id}/live/events', {
         params: { path: { match_id: matchId } },
@@ -65,4 +71,12 @@ export function useAppendFootballEvent(matchId: string) {
       queryClient.setQueryData(liveScoreQueryKey(matchId), data)
     },
   })
+}
+
+export function useAppendFootballEvent(matchId: string) {
+  return useAppendLiveEvent<FootballLiveEvent>(matchId, 'Football')
+}
+
+export function useAppendCricketEvent(matchId: string) {
+  return useAppendLiveEvent<CricketLiveEvent>(matchId, 'Cricket')
 }

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -1,0 +1,226 @@
+import type { components } from '@/types/api'
+import { memberName } from './members'
+
+export type CricketDelivery = components['schemas']['CricketDelivery']
+export type CricketInnings = components['schemas']['CricketInnings']
+export type CricketLiveState = components['schemas']['CricketLiveState']
+export type CricketExtraKind = components['schemas']['CricketExtraKind']
+export type CricketDismissalKind = components['schemas']['CricketDismissalKind']
+export type CricketBattingEntry = components['schemas']['CricketBattingEntry']
+export type CricketBowlingEntry = components['schemas']['CricketBowlingEntry']
+type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
+type Match = components['schemas']['Match']
+
+/** Narrows a live-score snapshot to its cricket state, or `null` when there's
+ *  no snapshot yet or it's for a different sport. */
+export function cricketLiveState(
+  snapshot: LiveScoreSnapshot | null | undefined,
+): CricketLiveState | null {
+  if (!snapshot || snapshot.state.sport !== 'Cricket') return null
+  return snapshot.state
+}
+
+/** The innings currently being played, or `null` when the match hasn't
+ *  started its first innings yet, or is between innings (see
+ *  `CricketLiveState.awaiting_next_innings`). */
+export function currentInnings(state: CricketLiveState): CricketInnings | null {
+  if (state.awaiting_next_innings) return null
+  return state.innings[state.innings.length - 1] ?? null
+}
+
+/** Whether a delivery counts toward the over (wides/no-balls don't). */
+export function isLegalDelivery(d: CricketDelivery): boolean {
+  return !(d.extra && (d.extra.kind === 'wide' || d.extra.kind === 'no_ball'))
+}
+
+/** Run rate so far, from the display-format `overs` (e.g. 18.2 = 18 overs +
+ *  2 balls, not 18.2 decimal overs). */
+export function runRate(runs: number, oversDisplay: number): number {
+  const wholeOvers = Math.floor(oversDisplay)
+  const balls = Math.round((oversDisplay - wholeOvers) * 10)
+  const totalBalls = wholeOvers * 6 + balls
+  return totalBalls > 0 ? (runs / totalBalls) * 6 : 0
+}
+
+/** This over's deliveries — everything recorded against the innings' latest
+ *  over index (we assign `over`/`ball` ourselves on submit, so this is a
+ *  simple filter rather than a rolling window). */
+export function currentOverDeliveries(innings: CricketInnings): CricketDelivery[] {
+  const latestOver = innings.deliveries.reduce((max, d) => Math.max(max, d.over), 0)
+  return innings.deliveries.filter((d) => d.over === latestOver)
+}
+
+/** Short chip label for a delivery in the "this over" row, e.g. "4", "W",
+ *  "·", "wd", "1lb". */
+export function deliveryChipLabel(d: CricketDelivery): string {
+  if (d.wicket) return 'W'
+  if (d.extra) {
+    const suffix: Record<CricketExtraKind, string> = {
+      wide: 'wd',
+      no_ball: 'nb',
+      bye: 'b',
+      leg_bye: 'lb',
+      penalty: 'pen',
+    }
+    return d.extra.runs > 1 ? `${d.extra.runs}${suffix[d.extra.kind]}` : suffix[d.extra.kind]
+  }
+  return d.runs_off_bat === 0 ? '·' : String(d.runs_off_bat)
+}
+
+/** Whether a chip should read as a "big" event (boundary/wicket) for styling. */
+export function isChipHighlighted(d: CricketDelivery): 'boundary' | 'wicket' | null {
+  if (d.wicket) return 'wicket'
+  if (!d.extra && (d.runs_off_bat === 4 || d.runs_off_bat === 6)) return 'boundary'
+  return null
+}
+
+const DISMISSAL_LABEL: Record<CricketDismissalKind, string> = {
+  bowled: 'Bowled',
+  caught: 'Caught',
+  leg_before_wicket: 'LBW',
+  run_out: 'Run out',
+  stumped: 'Stumped',
+  hit_wicket: 'Hit wicket',
+  retired_out: 'Retired out',
+  retired_hurt: 'Retired hurt',
+}
+
+export function dismissalLabel(kind: CricketDismissalKind): string {
+  return DISMISSAL_LABEL[kind]
+}
+
+/** Dismissal kinds a bowler is credited for (matches the backend's
+ *  `dismissal_credited_to_bowler`) — used to auto-fill/hide the bowler field
+ *  in the wicket dialog. */
+export function creditsBowler(kind: CricketDismissalKind): boolean {
+  return (
+    kind === 'bowled' ||
+    kind === 'caught' ||
+    kind === 'leg_before_wicket' ||
+    kind === 'stumped' ||
+    kind === 'hit_wicket'
+  )
+}
+
+/** A batter's card entry, or `null` if they haven't faced a ball yet (e.g. a
+ *  non-striker who's yet to be on strike) — not the same as not being on the
+ *  crease at all. */
+export function battingEntryFor(
+  innings: CricketInnings,
+  playerId: string | null,
+): CricketBattingEntry | null {
+  if (!playerId) return null
+  return innings.batting.find((b) => b.player_id === playerId) ?? null
+}
+
+export function bowlingEntryFor(
+  innings: CricketInnings,
+  playerId: string | null,
+): CricketBowlingEntry | null {
+  if (!playerId) return null
+  return innings.bowling.find((b) => b.player_id === playerId) ?? null
+}
+
+/** "3.2-0-24-1" bowling figures (overs-maidens-runs-wickets), or an em dash
+ *  before the bowler has sent down a delivery. */
+export function bowlingFigures(entry: CricketBowlingEntry | null): string {
+  if (!entry) return '—'
+  return `${entry.overs}-${entry.maidens}-${entry.runs_conceded}-${entry.wickets}`
+}
+
+/** "46 (32)" — runs and balls faced, or "0 (0)" before a batter's first ball. */
+export function battingLine(entry: CricketBattingEntry | null): string {
+  return `${entry?.runs ?? 0} (${entry?.balls_faced ?? 0})`
+}
+
+/** Batters who can't be picked as a new arrival — already dismissed for a
+ *  reason other than "retired hurt" (which lets the same batter resume). */
+export function outBattersFor(innings: CricketInnings): string[] {
+  return innings.batting
+    .filter((b) => b.dismissal && b.dismissal.kind !== 'retired_hurt')
+    .map((b) => b.player_id)
+}
+
+/** Player display name for a member id, if it's on the roster. */
+export function playerNameFor(
+  match: Pick<Match, 'players'>,
+  playerId: string | undefined | null,
+): string {
+  if (!playerId) return '—'
+  const player = match.players.find((p) => p.member.id === playerId)
+  return player ? memberName(player.member) : '—'
+}
+
+/**
+ * What's known about who's at the crease/bowling for the *next* delivery,
+ * folded from the current innings' delivery log. A `null` field means the
+ * scorer needs to pick someone before the next ball can be recorded — either
+ * a fresh innings (nothing bowled yet), a wicket just fell (the dismissed
+ * batter's slot is open), or an over just completed (a new bowler is
+ * required; the same bowler can't bowl consecutive overs).
+ *
+ * Strike rotates automatically on an odd number of the ball's rotating runs
+ * (off the bat, or byes/leg-byes — wides/no-balls don't rotate strike here)
+ * and always at the end of an over. One simplification: if the striker is
+ * dismissed on an over's final ball, the incoming batter is just placed in
+ * the now-open slot rather than fully modelling which physical end each
+ * player ends up at — a rare edge case not worth the added complexity here.
+ */
+export interface NextBallContext {
+  strikerPlayerId: string | null
+  nonStrikerPlayerId: string | null
+  bowlerPlayerId: string | null
+  /** 0-based over index the next delivery belongs to. */
+  over: number
+  /** 1-based ball number within that over. */
+  ball: number
+  /** The bowler who just finished an over — excluded from the next-bowler
+   *  picker. `null` unless a bowler pick is actually needed. */
+  previousOverBowlerPlayerId: string | null
+}
+
+export function nextBallContext(innings: CricketInnings): NextBallContext {
+  let striker: string | null = null
+  let nonStriker: string | null = null
+  let bowler: string | null = null
+  let legalInOver = 0
+  let over = 0
+  let previousOverBowler: string | null = null
+
+  for (const d of innings.deliveries) {
+    bowler = d.bowler_player_id
+    striker = d.striker_player_id
+    nonStriker = d.non_striker_player_id
+    previousOverBowler = null
+
+    if (d.wicket) {
+      if (d.wicket.dismissed_player_id === striker) striker = null
+      else if (d.wicket.dismissed_player_id === nonStriker) nonStriker = null
+    }
+
+    if (isLegalDelivery(d)) {
+      legalInOver += 1
+      const rotatingRuns =
+        d.runs_off_bat + (d.extra && (d.extra.kind === 'bye' || d.extra.kind === 'leg_bye') ? d.extra.runs : 0)
+      if (rotatingRuns % 2 === 1 && striker && nonStriker) {
+        ;[striker, nonStriker] = [nonStriker, striker]
+      }
+      if (legalInOver === 6) {
+        if (striker && nonStriker) [striker, nonStriker] = [nonStriker, striker]
+        previousOverBowler = bowler
+        bowler = null
+        over += 1
+        legalInOver = 0
+      }
+    }
+  }
+
+  return {
+    strikerPlayerId: striker,
+    nonStrikerPlayerId: nonStriker,
+    bowlerPlayerId: bowler,
+    over,
+    ball: legalInOver + 1,
+    previousOverBowlerPlayerId: previousOverBowler,
+  }
+}

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -1,0 +1,445 @@
+import { useEffect, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft } from 'lucide-react'
+import type { components } from '@/types/api'
+import { Button } from '@/components/ui/button'
+import { useAppendCricketEvent, useLiveScore } from '@/hooks/useLiveScore'
+import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
+import { SidePicker, PlayerPicker, sideName } from '@/components/agon/live/Pickers'
+import { WicketDialog } from '@/components/agon/live/WicketDialog'
+import { ExtraRunsDialog } from '@/components/agon/live/ExtraRunsDialog'
+import { playersOnSide } from '@/lib/members'
+import {
+  battingEntryFor,
+  battingLine,
+  bowlingEntryFor,
+  bowlingFigures,
+  cricketLiveState,
+  currentInnings,
+  currentOverDeliveries,
+  deliveryChipLabel,
+  isChipHighlighted,
+  nextBallContext,
+  outBattersFor,
+  playerNameFor,
+  runRate,
+} from '@/lib/cricketScore'
+
+type Match = components['schemas']['Match']
+type CricketDelivery = components['schemas']['CricketDelivery']
+type CricketDeliveryWicket = components['schemas']['CricketDeliveryWicket']
+type InningsEndReason = components['schemas']['InningsEndReason']
+
+const END_REASONS: { value: InningsEndReason; label: string }[] = [
+  { value: 'all_out', label: 'All out' },
+  { value: 'overs_complete', label: 'Overs complete' },
+  { value: 'declared', label: 'Declared' },
+  { value: 'target_reached', label: 'Target reached' },
+]
+
+/**
+ * The live cricket scoring screen: ball-by-ball entry (runs, extras,
+ * wickets), the current over, and the batting/bowling summary. Unlike
+ * football there's no clock — progress is overs/deliveries, all derivable
+ * from the event log itself (see `lib/cricketScore`), so no backend changes
+ * were needed to support this screen.
+ */
+export function CricketLiveScoringPage({ match }: { match: Match }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const live = useLiveScore(match.id, { refetchInterval: 8000 })
+  const appendEvent = useAppendCricketEvent(match.id)
+  const state = cricketLiveState(live.data)
+  const innings = state ? currentInnings(state) : null
+  const next = innings ? nextBallContext(innings) : null
+
+  // Locally-picked openers/replacement batter/next bowler — only used until
+  // the server confirms them via an actual delivery, at which point
+  // `nextBallContext` takes over as the source of truth.
+  const [pickedStriker, setPickedStriker] = useState<string | null>(null)
+  const [pickedNonStriker, setPickedNonStriker] = useState<string | null>(null)
+  const [pickedBowler, setPickedBowler] = useState<string | null>(null)
+  useEffect(() => {
+    if (next?.strikerPlayerId) setPickedStriker(null)
+    if (next?.nonStrikerPlayerId) setPickedNonStriker(null)
+    if (next?.bowlerPlayerId) setPickedBowler(null)
+  }, [next?.strikerPlayerId, next?.nonStrikerPlayerId, next?.bowlerPlayerId])
+
+  const [wicketOpen, setWicketOpen] = useState(false)
+  const [extraDialog, setExtraDialog] = useState<'wide' | 'no_ball' | 'bye' | null>(null)
+  const [endInningsOpen, setEndInningsOpen] = useState(false)
+  const [startBattingSide, setStartBattingSide] = useState<string | undefined>(undefined)
+
+  if (live.isLoading) {
+    return (
+      <div className="mx-auto max-w-xl">
+        <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
+      </div>
+    )
+  }
+
+  const header = (
+    <div className="flex items-center justify-between">
+      <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${match.id}`)}>
+        <ChevronLeft className="size-4" /> Back
+      </Button>
+      <LiveIndicator />
+    </div>
+  )
+
+  // No innings open — either the match hasn't started, or we're between
+  // innings. Either way: pick who's batting (the other side bowls).
+  if (!innings) {
+    return (
+      <div className="mx-auto flex max-w-xl flex-col gap-4">
+        {header}
+        <div>
+          <h1 className="text-lg font-semibold">
+            {match.sides[0]?.name?.trim() || 'Side A'} vs {match.sides[1]?.name?.trim() || 'Side B'}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {state && state.innings.length > 0 ? 'Start the next innings' : "You're scoring this match"}
+          </p>
+        </div>
+        <div className="rounded-xl border bg-card p-4">
+          <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Who's batting?
+          </p>
+          <SidePicker sides={match.sides} value={startBattingSide} onChange={setStartBattingSide} />
+        </div>
+        <Button
+          size="lg"
+          disabled={!startBattingSide || appendEvent.isPending}
+          onClick={() => {
+            const bowlingSideId = match.sides.find((s) => s.id !== startBattingSide)?.id
+            if (!startBattingSide || !bowlingSideId) return
+            appendEvent.mutate(
+              {
+                kind: 'InningsStart',
+                batting_side_id: startBattingSide,
+                bowling_side_id: bowlingSideId,
+              },
+              { onSuccess: () => setStartBattingSide(undefined) },
+            )
+          }}
+        >
+          {appendEvent.isPending ? 'Starting…' : 'Start innings'}
+        </Button>
+      </div>
+    )
+  }
+
+  const battingSide = match.sides.find((s) => s.id === innings.batting_side_id)
+  const bowlingSide = match.sides.find((s) => s.id === innings.bowling_side_id)
+  const effectiveStriker = next!.strikerPlayerId ?? pickedStriker
+  const effectiveNonStriker = next!.nonStrikerPlayerId ?? pickedNonStriker
+  const effectiveBowler = next!.bowlerPlayerId ?? pickedBowler
+  const readyToScore = !!effectiveStriker && !!effectiveNonStriker && !!effectiveBowler
+
+  const buildDelivery = (overrides: Partial<CricketDelivery>): CricketDelivery => ({
+    over: next!.over,
+    ball: next!.ball,
+    bowler_player_id: effectiveBowler!,
+    striker_player_id: effectiveStriker!,
+    non_striker_player_id: effectiveNonStriker!,
+    runs_off_bat: 0,
+    ...overrides,
+  })
+
+  const recordDelivery = (overrides: Partial<CricketDelivery>) => {
+    appendEvent.mutate({ kind: 'Delivery', ...buildDelivery(overrides) })
+  }
+
+  const endInnings = (reason: InningsEndReason) => {
+    appendEvent.mutate(
+      { kind: 'InningsEnd', reason },
+      {
+        onSuccess: () => {
+          setEndInningsOpen(false)
+          queryClient.invalidateQueries({ queryKey: ['feed'] })
+        },
+      },
+    )
+  }
+
+  const crr = runRate(innings.runs, innings.overs)
+  const strikerEntry = battingEntryFor(innings, effectiveStriker)
+  const nonStrikerEntry = battingEntryFor(innings, effectiveNonStriker)
+  const bowlerEntry = bowlingEntryFor(innings, effectiveBowler)
+  const overBalls = currentOverDeliveries(innings)
+  const outBatters = outBattersFor(innings)
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4">
+      {header}
+
+      <div>
+        <h1 className="text-lg font-semibold">
+          {sideName(battingSide!, 'Side A')} vs {sideName(bowlingSide!, 'Side B')}
+        </h1>
+        <p className="text-sm text-muted-foreground">You're scoring this match</p>
+      </div>
+
+      <div className="rounded-xl border bg-card p-4">
+        <p className="text-sm font-medium">{sideName(battingSide!, 'Side A')} batting</p>
+        <p className="mt-0.5 text-3xl font-medium tracking-tight">
+          {innings.runs}/{innings.wickets}
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            ({innings.overs.toFixed(1)} ov · CRR {crr.toFixed(2)})
+          </span>
+        </p>
+
+        <div className="mt-3 space-y-1 border-t pt-3 text-sm">
+          {effectiveStriker && (
+            <div className="flex items-center justify-between">
+              <span className="font-medium">{playerNameFor(match, effectiveStriker)}*</span>
+              <span className="text-muted-foreground">{battingLine(strikerEntry)}</span>
+            </div>
+          )}
+          {effectiveNonStriker && (
+            <div className="flex items-center justify-between">
+              <span>{playerNameFor(match, effectiveNonStriker)}</span>
+              <span className="text-muted-foreground">{battingLine(nonStrikerEntry)}</span>
+            </div>
+          )}
+          {effectiveBowler && (
+            <div className="mt-1.5 flex items-center justify-between border-t pt-1.5 text-xs">
+              <span className="text-muted-foreground">
+                Bowling: <span className="font-medium text-foreground">{playerNameFor(match, effectiveBowler)}</span>
+              </span>
+              <span className="text-muted-foreground">{bowlingFigures(bowlerEntry)}</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {overBalls.length > 0 && (
+        <div>
+          <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            This over
+          </p>
+          <div className="flex gap-2">
+            {overBalls.map((d, i) => (
+              <span
+                key={i}
+                className={`flex size-9 items-center justify-center rounded-full text-sm font-semibold ${
+                  isChipHighlighted(d) === 'boundary'
+                    ? 'bg-primary/15 text-primary'
+                    : isChipHighlighted(d) === 'wicket'
+                      ? 'bg-destructive/15 text-destructive'
+                      : 'bg-muted text-foreground'
+                }`}
+              >
+                {deliveryChipLabel(d)}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!readyToScore ? (
+        <div className="rounded-xl border bg-card p-4">
+          <p className="mb-3 text-sm font-medium">
+            {!effectiveBowler && (!effectiveStriker || !effectiveNonStriker)
+              ? 'New over, new batter — who is it?'
+              : !effectiveBowler
+                ? "New over — who's bowling?"
+                : 'Wicket! Who is coming in to bat?'}
+          </p>
+          {!effectiveStriker && (
+            <div className="mb-3">
+              <p className="mb-1.5 text-xs text-muted-foreground">Striker</p>
+              <PlayerPicker
+                players={playersOnSide(match.players, battingSide!)}
+                value={pickedStriker ?? undefined}
+                exclude={[effectiveNonStriker, ...outBatters]}
+                onChange={setPickedStriker}
+              />
+            </div>
+          )}
+          {!effectiveNonStriker && (
+            <div className="mb-3">
+              <p className="mb-1.5 text-xs text-muted-foreground">Non-striker</p>
+              <PlayerPicker
+                players={playersOnSide(match.players, battingSide!)}
+                value={pickedNonStriker ?? undefined}
+                exclude={[effectiveStriker, ...outBatters]}
+                onChange={setPickedNonStriker}
+              />
+            </div>
+          )}
+          {!effectiveBowler && (
+            <div>
+              <p className="mb-1.5 text-xs text-muted-foreground">Bowler</p>
+              <PlayerPicker
+                players={playersOnSide(match.players, bowlingSide!)}
+                value={pickedBowler ?? undefined}
+                exclude={next!.previousOverBowlerPlayerId ?? undefined}
+                onChange={setPickedBowler}
+              />
+            </div>
+          )}
+        </div>
+      ) : (
+        <div>
+          <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Runs off this ball
+          </p>
+          <div className="grid grid-cols-4 gap-2">
+            {[0, 1, 2, 3].map((n) => (
+              <button
+                key={n}
+                type="button"
+                disabled={appendEvent.isPending}
+                onClick={() => recordDelivery({ runs_off_bat: n })}
+                className="rounded-xl border bg-card p-4 text-lg font-semibold transition-colors hover:bg-muted disabled:opacity-50"
+              >
+                {n}
+              </button>
+            ))}
+            {[4, 6].map((n) => (
+              <button
+                key={n}
+                type="button"
+                disabled={appendEvent.isPending}
+                onClick={() => recordDelivery({ runs_off_bat: n })}
+                className="rounded-xl border border-primary/30 bg-primary/10 p-4 text-lg font-semibold text-primary transition-colors hover:bg-primary/15 disabled:opacity-50"
+              >
+                {n}
+              </button>
+            ))}
+            <button
+              type="button"
+              disabled={appendEvent.isPending}
+              onClick={() => setExtraDialog('bye')}
+              className="rounded-xl border bg-card p-4 text-sm font-semibold transition-colors hover:bg-muted disabled:opacity-50"
+            >
+              Bye
+            </button>
+          </div>
+
+          <div className="mt-2 grid grid-cols-3 gap-2">
+            <button
+              type="button"
+              disabled={appendEvent.isPending}
+              onClick={() => setExtraDialog('wide')}
+              className="rounded-xl border bg-card p-3 text-sm font-medium transition-colors hover:bg-muted disabled:opacity-50"
+            >
+              Wide
+            </button>
+            <button
+              type="button"
+              disabled={appendEvent.isPending}
+              onClick={() => setExtraDialog('no_ball')}
+              className="rounded-xl border bg-card p-3 text-sm font-medium transition-colors hover:bg-muted disabled:opacity-50"
+            >
+              No ball
+            </button>
+            <button
+              type="button"
+              disabled={appendEvent.isPending}
+              onClick={() => setWicketOpen(true)}
+              className="rounded-xl border border-destructive/30 bg-destructive/10 p-3 text-sm font-medium text-destructive transition-colors hover:bg-destructive/15 disabled:opacity-50"
+            >
+              Wicket
+            </button>
+          </div>
+        </div>
+      )}
+
+      {appendEvent.isError && (
+        <p className="text-center text-xs text-destructive">
+          Failed to record that ball — try again.
+        </p>
+      )}
+
+      {endInningsOpen ? (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4">
+          <p className="mb-2 text-sm font-medium">End this innings — why?</p>
+          <div className="grid grid-cols-2 gap-2">
+            {END_REASONS.map((r) => (
+              <Button
+                key={r.value}
+                variant="outline"
+                size="sm"
+                disabled={appendEvent.isPending}
+                onClick={() => endInnings(r.value)}
+              >
+                {r.label}
+              </Button>
+            ))}
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="mt-2"
+            onClick={() => setEndInningsOpen(false)}
+          >
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <Button variant="outline" onClick={() => setEndInningsOpen(true)}>
+          End innings
+        </Button>
+      )}
+
+      {readyToScore && (
+        <>
+          <WicketDialog
+            open={wicketOpen}
+            match={match}
+            battingSideId={innings.batting_side_id}
+            strikerPlayerId={effectiveStriker!}
+            nonStrikerPlayerId={effectiveNonStriker!}
+            submitting={appendEvent.isPending}
+            onOpenChange={setWicketOpen}
+            onSubmit={(wicket: CricketDeliveryWicket, runsBeforeDismissal) => {
+              recordDelivery({ runs_off_bat: runsBeforeDismissal, wicket })
+              setWicketOpen(false)
+            }}
+          />
+
+          <ExtraRunsDialog
+            open={extraDialog === 'wide'}
+            title="Wide"
+            kinds={[{ value: 'wide', label: 'Wide' }]}
+            submitting={appendEvent.isPending}
+            onOpenChange={(open) => !open && setExtraDialog(null)}
+            onPick={(kind, runs) => {
+              recordDelivery({ extra: { kind, runs } })
+              setExtraDialog(null)
+            }}
+          />
+          <ExtraRunsDialog
+            open={extraDialog === 'no_ball'}
+            title="No ball"
+            kinds={[{ value: 'no_ball', label: 'No ball' }]}
+            submitting={appendEvent.isPending}
+            onOpenChange={(open) => !open && setExtraDialog(null)}
+            onPick={(kind, runs) => {
+              recordDelivery({ extra: { kind, runs } })
+              setExtraDialog(null)
+            }}
+          />
+          <ExtraRunsDialog
+            open={extraDialog === 'bye'}
+            title="Byes"
+            kinds={[
+              { value: 'bye', label: 'Bye' },
+              { value: 'leg_bye', label: 'Leg bye' },
+            ]}
+            submitting={appendEvent.isPending}
+            onOpenChange={(open) => !open && setExtraDialog(null)}
+            onPick={(kind, runs) => {
+              recordDelivery({ extra: { kind, runs } })
+              setExtraDialog(null)
+            }}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { useLiveScore, useAppendFootballEvent } from '@/hooks/useLiveScore'
 import { RecordEventDialog, type EventKind } from '@/components/agon/live/RecordEventDialog'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
+import { CricketLiveScoringPage } from './CricketLiveScoringPage'
 import {
   currentMinute,
   describeEvent,
@@ -26,19 +27,14 @@ function sideName(match: Match, index: number, fallback: string): string {
   return match.sides[index]?.name?.trim() || fallback
 }
 
-/** How often the on-screen clock re-renders while a half is running. */
-const CLOCK_TICK_MS = 15_000
-
 /**
- * The live scoring screen: quick actions to log goals/cards/subs as they
- * happen, a running clock, and the event log so far. The clock is computed
- * from the server-recorded kickoff/half-time timestamps (see `lib/liveScore`),
- * so it's the same for every viewer, not just this device.
+ * Route entry for `/matches/:matchId/live`: fetches the match once and
+ * dispatches to the sport-specific scoring screen. Football and cricket have
+ * different live-scoring shapes entirely (a running clock vs. overs/wickets),
+ * so past the match fetch they don't share a component.
  */
 export function LiveScoringPage() {
   const { matchId } = useParams()
-  const navigate = useNavigate()
-  const queryClient = useQueryClient()
 
   const matchQuery = useQuery({
     queryKey: ['match', matchId],
@@ -52,19 +48,7 @@ export function LiveScoringPage() {
     },
   })
 
-  const live = useLiveScore(matchId, { refetchInterval: 8000 })
-  const append = useAppendFootballEvent(matchId ?? '')
-
-  const [now, setNow] = useState(() => new Date())
-  useEffect(() => {
-    const id = setInterval(() => setNow(new Date()), CLOCK_TICK_MS)
-    return () => clearInterval(id)
-  }, [])
-
-  const prefs = loadTrackPrefs(matchId ?? '')
-  const [dialogKind, setDialogKind] = useState<EventKind | null>(null)
-
-  if (matchQuery.isLoading || live.isLoading) {
+  if (matchQuery.isLoading) {
     return (
       <div className="mx-auto max-w-xl">
         <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
@@ -84,6 +68,45 @@ export function LiveScoringPage() {
   }
 
   const match = matchQuery.data
+  if (match.match_type === 'cricket') {
+    return <CricketLiveScoringPage match={match} />
+  }
+  return <FootballLiveScoringPage match={match} />
+}
+
+/** How often the on-screen clock re-renders while a half is running. */
+const CLOCK_TICK_MS = 15_000
+
+/**
+ * The live scoring screen: quick actions to log goals/cards/subs as they
+ * happen, a running clock, and the event log so far. The clock is computed
+ * from the server-recorded kickoff/half-time timestamps (see `lib/liveScore`),
+ * so it's the same for every viewer, not just this device.
+ */
+function FootballLiveScoringPage({ match }: { match: Match }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const live = useLiveScore(match.id, { refetchInterval: 8000 })
+  const append = useAppendFootballEvent(match.id)
+
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), CLOCK_TICK_MS)
+    return () => clearInterval(id)
+  }, [])
+
+  const prefs = loadTrackPrefs(match.id)
+  const [dialogKind, setDialogKind] = useState<EventKind | null>(null)
+
+  if (live.isLoading) {
+    return (
+      <div className="mx-auto max-w-xl">
+        <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
+      </div>
+    )
+  }
+
   const nameA = sideName(match, 0, 'Side A')
   const nameB = sideName(match, 1, 'Side B')
   const state = footballLiveState(live.data)
@@ -136,7 +159,7 @@ export function LiveScoringPage() {
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">
       <div className="flex items-center justify-between">
-        <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${matchId}`)}>
+        <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${match.id}`)}>
           <ChevronLeft className="size-4" /> Back
         </Button>
         <LiveIndicator />
@@ -183,7 +206,7 @@ export function LiveScoringPage() {
       </div>
 
       <Link
-        to={`/matches/${matchId}/live/setup`}
+        to={`/matches/${match.id}/live/setup`}
         className="text-center text-sm text-primary hover:underline"
       >
         + Track more (cards, subs)

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -12,9 +12,11 @@ import { SportBadge } from '@/components/agon/SportBadge'
 import { StatusBadge, matchBadgeStatus } from '@/components/agon/StatusBadge'
 import { ScoreConfirmationBar } from '@/components/agon/ScoreConfirmationBar'
 import { LiveMatchBlock } from '@/components/agon/live/LiveMatchBlock'
+import { CricketMatchBlock } from '@/components/agon/live/CricketMatchBlock'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { useLiveScore } from '@/hooks/useLiveScore'
 import { footballLiveState } from '@/lib/liveScore'
+import { cricketLiveState } from '@/lib/cricketScore'
 import { useCurrentUserId } from '@/hooks/useCurrentUserId'
 import { displayScore, headlineBySide, headlineLabel, setLine } from '@/lib/score'
 import {
@@ -105,7 +107,7 @@ function MatchDetail({
 
   const canEdit = isParticipant(match, currentUserId)
   const cancelled = match.status === 'cancelled'
-  const isLiveSport = match.match_type === 'football'
+  const isLiveSport = match.match_type === 'football' || match.match_type === 'cricket'
 
   const [sideA, sideB] = match.sides
   const nameA = sideName(sideA, 'Side A')
@@ -125,7 +127,13 @@ function MatchDetail({
     enabled: isLiveSport && match.status === 'in_progress',
     refetchInterval: 15000,
   })
-  const liveState = footballLiveState(live.data)
+  const footballState = footballLiveState(live.data)
+  const cricketState = cricketLiveState(live.data)
+  const hasLiveState = !!footballState || !!cricketState
+  // Football's setup screen also gates starting the clock; cricket has no
+  // equivalent preferences step, so it goes straight into scoring.
+  const liveEntryPath =
+    match.match_type === 'cricket' ? `/matches/${match.id}/live` : `/matches/${match.id}/live/setup`
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">
@@ -162,11 +170,15 @@ function MatchDetail({
           </div>
 
           {/* Score header — the live block (score + mini-ticker) takes over
-              while a football match is being scored live; otherwise the
-              usual confirmed/pending result. */}
-          {liveState ? (
+              while a football/cricket match is being scored live; otherwise
+              the usual confirmed/pending result. */}
+          {footballState ? (
             <div className="mt-3">
-              <LiveMatchBlock match={match} state={liveState} tickerLimit={3} />
+              <LiveMatchBlock match={match} state={footballState} tickerLimit={3} />
+            </div>
+          ) : cricketState ? (
+            <div className="mt-3">
+              <CricketMatchBlock match={match} state={cricketState} />
             </div>
           ) : scoreInfo ? (
             <div className="mt-3 flex items-center justify-between">
@@ -206,12 +218,12 @@ function MatchDetail({
           )}
 
           <div className="mt-3 flex items-center justify-between">
-            {liveState ? <LiveIndicator /> : <StatusBadge status={matchBadgeStatus(match)} />}
+            {hasLiveState ? <LiveIndicator /> : <StatusBadge status={matchBadgeStatus(match)} />}
             <div className="flex items-center gap-1">
               {canEdit && isLiveSport && !cancelled && match.status !== 'completed' && (
                 <Button asChild variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs text-primary">
-                  <Link to={`/matches/${match.id}/live/setup`}>
-                    <Radio className="size-3" /> {liveState ? 'Continue scoring' : 'Score live'}
+                  <Link to={liveEntryPath}>
+                    <Radio className="size-3" /> {hasLiveState ? 'Continue scoring' : 'Score live'}
                   </Link>
                 </Button>
               )}


### PR DESCRIPTION
## Summary

Follow-up to #25/#26 (football live scoring) — ball-by-ball live scoring for cricket, mirroring the mockups shared for it (live scoring screen + mini-ticker). Built around cricket's own model (innings/overs/wickets), not football's clock. **No backend changes needed** — the live-scoring API already fully modelled deliveries, extras, dismissals and innings boundaries.

- `lib/cricketScore.ts`: derives the current striker/non-striker/bowler — and whether the scorer needs to pick one (fresh innings, a wicket just fell, or a new over started) — purely by folding the delivery log. Also run-rate, "this over" ball-chip formatting, and batting/bowling card line helpers.
- `CricketLiveScoringPage`: single-tap runs (0-3, 4, 6), a Bye/Leg-bye runs dialog, Wide/No-ball, and a Wicket dialog (dismissal kind, who's out — either end for a run-out — optional fielder). Strike rotates automatically on odd runs and at the end of every over; the next bowler can't repeat the previous over's (enforced in the picker). Ending an innings is a manual action with a reason (all out / overs complete / declared / target reached), same posture as football's Half/FT tap.
- `CricketMatchBlock`: mini-ticker (score, batters on strike, "this over" balls) for the feed card and match detail page, mirroring the second mockup.
- Extracted `SidePicker`/`PlayerPicker` out of football's `RecordEventDialog` into `components/agon/live/Pickers.tsx` so both sports share the same roster-picking UI.
- `LiveScoringPage` is now a thin sport dispatcher (fetches the match once, renders the right screen); football's screen moved into `FootballLiveScoringPage` unchanged in behaviour.
- Cricket has no setup/track-preferences screen — there's nothing optional to toggle, every delivery is scored — so its entry point on the match detail page skips straight to `/live` instead of `/live/setup`.

### Scope notes (disclosed simplifications, same posture as the football PRs)
- Wide/no-ball/bye/leg-bye extras are capped at a simple 1-4 run picker rather than an open field.
- No-balls don't separately model runs off the bat in addition to the mandatory extra run.
- If a striker is dismissed on an over's exact final ball, the incoming batter is placed in the open slot without fully modelling which physical end each player ends up at (a rare edge case).
- No overs-limit/target/required-run-rate UI — the data model doesn't carry a configured overs limit, and it's not in the mockups either.

## Test plan
- [x] `agon_ui`: `tsc -b`, `eslint`, `vite build` all clean
- [ ] Manual click-through against a real backend/Supabase project (not possible in the sandbox this was built in — no Supabase credentials configured)

https://claude.ai/code/session_01Lyd6AiV1R9ff1sJJC5Bn8e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lyd6AiV1R9ff1sJJC5Bn8e)_