### PR TITLE
Add configurable extra-ball rules for cricket wides and no-balls

### DIFF
--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -332,7 +332,18 @@ pub struct CricketFormatRecord {
     pub balls_per_over: u32,
     pub no_ball_penalty_runs: u32,
     pub wide_penalty_runs: u32,
+    /// `#[serde(default = "default_true")]` for records written before these
+    /// two fields existed — the standard rule (extra ball) is the safe
+    /// default for a match that never configured otherwise.
+    #[serde(default = "default_true")]
+    pub wide_is_extra_ball: bool,
+    #[serde(default = "default_true")]
+    pub no_ball_is_extra_ball: bool,
     pub free_hit_after_no_ball: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// `MATCH#<matchId>` / `SIDE#<sideId>` — one side of a match.

--- a/agon_service/src/detailed_score/cricket.rs
+++ b/agon_service/src/detailed_score/cricket.rs
@@ -202,12 +202,21 @@ fn dismissal_credited_to_bowler(kind: &CricketDismissalKind) -> bool {
     )
 }
 
-/// True if the delivery counts as a legal ball (advances the over).
-fn is_legal_delivery(delivery: &CricketDelivery) -> bool {
-    !matches!(
-        delivery.extra.as_ref().map(|e| &e.kind),
-        Some(CricketExtraKind::Wide) | Some(CricketExtraKind::NoBall)
-    )
+/// True if the delivery counts as a legal ball (advances the over). Wides and
+/// no-balls are illegal (re-bowled as an extra delivery) under the standard
+/// rules, but a match format can configure either one to just count as one of
+/// the over's legal balls instead (see `CricketFormat::wide_is_extra_ball` /
+/// `no_ball_is_extra_ball`).
+fn is_legal_delivery(
+    delivery: &CricketDelivery,
+    wide_is_extra_ball: bool,
+    no_ball_is_extra_ball: bool,
+) -> bool {
+    match delivery.extra.as_ref().map(|e| &e.kind) {
+        Some(CricketExtraKind::Wide) => !wide_is_extra_ball,
+        Some(CricketExtraKind::NoBall) => !no_ball_is_extra_ball,
+        _ => true,
+    }
 }
 
 /// Runs charged to the bowler for a delivery: runs off the bat plus wides and
@@ -236,17 +245,19 @@ impl CricketInnings {
     /// Builds the innings overview (totals, batting/bowling cards, extras,
     /// fall-of-wickets) from a ball-by-ball delivery log. The deliveries are
     /// retained on the returned innings as the source of truth.
-    /// `balls_per_over` is the match's configured over length (see
-    /// `agon_service::match_format::CricketFormat::balls_per_over`) — it's
-    /// the only piece of match format the DAO-agnostic scoring math actually
-    /// needs, so it's threaded in as a plain argument rather than the whole
-    /// format.
+    /// `balls_per_over`, `wide_is_extra_ball` and `no_ball_is_extra_ball` are
+    /// the match's configured over length and extra-ball rules (see
+    /// `agon_service::match_format::CricketFormat`) — the only pieces of
+    /// match format the DAO-agnostic scoring math actually needs, so they're
+    /// threaded in as plain arguments rather than the whole format.
     pub fn from_deliveries(
         batting_side_id: String,
         bowling_side_id: String,
         declared: bool,
         deliveries: Vec<CricketDelivery>,
         balls_per_over: u32,
+        wide_is_extra_ball: bool,
+        no_ball_is_extra_ball: bool,
     ) -> Self {
         // First-appearance-ordered accumulators keyed by player_id.
         let mut batting: Vec<CricketBattingEntry> = Vec::new();
@@ -306,7 +317,7 @@ impl CricketInnings {
         }
 
         for delivery in &deliveries {
-            let legal = is_legal_delivery(delivery);
+            let legal = is_legal_delivery(delivery, wide_is_extra_ball, no_ball_is_extra_ball);
             let charged = runs_charged_to_bowler(delivery);
             let extra_runs = delivery.extra.as_ref().map(|e| e.runs).unwrap_or(0);
 
@@ -391,7 +402,10 @@ impl CricketInnings {
         for bw in &mut bowling {
             let balls: u32 = deliveries
                 .iter()
-                .filter(|d| d.bowler_player_id == bw.player_id && is_legal_delivery(d))
+                .filter(|d| {
+                    d.bowler_player_id == bw.player_id
+                        && is_legal_delivery(d, wide_is_extra_ball, no_ball_is_extra_ball)
+                })
                 .count() as u32;
             bw.overs = balls_to_overs(balls, balls_per_over);
             bw.maidens = over_runs
@@ -479,8 +493,15 @@ mod tests {
             },
         ];
 
-        let innings =
-            CricketInnings::from_deliveries("team_a".into(), "team_b".into(), false, deliveries, 6);
+        let innings = CricketInnings::from_deliveries(
+            "team_a".into(),
+            "team_b".into(),
+            false,
+            deliveries,
+            6,
+            true,
+            true,
+        );
 
         // Total runs: 4 + 6 + 1(wide) + 0 + 1 + 0 = 12.
         assert_eq!(innings.runs, 12);
@@ -530,8 +551,15 @@ mod tests {
             ball(0, 5, "B1", "S1", "S2", 1),
         ];
 
-        let innings =
-            CricketInnings::from_deliveries("team_a".into(), "team_b".into(), false, deliveries, 5);
+        let innings = CricketInnings::from_deliveries(
+            "team_a".into(),
+            "team_b".into(),
+            false,
+            deliveries,
+            5,
+            true,
+            true,
+        );
 
         assert_eq!(innings.overs, Overs { overs: 1, balls: 0 });
         let b1 = innings
@@ -540,5 +568,66 @@ mod tests {
             .find(|b| b.player_id == "B1")
             .expect("B1 bowling entry");
         assert_eq!(b1.overs, Overs { overs: 1, balls: 0 });
+    }
+
+    #[test]
+    fn wides_and_no_balls_can_be_configured_to_not_cost_an_extra_ball() {
+        // A casual-format over: wide, no-ball, then 4 plain deliveries. Under
+        // the standard rules that's a 4-ball over (wide/no-ball re-bowled);
+        // with both flags off here, the wide and no-ball each count as one of
+        // the over's 6 legal balls, so the whole thing completes in one over.
+        let deliveries = vec![
+            CricketDelivery {
+                over: 0,
+                ball: 1,
+                bowler_player_id: "B1".into(),
+                striker_player_id: "S1".into(),
+                non_striker_player_id: "S2".into(),
+                runs_off_bat: 0,
+                extra: Some(CricketDeliveryExtra {
+                    kind: CricketExtraKind::Wide,
+                    runs: 1,
+                }),
+                wicket: None,
+            },
+            CricketDelivery {
+                over: 0,
+                ball: 2,
+                bowler_player_id: "B1".into(),
+                striker_player_id: "S1".into(),
+                non_striker_player_id: "S2".into(),
+                runs_off_bat: 1,
+                extra: Some(CricketDeliveryExtra {
+                    kind: CricketExtraKind::NoBall,
+                    runs: 1,
+                }),
+                wicket: None,
+            },
+            ball(0, 3, "B1", "S1", "S2", 0),
+            ball(0, 4, "B1", "S1", "S2", 0),
+            ball(0, 5, "B1", "S1", "S2", 0),
+            ball(0, 6, "B1", "S1", "S2", 0),
+        ];
+
+        let innings = CricketInnings::from_deliveries(
+            "team_a".into(),
+            "team_b".into(),
+            false,
+            deliveries,
+            6,
+            false,
+            false,
+        );
+
+        assert_eq!(innings.overs, Overs { overs: 1, balls: 0 });
+        assert_eq!(innings.runs, 3); // 1 (wide) + 1 (no-ball penalty) + 1 (off the bat)
+        let b1 = innings
+            .bowling
+            .iter()
+            .find(|b| b.player_id == "B1")
+            .expect("B1 bowling entry");
+        assert_eq!(b1.overs, Overs { overs: 1, balls: 0 });
+        assert_eq!(b1.wides, 1);
+        assert_eq!(b1.no_balls, 1);
     }
 }

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -79,12 +79,28 @@ struct OpenInnings {
 /// not a stored index — so deleting a wrongly-placed boundary automatically
 /// re-flows every event after it back into the earlier innings on the next
 /// fold, with nothing to rewrite.
-/// `balls_per_over` is the match's configured over length (see
-/// `agon_service::match_format::CricketFormat::balls_per_over`); callers
-/// without a configured format pass the standard 6.
-pub fn derive_state(events: &[CricketLiveEvent], balls_per_over: u32) -> CricketLiveState {
+/// `balls_per_over`, `wide_is_extra_ball` and `no_ball_is_extra_ball` are the
+/// match's configured over length and extra-ball rules (see
+/// `agon_service::match_format::CricketFormat`); callers without a
+/// configured format pass the standard defaults (6, true, true).
+pub fn derive_state(
+    events: &[CricketLiveEvent],
+    balls_per_over: u32,
+    wide_is_extra_ball: bool,
+    no_ball_is_extra_ball: bool,
+) -> CricketLiveState {
     let mut innings: Vec<CricketInnings> = Vec::new();
     let mut current: Option<OpenInnings> = None;
+
+    let finish = |open: OpenInnings, declared: bool| {
+        finish_innings(
+            open,
+            declared,
+            balls_per_over,
+            wide_is_extra_ball,
+            no_ball_is_extra_ball,
+        )
+    };
 
     for event in events {
         match event {
@@ -92,7 +108,7 @@ pub fn derive_state(events: &[CricketLiveEvent], balls_per_over: u32) -> Cricket
                 // Close out anything left open without an explicit End,
                 // rather than losing it — shouldn't normally happen.
                 if let Some(open) = current.take() {
-                    innings.push(finish_innings(open, false, balls_per_over));
+                    innings.push(finish(open, false));
                 }
                 current = Some(OpenInnings {
                     batting_side_id: start.batting_side_id.clone(),
@@ -115,7 +131,7 @@ pub fn derive_state(events: &[CricketLiveEvent], balls_per_over: u32) -> Cricket
             CricketLiveEvent::InningsEnd(end) => {
                 if let Some(open) = current.take() {
                     let declared = matches!(end.reason, InningsEndReason::Declared);
-                    innings.push(finish_innings(open, declared, balls_per_over));
+                    innings.push(finish(open, declared));
                 }
             }
         }
@@ -123,7 +139,7 @@ pub fn derive_state(events: &[CricketLiveEvent], balls_per_over: u32) -> Cricket
 
     let awaiting_next_innings = current.is_none();
     if let Some(open) = current {
-        innings.push(finish_innings(open, false, balls_per_over));
+        innings.push(finish(open, false));
     }
 
     CricketLiveState {
@@ -132,13 +148,21 @@ pub fn derive_state(events: &[CricketLiveEvent], balls_per_over: u32) -> Cricket
     }
 }
 
-fn finish_innings(open: OpenInnings, declared: bool, balls_per_over: u32) -> CricketInnings {
+fn finish_innings(
+    open: OpenInnings,
+    declared: bool,
+    balls_per_over: u32,
+    wide_is_extra_ball: bool,
+    no_ball_is_extra_ball: bool,
+) -> CricketInnings {
     let mut built = CricketInnings::from_deliveries(
         open.batting_side_id,
         open.bowling_side_id,
         declared,
         open.deliveries,
         balls_per_over,
+        wide_is_extra_ball,
+        no_ball_is_extra_ball,
     );
     apply_retirements(&mut built, &open.retirements);
     built
@@ -217,7 +241,7 @@ mod tests {
             CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 1)),
         ];
 
-        let state = derive_state(&events, 6);
+        let state = derive_state(&events, 6, true, true);
         assert_eq!(state.innings.len(), 1);
         let innings = &state.innings[0];
         assert_eq!(
@@ -257,7 +281,7 @@ mod tests {
             }),
         ];
 
-        let state = derive_state(&events, 6);
+        let state = derive_state(&events, 6, true, true);
         let innings = &state.innings[0];
         assert_eq!(innings.wickets, 1);
         assert_eq!(innings.fall_of_wickets.len(), 1);
@@ -282,7 +306,7 @@ mod tests {
             CricketLiveEvent::Delivery(ball("sharma", "cole", "adeyemi", 1)),
         ];
 
-        let state = derive_state(&events, 6);
+        let state = derive_state(&events, 6, true, true);
         assert_eq!(state.innings.len(), 2);
         assert_eq!(state.innings[0].batting_side_id, "warriors");
         assert_eq!(state.innings[0].runs, 4);
@@ -313,7 +337,7 @@ mod tests {
             CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 2)),
         ];
 
-        let state = derive_state(&events, 6);
+        let state = derive_state(&events, 6, true, true);
 
         assert_eq!(
             state.innings.len(),

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -658,6 +658,8 @@ pub fn match_format_to_record(fmt: &MatchFormat) -> MatchFormatRecord {
             balls_per_over: f.balls_per_over,
             no_ball_penalty_runs: f.no_ball_penalty_runs,
             wide_penalty_runs: f.wide_penalty_runs,
+            wide_is_extra_ball: f.wide_is_extra_ball,
+            no_ball_is_extra_ball: f.no_ball_is_extra_ball,
             free_hit_after_no_ball: f.free_hit_after_no_ball,
         }),
     }
@@ -680,6 +682,8 @@ pub fn match_format_from_record(rec: &MatchFormatRecord) -> MatchFormat {
             balls_per_over: f.balls_per_over,
             no_ball_penalty_runs: f.no_ball_penalty_runs,
             wide_penalty_runs: f.wide_penalty_runs,
+            wide_is_extra_ball: f.wide_is_extra_ball,
+            no_ball_is_extra_ball: f.no_ball_is_extra_ball,
             free_hit_after_no_ball: f.free_hit_after_no_ball,
         }),
     }
@@ -1059,15 +1063,21 @@ pub fn derive_live_score_state(
                     LiveEventPayloadRecord::Football(_) => None,
                 })
                 .collect();
-            // Standard 6-ball over unless the match configured something else
-            // (e.g. The Hundred's 5).
-            let balls_per_over = match format {
-                Some(MatchFormatRecord::Cricket(f)) => f.balls_per_over,
-                _ => 6,
+            // Standard rules unless the match configured something else: a
+            // 6-ball over (e.g. The Hundred's 5), and both wides and no-balls
+            // as extra (re-bowled) deliveries.
+            let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) = match format {
+                Some(MatchFormatRecord::Cricket(f)) => {
+                    (f.balls_per_over, f.wide_is_extra_ball, f.no_ball_is_extra_ball)
+                }
+                _ => (6, true, true),
             };
-            Some(LiveScoreState::Cricket(
-                crate::live_score::cricket::derive_state(&events, balls_per_over),
-            ))
+            Some(LiveScoreState::Cricket(crate::live_score::cricket::derive_state(
+                &events,
+                balls_per_over,
+                wide_is_extra_ball,
+                no_ball_is_extra_ball,
+            )))
         }
         _ => None,
     }
@@ -1300,6 +1310,8 @@ mod tests {
                 balls_per_over: 6,
                 no_ball_penalty_runs: 2,
                 wide_penalty_runs: 1,
+                wide_is_extra_ball: true,
+                no_ball_is_extra_ball: false,
                 free_hit_after_no_ball: false,
             }),
         ];

--- a/agon_service/src/match_format.rs
+++ b/agon_service/src/match_format.rs
@@ -3,14 +3,18 @@
 //! configured, and clients fall back to their own sensible per-sport
 //! defaults rather than every match being required to specify one.
 //!
-//! Phase 1: purely descriptive. Nothing here is enforced by the live-scoring
+//! Phase 1: mostly descriptive. Nothing here is enforced by the live-scoring
 //! API yet — going over a configured overs limit doesn't block further
 //! deliveries, and a no-ball's configured penalty isn't applied
 //! automatically. Live-scoring clients use it to prefill sensible defaults
 //! and show progress against the configured limit (e.g. "14.2/20 overs").
 //! Actually enforcing it (free hits, auto-suggesting innings/half end,
 //! extra-time and penalty-shootout flows) is intentionally out of scope for
-//! now and would build on top of this.
+//! now and would build on top of this. `wide_is_extra_ball` and
+//! `no_ball_is_extra_ball` are the exceptions, alongside `balls_per_over`:
+//! they drive whether a wide/no-ball advances the over in
+//! `detailed_score::cricket::CricketInnings::from_deliveries`, since that's
+//! server-side scoring math, not just client display.
 
 use poem_openapi::{Object, Union};
 
@@ -52,6 +56,17 @@ pub struct CricketFormat {
     pub no_ball_penalty_runs: u32,
     /// Runs awarded for a wide.
     pub wide_penalty_runs: u32,
+    /// Whether a wide is re-bowled as an extra delivery (the standard rule —
+    /// `true`) or simply counts as one of the over's legal balls alongside its
+    /// penalty runs (a casual/social variant some sides play to keep overs
+    /// moving).
+    pub wide_is_extra_ball: bool,
+    /// Whether a no-ball is re-bowled as an extra delivery (`true`, the
+    /// standard rule) or counts as a legal ball, same trade-off as
+    /// `wide_is_extra_ball`. Independent of `free_hit_after_no_ball`: Test
+    /// cricket, for instance, plays no-balls as extra balls with no free hit
+    /// at all (free hits are a modern limited-overs addition).
+    pub no_ball_is_extra_ball: bool,
     /// Whether the delivery after a no-ball is a free hit.
     pub free_hit_after_no_ball: bool,
 }

--- a/agon_ui/src/components/agon/MatchFormatCard.tsx
+++ b/agon_ui/src/components/agon/MatchFormatCard.tsx
@@ -25,7 +25,9 @@ function FormatSummary({ match }: { match: Match }) {
       <p className="text-xs text-muted-foreground">
         {oversLimitLabel(fmt)} · {fmt.innings_per_side === 1 ? 'single' : 'two'} innings ·
         no-ball {fmt.no_ball_penalty_runs} run{fmt.no_ball_penalty_runs === 1 ? '' : 's'}
+        {!fmt.no_ball_is_extra_ball && ' (no extra ball)'}
         {fmt.free_hit_after_no_ball && ' + free hit'}
+        {!fmt.wide_is_extra_ball && ' · wide: no extra ball'}
       </p>
     )
   }

--- a/agon_ui/src/components/agon/MatchFormatEditor.tsx
+++ b/agon_ui/src/components/agon/MatchFormatEditor.tsx
@@ -147,6 +147,16 @@ export function CricketFields({
         />
       </div>
       <ToggleRow
+        label="Wide costs an extra ball"
+        checked={value.wide_is_extra_ball}
+        onChange={(wide_is_extra_ball) => onChange({ ...value, wide_is_extra_ball })}
+      />
+      <ToggleRow
+        label="No-ball costs an extra ball"
+        checked={value.no_ball_is_extra_ball}
+        onChange={(no_ball_is_extra_ball) => onChange({ ...value, no_ball_is_extra_ball })}
+      />
+      <ToggleRow
         label="Free hit after a no-ball"
         checked={value.free_hit_after_no_ball}
         onChange={(free_hit_after_no_ball) => onChange({ ...value, free_hit_after_no_ball })}

--- a/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
@@ -101,7 +101,7 @@ export function CricketMatchBlock({
 
   const battingName = sideNameFor(match, innings.batting_side_id)
   const bowlingName = sideNameFor(match, innings.bowling_side_id)
-  const next = nextBallContext(innings, format.balls_per_over)
+  const next = nextBallContext(innings, format)
   const striker = battingEntryFor(innings, next.strikerPlayerId)
   const nonStriker = battingEntryFor(innings, next.nonStrikerPlayerId)
   const overBalls = currentOverDeliveries(innings)

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -70,9 +70,17 @@ export function currentInnings(state: CricketLiveState): CricketInnings | null {
   return state.innings[state.innings.length - 1] ?? null
 }
 
-/** Whether a delivery counts toward the over (wides/no-balls don't). */
-export function isLegalDelivery(d: CricketDelivery): boolean {
-  return !(d.extra && (d.extra.kind === 'wide' || d.extra.kind === 'no_ball'))
+/** Whether a delivery counts toward the over. Wides/no-balls don't under the
+ *  standard rules, but a match format can configure either one to just count
+ *  as a legal ball instead (see `CricketFormat.wide_is_extra_ball` /
+ *  `no_ball_is_extra_ball`). */
+export function isLegalDelivery(
+  d: CricketDelivery,
+  format: Pick<CricketFormat, 'wide_is_extra_ball' | 'no_ball_is_extra_ball'>,
+): boolean {
+  if (d.extra?.kind === 'wide') return !format.wide_is_extra_ball
+  if (d.extra?.kind === 'no_ball') return !format.no_ball_is_extra_ball
+  return true
 }
 
 /** "19.4" — the conventional overs-and-balls display, e.g. 4 balls into the
@@ -314,7 +322,10 @@ export interface NextBallContext {
   previousOverBowlerPlayerId: string | null
 }
 
-export function nextBallContext(innings: CricketInnings, ballsPerOver: number): NextBallContext {
+export function nextBallContext(
+  innings: CricketInnings,
+  format: Pick<CricketFormat, 'balls_per_over' | 'wide_is_extra_ball' | 'no_ball_is_extra_ball'>,
+): NextBallContext {
   let striker: string | null = null
   let nonStriker: string | null = null
   let bowler: string | null = null
@@ -333,7 +344,7 @@ export function nextBallContext(innings: CricketInnings, ballsPerOver: number): 
       else if (d.wicket.dismissed_player_id === nonStriker) nonStriker = null
     }
 
-    if (isLegalDelivery(d)) {
+    if (isLegalDelivery(d, format)) {
       legalInOver += 1
       const rotatingRuns =
         d.runs_off_bat + (d.extra && (d.extra.kind === 'bye' || d.extra.kind === 'leg_bye') ? d.extra.runs : 0)
@@ -344,7 +355,7 @@ export function nextBallContext(innings: CricketInnings, ballsPerOver: number): 
       if (rotatingRuns % 2 === 1) {
         ;[striker, nonStriker] = [nonStriker, striker]
       }
-      if (legalInOver === ballsPerOver) {
+      if (legalInOver === format.balls_per_over) {
         ;[striker, nonStriker] = [nonStriker, striker]
         previousOverBowler = bowler
         bowler = null

--- a/agon_ui/src/lib/matchFormat.ts
+++ b/agon_ui/src/lib/matchFormat.ts
@@ -25,6 +25,8 @@ export const DEFAULT_CRICKET_FORMAT: CricketFormat = {
   balls_per_over: 6,
   no_ball_penalty_runs: 1,
   wide_penalty_runs: 1,
+  wide_is_extra_ball: true,
+  no_ball_is_extra_ball: true,
   free_hit_after_no_ball: true,
 }
 

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -74,6 +74,19 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
     if (next?.bowlerPlayerId) setPickedBowler(null)
   }, [next?.strikerPlayerId, next?.nonStrikerPlayerId, next?.bowlerPlayerId])
 
+  // Lets the scorer step back into the opener/bowler picker after all three
+  // are picked, to fix a mis-tap — only while the innings' very first ball
+  // hasn't been recorded yet, since the picks are still purely local state at
+  // that point (nothing on the server to correct). Once a real delivery
+  // exists corrections need to go through amending/deleting that event
+  // instead (see `live_score::cricket`'s doc comment) — broader in-innings
+  // correction support is a later step.
+  const [editingOpeningPicks, setEditingOpeningPicks] = useState(false)
+  const openingPicksUnconfirmed = innings ? innings.deliveries.length === 0 : false
+  useEffect(() => {
+    if (!openingPicksUnconfirmed) setEditingOpeningPicks(false)
+  }, [openingPicksUnconfirmed])
+
   const [wicketOpen, setWicketOpen] = useState(false)
   const [extraDialog, setExtraDialog] = useState<'no_ball' | 'bye' | null>(null)
   const [endInningsOpen, setEndInningsOpen] = useState(false)
@@ -240,6 +253,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   const effectiveNonStriker = next!.nonStrikerPlayerId ?? pickedNonStriker
   const effectiveBowler = next!.bowlerPlayerId ?? pickedBowler
   const readyToScore = !!effectiveStriker && !!effectiveNonStriker && !!effectiveBowler
+  const showPickerPanel = !readyToScore || editingOpeningPicks
 
   const buildDelivery = (overrides: Partial<CricketDelivery>): CricketDelivery => ({
     over: next!.over,
@@ -259,6 +273,62 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
     appendEvent.mutate(
       { kind: 'InningsEnd', reason },
       { onSuccess: () => setEndInningsOpen(false) },
+    )
+  }
+
+  // The over quota's been fully bowled but nothing on the backend blocks
+  // further deliveries (see `match_format`'s doc comment — enforcement is
+  // intentionally out of scope there), so the picker flow would otherwise
+  // just keep asking for a new bowler forever. Steer the scorer to end the
+  // innings instead once every configured over is used up.
+  const oversComplete =
+    format.overs_per_innings != null &&
+    innings.overs.overs >= format.overs_per_innings &&
+    innings.overs.balls === 0
+
+  if (oversComplete && !next!.bowlerPlayerId) {
+    return (
+      <div className="mx-auto flex max-w-xl flex-col gap-4">
+        {header}
+        <div>
+          <h1 className="text-lg font-semibold">
+            {sideName(battingSide!, 'Side A')} vs {sideName(bowlingSide!, 'Side B')}
+          </h1>
+          <p className="text-sm text-muted-foreground">Overs complete</p>
+        </div>
+        <div className="rounded-xl border bg-card p-4">
+          <p className="text-sm font-medium">{sideName(battingSide!, 'Side A')} batting</p>
+          <p className="mt-0.5 text-3xl font-medium tracking-tight">
+            {innings.runs}/{innings.wickets}
+            <span className="ml-2 text-sm font-normal text-muted-foreground">
+              ({formatOvers(innings.overs)}/{format.overs_per_innings} ov)
+            </span>
+          </p>
+        </div>
+        <div className="rounded-xl border border-primary/30 bg-primary/5 p-4">
+          <p className="mb-3 text-sm font-medium">
+            All {format.overs_per_innings} overs bowled — end this innings to continue.
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {END_REASONS.map((r) => (
+              <Button
+                key={r.value}
+                variant="outline"
+                size="sm"
+                disabled={appendEvent.isPending}
+                onClick={() => endInnings(r.value)}
+              >
+                {r.label}
+              </Button>
+            ))}
+          </div>
+          {appendEvent.isError && (
+            <p className="mt-2 text-xs text-destructive">
+              Failed to end the innings — try again.
+            </p>
+          )}
+        </div>
+      </div>
     )
   }
 
@@ -339,16 +409,18 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
         </div>
       )}
 
-      {!readyToScore ? (
+      {showPickerPanel ? (
         <div className="rounded-xl border bg-card p-4">
           <p className="mb-3 text-sm font-medium">
-            {!effectiveBowler && (!effectiveStriker || !effectiveNonStriker)
-              ? 'New over, new batter — who is it?'
-              : !effectiveBowler
-                ? "New over — who's bowling?"
-                : 'Wicket! Who is coming in to bat?'}
+            {editingOpeningPicks && readyToScore
+              ? 'Edit your selections'
+              : !effectiveBowler && (!effectiveStriker || !effectiveNonStriker)
+                ? 'New over, new batter — who is it?'
+                : !effectiveBowler
+                  ? "New over — who's bowling?"
+                  : 'Wicket! Who is coming in to bat?'}
           </p>
-          {!effectiveStriker && (
+          {(!effectiveStriker || editingOpeningPicks) && (
             <div className="mb-3">
               <p className="mb-1.5 text-xs text-muted-foreground">Striker</p>
               <PlayerPicker
@@ -359,7 +431,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
               />
             </div>
           )}
-          {!effectiveNonStriker && (
+          {(!effectiveNonStriker || editingOpeningPicks) && (
             <div className="mb-3">
               <p className="mb-1.5 text-xs text-muted-foreground">Non-striker</p>
               <PlayerPicker
@@ -370,7 +442,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
               />
             </div>
           )}
-          {!effectiveBowler && (
+          {(!effectiveBowler || editingOpeningPicks) && (
             <div>
               <p className="mb-1.5 text-xs text-muted-foreground">Bowler</p>
               <PlayerPicker
@@ -381,9 +453,28 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
               />
             </div>
           )}
+          {editingOpeningPicks && readyToScore && (
+            <Button
+              size="sm"
+              className="mt-3"
+              onClick={() => setEditingOpeningPicks(false)}
+            >
+              Done
+            </Button>
+          )}
         </div>
       ) : (
         <div>
+          {openingPicksUnconfirmed && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mb-2 h-auto px-0 text-xs text-muted-foreground hover:bg-transparent hover:underline"
+              onClick={() => setEditingOpeningPicks(true)}
+            >
+              Edit selections
+            </Button>
+          )}
           <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Runs off this ball
           </p>

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -60,7 +60,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   const state = cricketLiveState(live.data)
   const innings = state ? currentInnings(state) : null
   const format = cricketFormat(match.format)
-  const next = innings ? nextBallContext(innings, format.balls_per_over) : null
+  const next = innings ? nextBallContext(innings, format) : null
 
   // Locally-picked openers/replacement batter/next bowler — only used until
   // the server confirms them via an actual delivery, at which point


### PR DESCRIPTION
CricketFormat gains wide_is_extra_ball and no_ball_is_extra_ball, each
defaulting to the standard rule (re-bowled as an extra delivery). Setting
either to false makes that extra count as a legal ball instead — a
casual/social variant some sides play to keep overs moving. Independent of
free_hit_after_no_ball, which already existed: Test cricket plays no-balls
as extra balls with no free hit at all, so the two aren't coupled.

Threads the new flags through CricketInnings::from_deliveries and the
live-scoring fold (same pattern as balls_per_over), and mirrors them in the
DAO record with a default-true serde fallback for matches saved before
these fields existed. Updates the live-scoring UI's next-ball prediction
and the match format editor/summary to match.