### PR TITLE
Auto-flip match to in_progress on first live event

### DIFF
--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2235,6 +2235,25 @@ impl Api {
             Err(e) => return Err(dao_internal(e)),
         }
 
+        // Recording a live event is what "starting" a match means, whatever
+        // the sport (kickoff for football, the first ball for cricket) — flip
+        // a still-scheduled match to `in_progress` here rather than relying
+        // on each sport's client to remember a separate status PATCH.
+        if agg.match_.status == "scheduled" {
+            dao.update_match_meta(
+                &match_id,
+                None,
+                None,
+                Some("in_progress"),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .map_err(dao_internal)?;
+        }
+
         match self.recompute_live_state(dao, &match_id, &sport).await? {
             Some(snapshot) => Ok(AppendLiveEventsResponse::Ok(Json(snapshot))),
             None => Ok(AppendLiveEventsResponse::ValidationError(PlainText(

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -42,6 +42,11 @@ export function useLiveScore(
  * returned snapshot replaces the cache directly (cheaper and more current
  * than invalidating + refetching). Shared by the per-sport wrappers below —
  * each just tags its event with the right `sport` discriminator.
+ *
+ * The server flips a still-`scheduled` match to `in_progress` the first time
+ * any live event is recorded, so every append also invalidates the match and
+ * feed queries — that's the only signal the scorer's own client has that the
+ * status (and therefore other viewers' "Live" gate) may have just changed.
  */
 function useAppendLiveEvent<T extends { kind: string }>(
   matchId: string,
@@ -69,6 +74,8 @@ function useAppendLiveEvent<T extends { kind: string }>(
     },
     onSuccess: (data) => {
       queryClient.setQueryData(liveScoreQueryKey(matchId), data)
+      queryClient.invalidateQueries({ queryKey: ['match', matchId] })
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
     },
   })
 }

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -125,7 +125,7 @@ export function bowlingEntryFor(
  *  before the bowler has sent down a delivery. */
 export function bowlingFigures(entry: CricketBowlingEntry | null): string {
   if (!entry) return '—'
-  return `${entry.overs}-${entry.maidens}-${entry.runs_conceded}-${entry.wickets}`
+  return `${entry.overs.toFixed(1)}-${entry.maidens}-${entry.runs_conceded}-${entry.wickets}`
 }
 
 /** "46 (32)" — runs and balls faced, or "0 (0)" before a batter's first ball. */

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { ChevronLeft } from 'lucide-react'
 import type { components } from '@/types/api'
@@ -47,7 +46,6 @@ const END_REASONS: { value: InningsEndReason; label: string }[] = [
  */
 export function CricketLiveScoringPage({ match }: { match: Match }) {
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
 
   const live = useLiveScore(match.id, { refetchInterval: 8000 })
   const appendEvent = useAppendCricketEvent(match.id)
@@ -155,12 +153,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   const endInnings = (reason: InningsEndReason) => {
     appendEvent.mutate(
       { kind: 'InningsEnd', reason },
-      {
-        onSuccess: () => {
-          setEndInningsOpen(false)
-          queryClient.invalidateQueries({ queryKey: ['feed'] })
-        },
-      },
+      { onSuccess: () => setEndInningsOpen(false) },
     )
   }
 

--- a/agon_ui/src/pages/LiveScoringSetupPage.tsx
+++ b/agon_ui/src/pages/LiveScoringSetupPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ChevronLeft } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
@@ -60,7 +60,6 @@ function TrackRow({
 export function LiveScoringSetupPage() {
   const { matchId } = useParams()
   const navigate = useNavigate()
-  const queryClient = useQueryClient()
 
   const query = useQuery({
     queryKey: ['match', matchId],
@@ -94,23 +93,18 @@ export function LiveScoringSetupPage() {
 
   const start = useMutation({
     mutationFn: async () => {
-      if (!matchId || !query.data) return
-      if (query.data.status !== 'in_progress') {
-        const { error } = await fetchClient.PATCH('/matches/{match_id}', {
-          params: { path: { match_id: matchId } },
-          body: { status: 'in_progress' },
-        })
-        if (error) throw new Error('Failed to start the match')
-      }
+      if (!matchId) return
       // The live clock starts now, once — recorded as a real event so every
       // viewer (not just this device) can compute the same running minute.
+      // Appending it is also what flips the match from `scheduled` to
+      // `in_progress` server-side (see `append_live_events`), which is what
+      // makes the live score visible on other viewers' feed/detail screens —
+      // no separate status PATCH needed here.
       if (!alreadyKickedOff) {
         await appendEvent.mutateAsync({ kind: 'Period', period: 'kick_off' })
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['match', matchId] })
-      queryClient.invalidateQueries({ queryKey: ['feed'] })
       navigate(`/matches/${matchId}/live`, { replace: true })
     },
   })


### PR DESCRIPTION
## Summary
Moves match status transition from `scheduled` → `in_progress` from the client to the server, triggered automatically when the first live event is recorded. This ensures all viewers see the match go live at the same moment and simplifies the client-side logic.

## Key Changes

**Backend (agon_service)**
- `append_live_events` now checks if a match is still `scheduled` and flips it to `in_progress` before recomputing live state
- This single server-side action replaces the need for a separate status PATCH from the client

**Frontend (agon_ui)**
- Removed the explicit `PATCH /matches/{match_id}` status update from `LiveScoringSetupPage.start()` — appending the `kick_off` event now handles the transition
- Removed unused `useQueryClient` imports from `LiveScoringSetupPage` and `CricketLiveScoringPage`
- Moved query invalidation (`match` and `feed`) into the shared `useAppendLiveEvent` hook's `onSuccess` callback, so every live event append (not just the initial start) signals that match status may have changed
- Removed redundant `queryClient.invalidateQueries` calls from individual mutation handlers in `CricketLiveScoringPage.endInnings()`
- Updated `bowlingFigures()` to format overs with one decimal place for consistency

## Implementation Details
- The server-side status flip is idempotent: only `scheduled` matches transition, so re-appending events won't cause issues
- Query invalidation is now centralized in `useAppendLiveEvent`, ensuring the match and feed queries refresh whenever any live event is recorded — this is the signal that the match's visibility/status may have changed for other viewers
- The comment in `useLiveScore.ts` documents why invalidation happens at the append level rather than per-sport

https://claude.ai/code/session_012ku9PGhC4LpQDDMHCKZU2u