### PR TITLE
Fix cricket run-rate graph: submit deliveries via the live event log, not detailed_score

### DIFF
--- a/agon_core/src/dao/keys.rs
+++ b/agon_core/src/dao/keys.rs
@@ -163,9 +163,6 @@ pub enum Sk {
     /// corrections are later events (a `void` payload referencing an earlier
     /// seq), not edits.
     LiveEvent(u32),
-    /// Cached live-scoring state derived by folding the `LIVEEVT#` log — a
-    /// rebuildable cache, never authoritative. `#LIVESTATE`
-    LiveState,
 
     /// A score submission. `SCORESUB#<subId>` — addressed by id; time ordering
     /// is via GSI1 (`MSUBMISSIONS#<matchId>` / `<ts>#<subId>`).
@@ -209,7 +206,6 @@ impl Sk {
             Sk::Detail(_) => "DETAIL",
             Sk::Like(_) => "LIKE",
             Sk::LiveEvent(_) => "LIVEEVT",
-            Sk::LiveState => "#LIVESTATE",
             Sk::ScoreSubmission(_) => "SCORESUB",
             Sk::Comment(_) => "COMMENT",
             Sk::Reply(_) => "REPLY",
@@ -224,7 +220,7 @@ impl fmt::Display for Sk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             // Marker keys (the prefix is the whole key).
-            Sk::Profile | Sk::Meta | Sk::Guard | Sk::LiveState => write!(f, "{}", self.prefix()),
+            Sk::Profile | Sk::Meta | Sk::Guard => write!(f, "{}", self.prefix()),
 
             // Single-value keys.
             Sk::Follower(v)
@@ -265,7 +261,6 @@ impl FromStr for Sk {
             "#PROFILE" => return Ok(Sk::Profile),
             "#META" => return Ok(Sk::Meta),
             "#GUARD" => return Ok(Sk::Guard),
-            "#LIVESTATE" => return Ok(Sk::LiveState),
             _ => {}
         }
 
@@ -350,7 +345,6 @@ mod tests {
         sk_roundtrip(Sk::Profile, "#PROFILE");
         sk_roundtrip(Sk::Meta, "#META");
         sk_roundtrip(Sk::Guard, "#GUARD");
-        sk_roundtrip(Sk::LiveState, "#LIVESTATE");
     }
 
     #[test]

--- a/agon_core/src/dao/keys.rs
+++ b/agon_core/src/dao/keys.rs
@@ -163,6 +163,11 @@ pub enum Sk {
     /// corrections are later events (a `void` payload referencing an earlier
     /// seq), not edits.
     LiveEvent(u32),
+    /// Cached live-scoring summary derived by folding the `LIVEEVT#` log — a
+    /// rebuildable cache, never authoritative, and fixed-size regardless of
+    /// match length (see `agon_service::live_score::cricket::CricketLiveState`).
+    /// `#LIVESTATE`
+    LiveState,
 
     /// A score submission. `SCORESUB#<subId>` — addressed by id; time ordering
     /// is via GSI1 (`MSUBMISSIONS#<matchId>` / `<ts>#<subId>`).
@@ -206,6 +211,7 @@ impl Sk {
             Sk::Detail(_) => "DETAIL",
             Sk::Like(_) => "LIKE",
             Sk::LiveEvent(_) => "LIVEEVT",
+            Sk::LiveState => "#LIVESTATE",
             Sk::ScoreSubmission(_) => "SCORESUB",
             Sk::Comment(_) => "COMMENT",
             Sk::Reply(_) => "REPLY",
@@ -220,7 +226,7 @@ impl fmt::Display for Sk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             // Marker keys (the prefix is the whole key).
-            Sk::Profile | Sk::Meta | Sk::Guard => write!(f, "{}", self.prefix()),
+            Sk::Profile | Sk::Meta | Sk::Guard | Sk::LiveState => write!(f, "{}", self.prefix()),
 
             // Single-value keys.
             Sk::Follower(v)
@@ -261,6 +267,7 @@ impl FromStr for Sk {
             "#PROFILE" => return Ok(Sk::Profile),
             "#META" => return Ok(Sk::Meta),
             "#GUARD" => return Ok(Sk::Guard),
+            "#LIVESTATE" => return Ok(Sk::LiveState),
             _ => {}
         }
 
@@ -345,6 +352,7 @@ mod tests {
         sk_roundtrip(Sk::Profile, "#PROFILE");
         sk_roundtrip(Sk::Meta, "#META");
         sk_roundtrip(Sk::Guard, "#GUARD");
+        sk_roundtrip(Sk::LiveState, "#LIVESTATE");
     }
 
     #[test]

--- a/agon_core/src/dao/keys.rs
+++ b/agon_core/src/dao/keys.rs
@@ -163,11 +163,6 @@ pub enum Sk {
     /// corrections are later events (a `void` payload referencing an earlier
     /// seq), not edits.
     LiveEvent(u32),
-    /// Cached live-scoring summary derived by folding the `LIVEEVT#` log — a
-    /// rebuildable cache, never authoritative, and fixed-size regardless of
-    /// match length (see `agon_service::live_score::cricket::CricketLiveState`).
-    /// `#LIVESTATE`
-    LiveState,
 
     /// A score submission. `SCORESUB#<subId>` — addressed by id; time ordering
     /// is via GSI1 (`MSUBMISSIONS#<matchId>` / `<ts>#<subId>`).
@@ -211,7 +206,6 @@ impl Sk {
             Sk::Detail(_) => "DETAIL",
             Sk::Like(_) => "LIKE",
             Sk::LiveEvent(_) => "LIVEEVT",
-            Sk::LiveState => "#LIVESTATE",
             Sk::ScoreSubmission(_) => "SCORESUB",
             Sk::Comment(_) => "COMMENT",
             Sk::Reply(_) => "REPLY",
@@ -226,7 +220,7 @@ impl fmt::Display for Sk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             // Marker keys (the prefix is the whole key).
-            Sk::Profile | Sk::Meta | Sk::Guard | Sk::LiveState => write!(f, "{}", self.prefix()),
+            Sk::Profile | Sk::Meta | Sk::Guard => write!(f, "{}", self.prefix()),
 
             // Single-value keys.
             Sk::Follower(v)
@@ -267,7 +261,6 @@ impl FromStr for Sk {
             "#PROFILE" => return Ok(Sk::Profile),
             "#META" => return Ok(Sk::Meta),
             "#GUARD" => return Ok(Sk::Guard),
-            "#LIVESTATE" => return Ok(Sk::LiveState),
             _ => {}
         }
 
@@ -352,7 +345,6 @@ mod tests {
         sk_roundtrip(Sk::Profile, "#PROFILE");
         sk_roundtrip(Sk::Meta, "#META");
         sk_roundtrip(Sk::Guard, "#GUARD");
-        sk_roundtrip(Sk::LiveState, "#LIVESTATE");
     }
 
     #[test]

--- a/agon_core/src/dao/live_score_ops.rs
+++ b/agon_core/src/dao/live_score_ops.rs
@@ -1,10 +1,15 @@
 //! Live-scoring event log: batched, transactional append with optimistic
-//! concurrency (so an offline device can catch up safely), direct
-//! delete/amend for corrections, plus the derived state cache.
+//! concurrency (so an offline device can catch up safely), plus direct
+//! delete/amend for corrections.
 //!
-//! The event log (`LIVEEVT#<seq>`) is the source of truth; `#LIVESTATE` is a
-//! rebuildable cache, never trusted as authoritative on its own. Corrections
-//! are direct mutations of the log — `delete_live_event` removes an item
+//! The event log (`LIVEEVT#<seq>`) is the sole source of truth — one item per
+//! event, with no per-item size ceiling regardless of how long a match runs.
+//! There's deliberately no separate cache of the derived state: folding the
+//! log is cheap enough to do on every read (`agon_service`'s
+//! `derive_live_snapshot`), and a cache here would just be a second place a
+//! large match's data could hit DynamoDB's item size cap — the very problem
+//! this log's one-item-per-event shape exists to avoid. Corrections are
+//! direct mutations of the log — `delete_live_event` removes an item
 //! outright, `amend_live_event` overwrites its payload in place — not a
 //! layered "this is void" marker to filter out on every read.
 
@@ -15,12 +20,11 @@ use aws_sdk_dynamodb::types::{AttributeValue, Put, TransactWriteItem, Update};
 
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
-use super::item::{ATTR_PK, ATTR_SK, from_item, s, to_item};
+use super::item::{ATTR_PK, ATTR_SK, s, to_item};
 use super::keys::{Pk, Sk};
-use super::records::{LiveEventPayloadRecord, LiveEventRecord, LiveStateRecord};
+use super::records::{LiveEventPayloadRecord, LiveEventRecord};
 
 pub const TYPE_LIVE_EVENT: &str = "live_event";
-pub const TYPE_LIVE_STATE: &str = "live_state";
 
 /// DynamoDB caps `TransactWriteItems` at 100 items per call. One of those is
 /// the seq-counter reservation, leaving this many for the events themselves.
@@ -194,48 +198,13 @@ impl Dao {
     }
 
     /// Read every live event in the match's log, in seq order. Drains all
-    /// query pages — event logs are small (low hundreds at most for a single
-    /// match) so this is never a 1 MB-page concern.
+    /// query pages, so this stays correct regardless of how many events a
+    /// match accumulates (a full multi-innings, unlimited-overs match can run
+    /// to thousands) — each is its own small item, so there's no per-item
+    /// size concern the way one record holding the whole log would have.
     pub async fn list_live_events(&self, match_id: &str) -> DaoResult<Vec<LiveEventRecord>> {
         self.query_match_collection(match_id, Sk::LiveEvent(0).prefix())
             .await
-    }
-
-    /// Fetch the cached derived live state. `None` if never computed.
-    pub async fn get_live_state(&self, match_id: &str) -> DaoResult<Option<LiveStateRecord>> {
-        let out = self
-            .client
-            .get_item()
-            .table_name(self.table())
-            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
-            .key(ATTR_SK, s(Sk::LiveState.to_string()))
-            .send()
-            .await
-            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
-        match out.item {
-            Some(item) => Ok(Some(from_item(item)?)),
-            None => Ok(None),
-        }
-    }
-
-    /// Write (overwrite) the cached derived live state. Best-effort: never
-    /// part of the append transaction, always safely recomputable from the
-    /// log, so a failure here doesn't need to roll back the append.
-    pub async fn put_live_state(&self, match_id: &str, state: &LiveStateRecord) -> DaoResult<()> {
-        let item = to_item(
-            &Pk::Match(match_id.into()),
-            &Sk::LiveState,
-            TYPE_LIVE_STATE,
-            state,
-        )?;
-        self.client
-            .put_item()
-            .table_name(self.table())
-            .set_item(Some(item))
-            .send()
-            .await
-            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
-        Ok(())
     }
 }
 

--- a/agon_core/src/dao/live_score_ops.rs
+++ b/agon_core/src/dao/live_score_ops.rs
@@ -1,19 +1,14 @@
 //! Live-scoring event log: batched, transactional append with optimistic
-//! concurrency (so an offline device can catch up safely), direct
-//! delete/amend for corrections, plus a cache of the derived summary.
+//! concurrency (so an offline device can catch up safely), plus direct
+//! delete/amend for corrections.
 //!
 //! The event log (`LIVEEVT#<seq>`) is the sole source of truth — one item per
 //! event, with no per-item size ceiling regardless of how long a match runs.
-//! `#LIVESTATE` is a *fixed-size* cache of the folded summary
-//! (`agon_service::live_score::cricket::CricketLiveState`; see its own docs
-//! for why it stays small no matter how long the match runs), rebuilt from
-//! the log on every append and never trusted as authoritative on its own —
-//! unlike the full per-innings scorecard (batting/bowling cards), which is
-//! never cached here at all and only ever computed once, when a match
-//! completes (see `agon_service::live_score::cricket::fold_full_scorecard`).
-//! Corrections are direct mutations of the log — `delete_live_event` removes
-//! an item outright, `amend_live_event` overwrites its payload in place —
-//! not a layered "this is void" marker to filter out on every read.
+//! The derived scorecard it folds into lives in `MatchDetailedScoreRecord`
+//! (`DETAIL#<sport>`) — see that record's doc comment. Corrections are
+//! direct mutations of the log — `delete_live_event` removes an item
+//! outright, `amend_live_event` overwrites its payload in place — not a
+//! layered "this is void" marker to filter out on every read.
 
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::delete_item::DeleteItemError;
@@ -22,13 +17,12 @@ use aws_sdk_dynamodb::types::{AttributeValue, Put, TransactWriteItem, Update};
 
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
-use super::item::{ATTR_PK, ATTR_SK, from_item, s, to_item};
+use super::item::{ATTR_PK, ATTR_SK, s, to_item};
 use super::keys::{Pk, Sk};
 use super::page::Page;
-use super::records::{LiveEventPayloadRecord, LiveEventRecord, LiveStateRecord};
+use super::records::{LiveEventPayloadRecord, LiveEventRecord};
 
 pub const TYPE_LIVE_EVENT: &str = "live_event";
-pub const TYPE_LIVE_STATE: &str = "live_state";
 
 /// DynamoDB caps `TransactWriteItems` at 100 items per call. One of those is
 /// the seq-counter reservation, leaving this many for the events themselves.
@@ -234,45 +228,6 @@ impl Dao {
             limit,
         )
         .await
-    }
-
-    /// Fetch the cached derived live summary. `None` if never computed.
-    pub async fn get_live_state(&self, match_id: &str) -> DaoResult<Option<LiveStateRecord>> {
-        let out = self
-            .client
-            .get_item()
-            .table_name(self.table())
-            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
-            .key(ATTR_SK, s(Sk::LiveState.to_string()))
-            .send()
-            .await
-            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
-        match out.item {
-            Some(item) => Ok(Some(from_item(item)?)),
-            None => Ok(None),
-        }
-    }
-
-    /// Write (overwrite) the cached derived live summary. Best-effort: never
-    /// part of the append transaction, always safely recomputable from the
-    /// log, so a failure here doesn't need to roll back the append. Safe to
-    /// call on every single delivery — the summary is fixed-size regardless
-    /// of match length (see the module docs).
-    pub async fn put_live_state(&self, match_id: &str, state: &LiveStateRecord) -> DaoResult<()> {
-        let item = to_item(
-            &Pk::Match(match_id.into()),
-            &Sk::LiveState,
-            TYPE_LIVE_STATE,
-            state,
-        )?;
-        self.client
-            .put_item()
-            .table_name(self.table())
-            .set_item(Some(item))
-            .send()
-            .await
-            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
-        Ok(())
     }
 }
 

--- a/agon_core/src/dao/live_score_ops.rs
+++ b/agon_core/src/dao/live_score_ops.rs
@@ -1,17 +1,19 @@
 //! Live-scoring event log: batched, transactional append with optimistic
-//! concurrency (so an offline device can catch up safely), plus direct
-//! delete/amend for corrections.
+//! concurrency (so an offline device can catch up safely), direct
+//! delete/amend for corrections, plus a cache of the derived summary.
 //!
 //! The event log (`LIVEEVT#<seq>`) is the sole source of truth — one item per
 //! event, with no per-item size ceiling regardless of how long a match runs.
-//! There's deliberately no separate cache of the derived state: folding the
-//! log is cheap enough to do on every read (`agon_service`'s
-//! `derive_live_snapshot`), and a cache here would just be a second place a
-//! large match's data could hit DynamoDB's item size cap — the very problem
-//! this log's one-item-per-event shape exists to avoid. Corrections are
-//! direct mutations of the log — `delete_live_event` removes an item
-//! outright, `amend_live_event` overwrites its payload in place — not a
-//! layered "this is void" marker to filter out on every read.
+//! `#LIVESTATE` is a *fixed-size* cache of the folded summary
+//! (`agon_service::live_score::cricket::CricketLiveState`; see its own docs
+//! for why it stays small no matter how long the match runs), rebuilt from
+//! the log on every append and never trusted as authoritative on its own —
+//! unlike the full per-innings scorecard (batting/bowling cards), which is
+//! never cached here at all and only ever computed once, when a match
+//! completes (see `agon_service::live_score::cricket::fold_full_scorecard`).
+//! Corrections are direct mutations of the log — `delete_live_event` removes
+//! an item outright, `amend_live_event` overwrites its payload in place —
+//! not a layered "this is void" marker to filter out on every read.
 
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::delete_item::DeleteItemError;
@@ -20,11 +22,13 @@ use aws_sdk_dynamodb::types::{AttributeValue, Put, TransactWriteItem, Update};
 
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
-use super::item::{ATTR_PK, ATTR_SK, s, to_item};
+use super::item::{ATTR_PK, ATTR_SK, from_item, s, to_item};
 use super::keys::{Pk, Sk};
-use super::records::{LiveEventPayloadRecord, LiveEventRecord};
+use super::page::Page;
+use super::records::{LiveEventPayloadRecord, LiveEventRecord, LiveStateRecord};
 
 pub const TYPE_LIVE_EVENT: &str = "live_event";
+pub const TYPE_LIVE_STATE: &str = "live_state";
 
 /// DynamoDB caps `TransactWriteItems` at 100 items per call. One of those is
 /// the seq-counter reservation, leaving this many for the events themselves.
@@ -202,9 +206,73 @@ impl Dao {
     /// match accumulates (a full multi-innings, unlimited-overs match can run
     /// to thousands) — each is its own small item, so there's no per-item
     /// size concern the way one record holding the whole log would have.
+    /// Internal use only (folding the whole log) — the public API paginates
+    /// via `list_live_events_page` instead of ever returning this whole.
     pub async fn list_live_events(&self, match_id: &str) -> DaoResult<Vec<LiveEventRecord>> {
         self.query_match_collection(match_id, Sk::LiveEvent(0).prefix())
             .await
+    }
+
+    /// One page of the match's live event log, oldest first (`seq` order —
+    /// the zero-padded key sorts numerically). What `GET
+    /// /matches/:id/live/events` actually serves.
+    pub async fn list_live_events_page(
+        &self,
+        match_id: &str,
+        cursor: Option<&str>,
+        limit: u32,
+    ) -> DaoResult<Page<LiveEventRecord>> {
+        self.query_page(
+            self.client
+                .query()
+                .table_name(self.table())
+                .key_condition_expression("#pk = :pk AND begins_with(SK, :sk)")
+                .expression_attribute_names("#pk", ATTR_PK)
+                .expression_attribute_values(":pk", s(Pk::Match(match_id.into()).to_string()))
+                .expression_attribute_values(":sk", s(Sk::LiveEvent(0).prefix())),
+            cursor,
+            limit,
+        )
+        .await
+    }
+
+    /// Fetch the cached derived live summary. `None` if never computed.
+    pub async fn get_live_state(&self, match_id: &str) -> DaoResult<Option<LiveStateRecord>> {
+        let out = self
+            .client
+            .get_item()
+            .table_name(self.table())
+            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
+            .key(ATTR_SK, s(Sk::LiveState.to_string()))
+            .send()
+            .await
+            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+        match out.item {
+            Some(item) => Ok(Some(from_item(item)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Write (overwrite) the cached derived live summary. Best-effort: never
+    /// part of the append transaction, always safely recomputable from the
+    /// log, so a failure here doesn't need to roll back the append. Safe to
+    /// call on every single delivery — the summary is fixed-size regardless
+    /// of match length (see the module docs).
+    pub async fn put_live_state(&self, match_id: &str, state: &LiveStateRecord) -> DaoResult<()> {
+        let item = to_item(
+            &Pk::Match(match_id.into()),
+            &Sk::LiveState,
+            TYPE_LIVE_STATE,
+            state,
+        )?;
+        self.client
+            .put_item()
+            .table_name(self.table())
+            .set_item(Some(item))
+            .send()
+            .await
+            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+        Ok(())
     }
 }
 

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -374,18 +374,29 @@ pub struct MatchPlayerRecord {
     pub invitation: Option<EmbeddedInvitationRecord>,
 }
 
-/// `MATCH#<matchId>` / `DETAIL#<sport>` — the sport-specific detailed score.
+/// `MATCH#<matchId>` / `DETAIL#<sport>` — the match's detailed score: live or
+/// finished, the same record either way (see `agon_service::detailed_score`'s
+/// module docs). A cricket match being scored live keeps this up to date
+/// incrementally, one delivery at a time; a manually-entered match (or one
+/// past its last live event) just has it written directly.
 ///
 /// The `detail` payload is intentionally `serde_json::Value`: it is a large,
-/// deeply-nested, sport-polymorphic blob (a full cricket scorecard with
-/// ball-by-ball deliveries, or a football event timeline) that the DAO only ever
-/// stores and returns verbatim — it never reads inside it. Typing it would mean
-/// porting the entire detailed-score union into the DAO for zero benefit here.
-/// This is the one deliberate exception to the "type everything" rule.
+/// deeply-nested, sport-polymorphic blob (a full cricket scorecard, or a
+/// football event timeline) that the DAO only ever stores and returns
+/// verbatim — it never reads inside it. Typing it would mean porting the
+/// entire detailed-score union into the DAO for zero benefit here. This is
+/// the one deliberate exception to the "type everything" rule.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct MatchDetailedScoreRecord {
     pub sport: String,
     pub detail: serde_json::Value,
+    /// The seq of the last live event folded into `detail`, if any — `None`
+    /// for a match with no live event log behind this record (manual
+    /// entry). Lets an incremental update confirm this is caught up to
+    /// exactly the start of the new batch before applying it, and lets a
+    /// reader know whether to trust this over a fresh derive.
+    #[serde(default)]
+    pub last_seq: Option<u32>,
 }
 
 /// `MATCH#<matchId>` / `LIVEEVT#<seq>` — one live-scoring event, in append
@@ -580,23 +591,6 @@ pub enum InningsEndReasonRecord {
     OversComplete,
     Declared,
     TargetReached,
-}
-
-/// `MATCH#<matchId>` / `#LIVESTATE` — cached live-scoring summary, derived by
-/// folding the `LIVEEVT#` log. A cache, not a source of truth: safe to
-/// recompute or go briefly stale (e.g. after a crash between an event write
-/// and the cache rewrite) — the next append recomputes it from the full log.
-/// Unlike `MatchDetailedScoreRecord`, this one is fixed-size regardless of
-/// match length (see `agon_service::live_score::cricket::CricketLiveState`),
-/// which is what makes it safe to rewrite on every single delivery. `state`
-/// is opaque per the same rule as `MatchDetailedScoreRecord.detail`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LiveStateRecord {
-    pub sport: String,
-    pub state: serde_json::Value,
-    /// The seq of the last event folded into `state`, so a reader can tell
-    /// whether the cache might be behind the current log tip.
-    pub last_seq: u32,
 }
 
 /// `MATCH#<matchId>` / `SCORESUB#<ts>#<subId>` — a score submission and its

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -582,6 +582,23 @@ pub enum InningsEndReasonRecord {
     TargetReached,
 }
 
+/// `MATCH#<matchId>` / `#LIVESTATE` — cached live-scoring summary, derived by
+/// folding the `LIVEEVT#` log. A cache, not a source of truth: safe to
+/// recompute or go briefly stale (e.g. after a crash between an event write
+/// and the cache rewrite) — the next append recomputes it from the full log.
+/// Unlike `MatchDetailedScoreRecord`, this one is fixed-size regardless of
+/// match length (see `agon_service::live_score::cricket::CricketLiveState`),
+/// which is what makes it safe to rewrite on every single delivery. `state`
+/// is opaque per the same rule as `MatchDetailedScoreRecord.detail`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LiveStateRecord {
+    pub sport: String,
+    pub state: serde_json::Value,
+    /// The seq of the last event folded into `state`, so a reader can tell
+    /// whether the cache might be behind the current log tip.
+    pub last_seq: u32,
+}
+
 /// `MATCH#<matchId>` / `SCORESUB#<ts>#<subId>` — a score submission and its
 /// responses. Score and responses are opaque JSON.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -582,20 +582,6 @@ pub enum InningsEndReasonRecord {
     TargetReached,
 }
 
-/// `MATCH#<matchId>` / `#LIVESTATE` — cached live-scoring state, derived by
-/// folding the `LIVEEVT#` log. A cache, not a source of truth: safe to
-/// recompute or go briefly stale (e.g. after a crash between an event write
-/// and the cache rewrite) — the next append recomputes it from the full log.
-/// `state` is opaque per the same rule as `MatchDetailedScoreRecord.detail`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LiveStateRecord {
-    pub sport: String,
-    pub state: serde_json::Value,
-    /// The seq of the last event folded into `state`, so a reader can tell
-    /// whether the cache might be behind the current log tip.
-    pub last_seq: u32,
-}
-
 /// `MATCH#<matchId>` / `SCORESUB#<ts>#<subId>` — a score submission and its
 /// responses. Score and responses are opaque JSON.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/agon_service/src/detailed_score/cricket.rs
+++ b/agon_service/src/detailed_score/cricket.rs
@@ -1,10 +1,82 @@
 use poem_openapi::{Enum, Object};
 
-/// Full cricket scorecard: one entry per innings, each with batting and
-/// bowling cards plus the extras/fall-of-wicket detail.
+/// A match's full cricket detail — live or finished, the same shape either
+/// way. `innings` covers the whole match so far (batting/bowling cards,
+/// extras, fall-of-wickets — bounded by roster size, not ball count, so it
+/// stays small regardless of match length). `recent_deliveries` and
+/// `next_ball_context` describe only the *current* innings, and are `None`
+/// once there isn't one (between innings, or the match is over) — there's
+/// nothing "next" to give context for.
+///
+/// A match scored ball-by-ball (live, in-app) builds this incrementally, one
+/// delivery at a time (see `live_score::cricket::apply_delivery`), from the
+/// event log — which is *not* part of this record. It's already stored one
+/// item per ball in the match's live event log, which has no practical size
+/// ceiling; duplicating it here would mean a second, much larger copy
+/// embedded in this single record, risking DynamoDB's per-item size cap on a
+/// long match. A finished match's complete ball-by-ball history reads that
+/// log directly (paginated — `GET /matches/:id/live/events`) instead of
+/// this record.
 #[derive(Object)]
 pub struct CricketDetail {
     pub innings: Vec<CricketInnings>,
+    pub recent_deliveries: Option<Vec<CricketDelivery>>,
+    pub next_ball_context: Option<NextBallContext>,
+    /// True once the log's last innings has ended and no following one has
+    /// started yet (i.e. between innings, or nothing's been recorded).
+    pub awaiting_next_innings: bool,
+}
+
+/// How many balls back `CricketDetail.recent_deliveries` keeps for the "this
+/// over"/recent-balls row — enough to show a bit more than the current over,
+/// nowhere near a whole innings.
+pub const RECENT_DELIVERIES_LIMIT: usize = 18;
+
+/// What's known about who's at the crease/bowling for the *next* delivery,
+/// folded incrementally as events are recorded. A `None` field means the
+/// scorer needs to pick someone before the next ball can be recorded —
+/// either a fresh innings (nothing bowled yet), a wicket just fell (the
+/// dismissed batter's slot is open), or an over just completed (a new
+/// bowler is required; the same bowler can't bowl consecutive overs).
+///
+/// Mirrors `agon_ui/src/lib/cricketScore.ts`'s `NextBallContext` field-for-
+/// field and step-for-step — kept in sync by hand. The frontend runs the
+/// identical fold offline, against deliveries a device has recorded locally
+/// but not yet synced, which is exactly the case this incremental (one
+/// delivery at a time) shape is built for: apply one step to the last-known
+/// context, don't replay history.
+#[derive(Object, Clone)]
+pub struct NextBallContext {
+    pub striker_player_id: Option<String>,
+    pub non_striker_player_id: Option<String>,
+    pub bowler_player_id: Option<String>,
+    /// 0-based over index the next delivery belongs to.
+    pub over: u32,
+    /// 1-based ball number within that over.
+    pub ball: u32,
+    /// The bowler who just finished an over — excluded from the next-bowler
+    /// picker. `None` unless a bowler pick is actually needed.
+    pub previous_over_bowler_player_id: Option<String>,
+    /// Runs conceded so far in the *current* over (resets to 0 at each over
+    /// boundary) — what decides whether the over that just completed was a
+    /// maiden, without needing to look back at the deliveries that made it
+    /// up. Also just useful on its own for a live "this over: 4 runs" read.
+    pub runs_conceded_this_over: u32,
+}
+
+impl NextBallContext {
+    /// The state before any delivery has been recorded in an innings.
+    pub fn opening() -> Self {
+        NextBallContext {
+            striker_player_id: None,
+            non_striker_player_id: None,
+            bowler_player_id: None,
+            over: 0,
+            ball: 1,
+            previous_over_bowler_player_id: None,
+            runs_conceded_this_over: 0,
+        }
+    }
 }
 
 /// A count of overs bowled/faced: whole overs plus balls into the current
@@ -22,18 +94,10 @@ pub struct Overs {
     pub balls: u32,
 }
 
-/// A cricket innings supports two tiers of fidelity:
-///   1. Minimal — just `runs`/`wickets`/`overs`, leaving the cards empty.
-///   2. Scorecard — full per-player `batting`/`bowling` cards.
-///
-/// A match scored ball-by-ball (live, in-app) reaches this via
-/// `from_deliveries`, folding a delivery log into the same shape — but that
-/// log itself isn't part of it. It's already stored one item per ball in the
-/// match's live event log (`live_score::cricket`), which has no practical
-/// size ceiling; duplicating it here would mean a second, much larger copy
-/// embedded in this single record, risking DynamoDB's per-item size cap on a
-/// long match. `live_score::cricket::CricketLiveInnings` is the equivalent
-/// shape that does carry deliveries, for the one place that needs them.
+/// One innings' full detail: totals, batting/bowling cards, extras, and
+/// fall-of-wickets. Bounded by roster size (how many players batted/bowled),
+/// not ball count, so it stays small regardless of how long the innings runs
+/// — safe to keep in `CricketDetail` and update on every single delivery.
 #[derive(Object)]
 pub struct CricketInnings {
     /// The batting side for this innings (references MatchSide.id).
@@ -52,6 +116,29 @@ pub struct CricketInnings {
     pub bowling: Vec<CricketBowlingEntry>,
     pub extras: CricketExtras,
     pub fall_of_wickets: Vec<CricketFallOfWicket>,
+}
+
+impl CricketInnings {
+    pub fn opening(batting_side_id: String, bowling_side_id: String) -> Self {
+        CricketInnings {
+            batting_side_id,
+            bowling_side_id,
+            runs: 0,
+            wickets: 0,
+            overs: Overs { overs: 0, balls: 0 },
+            declared: false,
+            batting: Vec::new(),
+            bowling: Vec::new(),
+            extras: CricketExtras {
+                byes: 0,
+                leg_byes: 0,
+                wides: 0,
+                no_balls: 0,
+                penalty: 0,
+            },
+            fall_of_wickets: Vec::new(),
+        }
+    }
 }
 
 /// A single delivery (ball) in an innings. The atomic unit of in-app scoring.
@@ -181,7 +268,7 @@ pub struct CricketFallOfWicket {
     pub overs: Option<Overs>,
 }
 
-/// Cricket scoring rules encoded by the aggregator below:
+/// Cricket scoring rules encoded by `live_score::cricket::apply_delivery`:
 /// - A delivery is *legal* (counts toward overs and balls faced) unless it is a
 ///   wide or no-ball.
 /// - `runs_off_bat` is credited to the striker and the team total.
@@ -191,7 +278,7 @@ pub struct CricketFallOfWicket {
 ///   or hit-wicket; run-outs and retirements are not.
 /// - A maiden is an over in which the bowler concedes no runs (byes/leg-byes do
 ///   not count against the bowler, so they do not break a maiden).
-fn dismissal_credited_to_bowler(kind: &CricketDismissalKind) -> bool {
+pub(crate) fn dismissal_credited_to_bowler(kind: &CricketDismissalKind) -> bool {
     matches!(
         kind,
         CricketDismissalKind::Bowled
@@ -221,7 +308,7 @@ pub(crate) fn is_legal_delivery(
 
 /// Runs charged to the bowler for a delivery: runs off the bat plus wides and
 /// no-balls. Byes, leg-byes and penalties are not the bowler's responsibility.
-fn runs_charged_to_bowler(delivery: &CricketDelivery) -> u32 {
+pub(crate) fn runs_charged_to_bowler(delivery: &CricketDelivery) -> u32 {
     let extra = delivery
         .extra
         .as_ref()
@@ -238,394 +325,5 @@ pub(crate) fn balls_to_overs(balls: u32, balls_per_over: u32) -> Overs {
     Overs {
         overs: balls / balls_per_over,
         balls: balls % balls_per_over,
-    }
-}
-
-impl CricketInnings {
-    /// Builds the innings overview (totals, batting/bowling cards, extras,
-    /// fall-of-wickets) from a ball-by-ball delivery log.
-    /// `balls_per_over`, `wide_is_extra_ball` and `no_ball_is_extra_ball` are
-    /// the match's configured over length and extra-ball rules (see
-    /// `agon_service::match_format::CricketFormat`) — the only pieces of
-    /// match format the DAO-agnostic scoring math actually needs, so they're
-    /// threaded in as plain arguments rather than the whole format.
-    pub fn from_deliveries(
-        batting_side_id: String,
-        bowling_side_id: String,
-        declared: bool,
-        deliveries: &[CricketDelivery],
-        balls_per_over: u32,
-        wide_is_extra_ball: bool,
-        no_ball_is_extra_ball: bool,
-    ) -> Self {
-        // First-appearance-ordered accumulators keyed by player_id.
-        let mut batting: Vec<CricketBattingEntry> = Vec::new();
-        let mut bowling: Vec<CricketBowlingEntry> = Vec::new();
-        let mut extras = CricketExtras {
-            byes: 0,
-            leg_byes: 0,
-            wides: 0,
-            no_balls: 0,
-            penalty: 0,
-        };
-        let mut fall_of_wickets: Vec<CricketFallOfWicket> = Vec::new();
-        let mut total_runs: u32 = 0;
-        let mut wickets: u32 = 0;
-        let mut legal_balls: u32 = 0;
-        // (bowler_player_id, over) -> runs charged, to detect maidens.
-        let mut over_runs: Vec<((String, u32), u32)> = Vec::new();
-
-        fn batter<'a>(
-            batting: &'a mut Vec<CricketBattingEntry>,
-            player_id: &str,
-        ) -> &'a mut CricketBattingEntry {
-            if let Some(pos) = batting.iter().position(|b| b.player_id == player_id) {
-                &mut batting[pos]
-            } else {
-                batting.push(CricketBattingEntry {
-                    player_id: player_id.to_string(),
-                    runs: 0,
-                    balls_faced: 0,
-                    fours: 0,
-                    sixes: 0,
-                    dismissal: None,
-                    batting_position: Some(batting.len() as u32 + 1),
-                });
-                batting.last_mut().unwrap()
-            }
-        }
-
-        fn bowler<'a>(
-            bowling: &'a mut Vec<CricketBowlingEntry>,
-            player_id: &str,
-        ) -> &'a mut CricketBowlingEntry {
-            if let Some(pos) = bowling.iter().position(|b| b.player_id == player_id) {
-                &mut bowling[pos]
-            } else {
-                bowling.push(CricketBowlingEntry {
-                    player_id: player_id.to_string(),
-                    overs: Overs { overs: 0, balls: 0 },
-                    maidens: 0,
-                    runs_conceded: 0,
-                    wickets: 0,
-                    wides: 0,
-                    no_balls: 0,
-                });
-                bowling.last_mut().unwrap()
-            }
-        }
-
-        for delivery in deliveries {
-            let legal = is_legal_delivery(delivery, wide_is_extra_ball, no_ball_is_extra_ball);
-            let charged = runs_charged_to_bowler(delivery);
-            let extra_runs = delivery.extra.as_ref().map(|e| e.runs).unwrap_or(0);
-
-            total_runs += delivery.runs_off_bat + extra_runs;
-            if legal {
-                legal_balls += 1;
-            }
-
-            // Batting: striker is credited runs off the bat and faces legal
-            // balls and no-balls (but not wides).
-            {
-                let b = batter(&mut batting, &delivery.striker_player_id);
-                b.runs += delivery.runs_off_bat;
-                let faced_ball = !matches!(
-                    delivery.extra.as_ref().map(|e| &e.kind),
-                    Some(CricketExtraKind::Wide)
-                );
-                if faced_ball {
-                    b.balls_faced += 1;
-                }
-                match delivery.runs_off_bat {
-                    4 => b.fours += 1,
-                    6 => b.sixes += 1,
-                    _ => {}
-                }
-            }
-
-            // Bowling figures.
-            {
-                let bw = bowler(&mut bowling, &delivery.bowler_player_id);
-                bw.runs_conceded += charged;
-                if let Some(extra) = &delivery.extra {
-                    match extra.kind {
-                        CricketExtraKind::Wide => bw.wides += 1,
-                        CricketExtraKind::NoBall => bw.no_balls += 1,
-                        _ => {}
-                    }
-                }
-            }
-
-            // Track runs per bowler-over for maiden detection.
-            let key = (delivery.bowler_player_id.clone(), delivery.over);
-            if let Some(entry) = over_runs.iter_mut().find(|(k, _)| *k == key) {
-                entry.1 += charged;
-            } else {
-                over_runs.push((key, charged));
-            }
-
-            // Extras breakdown.
-            if let Some(extra) = &delivery.extra {
-                match extra.kind {
-                    CricketExtraKind::Bye => extras.byes += extra.runs,
-                    CricketExtraKind::LegBye => extras.leg_byes += extra.runs,
-                    CricketExtraKind::Wide => extras.wides += extra.runs,
-                    CricketExtraKind::NoBall => extras.no_balls += extra.runs,
-                    CricketExtraKind::Penalty => extras.penalty += extra.runs,
-                }
-            }
-
-            // Wicket.
-            if let Some(wicket) = &delivery.wicket {
-                wickets += 1;
-                fall_of_wickets.push(CricketFallOfWicket {
-                    wicket: wickets,
-                    runs: total_runs,
-                    player_id: wicket.dismissed_player_id.clone(),
-                    overs: Some(balls_to_overs(legal_balls, balls_per_over)),
-                });
-                if dismissal_credited_to_bowler(&wicket.kind) {
-                    bowler(&mut bowling, &delivery.bowler_player_id).wickets += 1;
-                }
-                let b = batter(&mut batting, &wicket.dismissed_player_id);
-                b.dismissal = Some(CricketDismissal {
-                    kind: wicket.kind.clone(),
-                    bowler_player_id: wicket.bowler_player_id.clone(),
-                    fielder_player_id: wicket.fielder_player_id.clone(),
-                });
-            }
-        }
-
-        // Per-bowler overs and maidens.
-        for bw in &mut bowling {
-            let balls: u32 = deliveries
-                .iter()
-                .filter(|d| {
-                    d.bowler_player_id == bw.player_id
-                        && is_legal_delivery(d, wide_is_extra_ball, no_ball_is_extra_ball)
-                })
-                .count() as u32;
-            bw.overs = balls_to_overs(balls, balls_per_over);
-            bw.maidens = over_runs
-                .iter()
-                .filter(|((bowler_id, _), runs)| *bowler_id == bw.player_id && *runs == 0)
-                .count() as u32;
-        }
-
-        CricketInnings {
-            batting_side_id,
-            bowling_side_id,
-            runs: total_runs,
-            wickets,
-            overs: balls_to_overs(legal_balls, balls_per_over),
-            declared,
-            batting,
-            bowling,
-            extras,
-            fall_of_wickets,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// A plain run-scoring delivery (no extra, no wicket).
-    fn ball(
-        over: u32,
-        ball: u32,
-        bowler: &str,
-        striker: &str,
-        non_striker: &str,
-        runs: u32,
-    ) -> CricketDelivery {
-        CricketDelivery {
-            over,
-            ball,
-            bowler_player_id: bowler.to_string(),
-            striker_player_id: striker.to_string(),
-            non_striker_player_id: non_striker.to_string(),
-            runs_off_bat: runs,
-            extra: None,
-            wicket: None,
-        }
-    }
-
-    #[test]
-    fn aggregates_overview_from_deliveries() {
-        // One over from bowler B1: 4, 6, wide(+1), dot, 1, W(bowled striker S1).
-        let deliveries = vec![
-            ball(0, 1, "B1", "S1", "S2", 4),
-            ball(0, 2, "B1", "S1", "S2", 6),
-            CricketDelivery {
-                over: 0,
-                ball: 2,
-                bowler_player_id: "B1".into(),
-                striker_player_id: "S1".into(),
-                non_striker_player_id: "S2".into(),
-                runs_off_bat: 0,
-                extra: Some(CricketDeliveryExtra {
-                    kind: CricketExtraKind::Wide,
-                    runs: 1,
-                }),
-                wicket: None,
-            },
-            ball(0, 3, "B1", "S1", "S2", 0),
-            ball(0, 4, "B1", "S1", "S2", 1),
-            CricketDelivery {
-                over: 0,
-                ball: 5,
-                bowler_player_id: "B1".into(),
-                striker_player_id: "S1".into(),
-                non_striker_player_id: "S2".into(),
-                runs_off_bat: 0,
-                extra: None,
-                wicket: Some(CricketDeliveryWicket {
-                    kind: CricketDismissalKind::Bowled,
-                    dismissed_player_id: "S1".into(),
-                    bowler_player_id: Some("B1".into()),
-                    fielder_player_id: None,
-                }),
-            },
-        ];
-
-        let innings = CricketInnings::from_deliveries(
-            "team_a".into(),
-            "team_b".into(),
-            false,
-            &deliveries,
-            6,
-            true,
-            true,
-        );
-
-        // Total runs: 4 + 6 + 1(wide) + 0 + 1 + 0 = 12.
-        assert_eq!(innings.runs, 12);
-        assert_eq!(innings.wickets, 1);
-        // 5 legal balls (wide excluded) -> 0 overs + 5 balls.
-        assert_eq!(innings.overs, Overs { overs: 0, balls: 5 });
-        assert_eq!(innings.extras.wides, 1);
-
-        // Striker S1: 11 runs off the bat, faced 5 balls (wide not faced),
-        // one four, one six, bowled.
-        let s1 = innings
-            .batting
-            .iter()
-            .find(|b| b.player_id == "S1")
-            .expect("S1 batting entry");
-        assert_eq!(s1.runs, 11);
-        assert_eq!(s1.balls_faced, 5);
-        assert_eq!(s1.fours, 1);
-        assert_eq!(s1.sixes, 1);
-        assert!(matches!(
-            s1.dismissal.as_ref().map(|d| &d.kind),
-            Some(CricketDismissalKind::Bowled)
-        ));
-
-        // Bowler B1: all 12 runs charged, 1 wicket, 1 wide, not a maiden.
-        let b1 = innings
-            .bowling
-            .iter()
-            .find(|b| b.player_id == "B1")
-            .expect("B1 bowling entry");
-        assert_eq!(b1.runs_conceded, 12);
-        assert_eq!(b1.wickets, 1);
-        assert_eq!(b1.wides, 1);
-        assert_eq!(b1.maidens, 0);
-    }
-
-    #[test]
-    fn respects_a_configured_balls_per_over_other_than_six() {
-        // The Hundred-style 5-ball over: 5 legal deliveries should complete
-        // exactly one over (1 over + 0 balls), not 0 overs + 5 balls as it
-        // would under a 6-ball over.
-        let deliveries = vec![
-            ball(0, 1, "B1", "S1", "S2", 1),
-            ball(0, 2, "B1", "S1", "S2", 1),
-            ball(0, 3, "B1", "S1", "S2", 1),
-            ball(0, 4, "B1", "S1", "S2", 1),
-            ball(0, 5, "B1", "S1", "S2", 1),
-        ];
-
-        let innings = CricketInnings::from_deliveries(
-            "team_a".into(),
-            "team_b".into(),
-            false,
-            &deliveries,
-            5,
-            true,
-            true,
-        );
-
-        assert_eq!(innings.overs, Overs { overs: 1, balls: 0 });
-        let b1 = innings
-            .bowling
-            .iter()
-            .find(|b| b.player_id == "B1")
-            .expect("B1 bowling entry");
-        assert_eq!(b1.overs, Overs { overs: 1, balls: 0 });
-    }
-
-    #[test]
-    fn wides_and_no_balls_can_be_configured_to_not_cost_an_extra_ball() {
-        // A casual-format over: wide, no-ball, then 4 plain deliveries. Under
-        // the standard rules that's a 4-ball over (wide/no-ball re-bowled);
-        // with both flags off here, the wide and no-ball each count as one of
-        // the over's 6 legal balls, so the whole thing completes in one over.
-        let deliveries = vec![
-            CricketDelivery {
-                over: 0,
-                ball: 1,
-                bowler_player_id: "B1".into(),
-                striker_player_id: "S1".into(),
-                non_striker_player_id: "S2".into(),
-                runs_off_bat: 0,
-                extra: Some(CricketDeliveryExtra {
-                    kind: CricketExtraKind::Wide,
-                    runs: 1,
-                }),
-                wicket: None,
-            },
-            CricketDelivery {
-                over: 0,
-                ball: 2,
-                bowler_player_id: "B1".into(),
-                striker_player_id: "S1".into(),
-                non_striker_player_id: "S2".into(),
-                runs_off_bat: 1,
-                extra: Some(CricketDeliveryExtra {
-                    kind: CricketExtraKind::NoBall,
-                    runs: 1,
-                }),
-                wicket: None,
-            },
-            ball(0, 3, "B1", "S1", "S2", 0),
-            ball(0, 4, "B1", "S1", "S2", 0),
-            ball(0, 5, "B1", "S1", "S2", 0),
-            ball(0, 6, "B1", "S1", "S2", 0),
-        ];
-
-        let innings = CricketInnings::from_deliveries(
-            "team_a".into(),
-            "team_b".into(),
-            false,
-            &deliveries,
-            6,
-            false,
-            false,
-        );
-
-        assert_eq!(innings.overs, Overs { overs: 1, balls: 0 });
-        assert_eq!(innings.runs, 3); // 1 (wide) + 1 (no-ball penalty) + 1 (off the bat)
-        let b1 = innings
-            .bowling
-            .iter()
-            .find(|b| b.player_id == "B1")
-            .expect("B1 bowling entry");
-        assert_eq!(b1.overs, Overs { overs: 1, balls: 0 });
-        assert_eq!(b1.wides, 1);
-        assert_eq!(b1.no_balls, 1);
     }
 }

--- a/agon_service/src/detailed_score/cricket.rs
+++ b/agon_service/src/detailed_score/cricket.rs
@@ -207,7 +207,7 @@ fn dismissal_credited_to_bowler(kind: &CricketDismissalKind) -> bool {
 /// rules, but a match format can configure either one to just count as one of
 /// the over's legal balls instead (see `CricketFormat::wide_is_extra_ball` /
 /// `no_ball_is_extra_ball`).
-fn is_legal_delivery(
+pub(crate) fn is_legal_delivery(
     delivery: &CricketDelivery,
     wide_is_extra_ball: bool,
     no_ball_is_extra_ball: bool,
@@ -234,7 +234,7 @@ fn runs_charged_to_bowler(delivery: &CricketDelivery) -> u32 {
 /// Converts a count of legal balls into whole overs + balls, e.g. 13 balls
 /// -> 2 overs + 1 ball, given how many legal deliveries make an over (6 for
 /// almost everything, 5 for The Hundred).
-fn balls_to_overs(balls: u32, balls_per_over: u32) -> Overs {
+pub(crate) fn balls_to_overs(balls: u32, balls_per_over: u32) -> Overs {
     Overs {
         overs: balls / balls_per_over,
         balls: balls % balls_per_over,

--- a/agon_service/src/detailed_score/cricket.rs
+++ b/agon_service/src/detailed_score/cricket.rs
@@ -22,15 +22,18 @@ pub struct Overs {
     pub balls: u32,
 }
 
-/// A cricket innings supports three tiers of fidelity:
+/// A cricket innings supports two tiers of fidelity:
 ///   1. Minimal — just `runs`/`wickets`/`overs`, leaving the cards empty.
 ///   2. Scorecard — full per-player `batting`/`bowling` cards.
-///   3. Ball-by-ball — a `deliveries` log (for live in-app scoring).
 ///
-/// The aggregate fields (`runs`, `wickets`, `overs`, `batting`, `bowling`,
-/// `extras`, `fall_of_wickets`) are the always-present *overview*. When
-/// `deliveries` is populated it is the source of truth and the overview is
-/// generated from it; otherwise the overview is entered directly.
+/// A match scored ball-by-ball (live, in-app) reaches this via
+/// `from_deliveries`, folding a delivery log into the same shape — but that
+/// log itself isn't part of it. It's already stored one item per ball in the
+/// match's live event log (`live_score::cricket`), which has no practical
+/// size ceiling; duplicating it here would mean a second, much larger copy
+/// embedded in this single record, risking DynamoDB's per-item size cap on a
+/// long match. `live_score::cricket::CricketLiveInnings` is the equivalent
+/// shape that does carry deliveries, for the one place that needs them.
 #[derive(Object)]
 pub struct CricketInnings {
     /// The batting side for this innings (references MatchSide.id).
@@ -49,9 +52,6 @@ pub struct CricketInnings {
     pub bowling: Vec<CricketBowlingEntry>,
     pub extras: CricketExtras,
     pub fall_of_wickets: Vec<CricketFallOfWicket>,
-    /// Optional ball-by-ball log. When present, the overview above is generated
-    /// from these deliveries. Empty when the innings was not scored ball-by-ball.
-    pub deliveries: Vec<CricketDelivery>,
 }
 
 /// A single delivery (ball) in an innings. The atomic unit of in-app scoring.
@@ -243,8 +243,7 @@ fn balls_to_overs(balls: u32, balls_per_over: u32) -> Overs {
 
 impl CricketInnings {
     /// Builds the innings overview (totals, batting/bowling cards, extras,
-    /// fall-of-wickets) from a ball-by-ball delivery log. The deliveries are
-    /// retained on the returned innings as the source of truth.
+    /// fall-of-wickets) from a ball-by-ball delivery log.
     /// `balls_per_over`, `wide_is_extra_ball` and `no_ball_is_extra_ball` are
     /// the match's configured over length and extra-ball rules (see
     /// `agon_service::match_format::CricketFormat`) — the only pieces of
@@ -254,7 +253,7 @@ impl CricketInnings {
         batting_side_id: String,
         bowling_side_id: String,
         declared: bool,
-        deliveries: Vec<CricketDelivery>,
+        deliveries: &[CricketDelivery],
         balls_per_over: u32,
         wide_is_extra_ball: bool,
         no_ball_is_extra_ball: bool,
@@ -316,7 +315,7 @@ impl CricketInnings {
             }
         }
 
-        for delivery in &deliveries {
+        for delivery in deliveries {
             let legal = is_legal_delivery(delivery, wide_is_extra_ball, no_ball_is_extra_ball);
             let charged = runs_charged_to_bowler(delivery);
             let extra_runs = delivery.extra.as_ref().map(|e| e.runs).unwrap_or(0);
@@ -425,7 +424,6 @@ impl CricketInnings {
             bowling,
             extras,
             fall_of_wickets,
-            deliveries,
         }
     }
 }
@@ -497,7 +495,7 @@ mod tests {
             "team_a".into(),
             "team_b".into(),
             false,
-            deliveries,
+            &deliveries,
             6,
             true,
             true,
@@ -555,7 +553,7 @@ mod tests {
             "team_a".into(),
             "team_b".into(),
             false,
-            deliveries,
+            &deliveries,
             5,
             true,
             true,
@@ -613,7 +611,7 @@ mod tests {
             "team_a".into(),
             "team_b".into(),
             false,
-            deliveries,
+            &deliveries,
             6,
             false,
             false,

--- a/agon_service/src/detailed_score/football.rs
+++ b/agon_service/src/detailed_score/football.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use poem_openapi::{Enum, Object};
 
 /// A match's full football detail — live or finished, the same shape either
@@ -5,9 +7,9 @@ use poem_openapi::{Enum, Object};
 /// well-typed list rather than flattened into one generic "event" shape — a
 /// goal's scorer/assist/own-goal/penalty fields mean the same thing here as
 /// when they were recorded, no interpreting a shared field differently per
-/// event kind. The phase fields (`kickoff_at`, `half_time_at`, ...) are
-/// historical facts, not "current state" — nothing here needs to go blank
-/// once the match is over the way cricket's next-ball context does.
+/// event kind. `period_times` are historical facts, not "current state" —
+/// nothing here needs to go blank once the match is over the way cricket's
+/// next-ball context does.
 #[derive(Object)]
 pub struct FootballDetail {
     pub score: Vec<FootballSideGoals>,
@@ -16,10 +18,15 @@ pub struct FootballDetail {
     pub substitutions: Vec<FootballSubstitutionEvent>,
     /// The most recent period marker seen, if any.
     pub period: Option<FootballPeriod>,
-    pub kickoff_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub half_time_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub second_half_kickoff_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub full_time_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// When each period marker was recorded, keyed by kind — one entry per
+    /// `FootballPeriod` variant seen so far (a marker recorded twice
+    /// overwrites, it doesn't append; see `FootballPeriod`'s doc comment on
+    /// why every current variant is a once-per-match boundary). A map here
+    /// rather than a named field per marker (the original
+    /// `kickoff_at`/`half_time_at`/`second_half_kickoff_at`/`full_time_at`
+    /// shape) so a new kind of marker — extra time, a drinks break — doesn't
+    /// need a new field each time.
+    pub period_times: HashMap<FootballPeriod, chrono::DateTime<chrono::Utc>>,
 }
 
 /// A side's running goal tally, derived from the event log (a convenience for
@@ -66,7 +73,7 @@ pub struct FootballSubstitutionEvent {
     pub minute: Option<u32>,
 }
 
-#[derive(Enum, Clone, PartialEq)]
+#[derive(Enum, Clone, Copy, PartialEq, Eq, Hash)]
 #[oai(rename_all = "snake_case")]
 pub enum FootballPeriod {
     /// Kickoff — the moment the match clock actually starts. Recorded once,
@@ -84,4 +91,39 @@ pub enum FootballPeriod {
     ExtraTimeHalfTime,
     ExtraTimeFullTime,
     PenaltiesComplete,
+}
+
+/// `ToString`/`FromStr` (via `Display`) mirroring the `#[oai(rename_all =
+/// "snake_case")]` wire form above — needed so `FootballPeriod` can be used
+/// as a `HashMap` key (`period_times`), which poem-openapi represents as a
+/// plain JSON object keyed by this string form.
+impl std::fmt::Display for FootballPeriod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            FootballPeriod::KickOff => "kick_off",
+            FootballPeriod::HalfTime => "half_time",
+            FootballPeriod::SecondHalfKickOff => "second_half_kick_off",
+            FootballPeriod::FullTime => "full_time",
+            FootballPeriod::ExtraTimeHalfTime => "extra_time_half_time",
+            FootballPeriod::ExtraTimeFullTime => "extra_time_full_time",
+            FootballPeriod::PenaltiesComplete => "penalties_complete",
+        })
+    }
+}
+
+impl std::str::FromStr for FootballPeriod {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "kick_off" => Ok(FootballPeriod::KickOff),
+            "half_time" => Ok(FootballPeriod::HalfTime),
+            "second_half_kick_off" => Ok(FootballPeriod::SecondHalfKickOff),
+            "full_time" => Ok(FootballPeriod::FullTime),
+            "extra_time_half_time" => Ok(FootballPeriod::ExtraTimeHalfTime),
+            "extra_time_full_time" => Ok(FootballPeriod::ExtraTimeFullTime),
+            "penalties_complete" => Ok(FootballPeriod::PenaltiesComplete),
+            other => Err(format!("unknown football period: {other}")),
+        }
+    }
 }

--- a/agon_service/src/detailed_score/football.rs
+++ b/agon_service/src/detailed_score/football.rs
@@ -1,35 +1,87 @@
 use poem_openapi::{Enum, Object};
 
-/// Football detail is an ordered timeline of match events. The summary score
-/// (goals per side) can be derived by counting Goal events.
+/// A match's full football detail — live or finished, the same shape either
+/// way. Every goal, card, and substitution recorded, each in its own
+/// well-typed list rather than flattened into one generic "event" shape — a
+/// goal's scorer/assist/own-goal/penalty fields mean the same thing here as
+/// when they were recorded, no interpreting a shared field differently per
+/// event kind. The phase fields (`kickoff_at`, `half_time_at`, ...) are
+/// historical facts, not "current state" — nothing here needs to go blank
+/// once the match is over the way cricket's next-ball context does.
 #[derive(Object)]
 pub struct FootballDetail {
-    pub events: Vec<FootballEvent>,
+    pub score: Vec<FootballSideGoals>,
+    pub goals: Vec<FootballGoalEvent>,
+    pub cards: Vec<FootballCardEvent>,
+    pub substitutions: Vec<FootballSubstitutionEvent>,
+    /// The most recent period marker seen, if any.
+    pub period: Option<FootballPeriod>,
+    pub kickoff_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub half_time_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub second_half_kickoff_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub full_time_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-#[derive(Enum)]
-#[oai(rename_all = "snake_case")]
-pub enum FootballEventKind {
-    Goal,
-    OwnGoal,
-    Penalty,
-    YellowCard,
-    RedCard,
-    Substitution,
-}
-
+/// A side's running goal tally, derived from the event log (a convenience for
+/// cheap reads — e.g. a feed card — that don't want to re-derive it from
+/// `goals` themselves).
 #[derive(Object)]
-pub struct FootballEvent {
-    pub kind: FootballEventKind,
-    /// The side this event belongs to (references MatchSide.id).
+pub struct FootballSideGoals {
     pub side_id: String,
-    /// Match minute, if recorded.
-    pub minute: Option<u32>,
-    /// Player who performed the action: scorer, card recipient, player coming
-    /// on. References MatchPlayer's member id.
-    pub player_id: Option<String>,
-    /// Assisting player for a goal. None for own goals or unassisted goals.
+    pub goals: u32,
+}
+
+#[derive(Object, Clone)]
+pub struct FootballGoalEvent {
+    /// The side this goal counts for.
+    pub side_id: String,
+    /// None for an own goal with no recorded scorer.
+    pub scorer_player_id: Option<String>,
     pub assist_player_id: Option<String>,
-    /// Player coming off, for a substitution (paired with `player_id` coming on).
-    pub substituted_player_id: Option<String>,
+    pub own_goal: bool,
+    pub penalty: bool,
+    pub minute: Option<u32>,
+}
+
+#[derive(Enum, Clone)]
+#[oai(rename_all = "snake_case")]
+pub enum FootballCardColor {
+    Yellow,
+    Red,
+}
+
+#[derive(Object, Clone)]
+pub struct FootballCardEvent {
+    pub side_id: String,
+    pub player_id: String,
+    pub color: FootballCardColor,
+    pub minute: Option<u32>,
+}
+
+#[derive(Object, Clone)]
+pub struct FootballSubstitutionEvent {
+    pub side_id: String,
+    pub player_in_id: String,
+    pub player_out_id: String,
+    pub minute: Option<u32>,
+}
+
+#[derive(Enum, Clone, PartialEq)]
+#[oai(rename_all = "snake_case")]
+pub enum FootballPeriod {
+    /// Kickoff — the moment the match clock actually starts. Recorded once,
+    /// when the scorer starts live scoring; distinct from `Match.starts_at`
+    /// (the *scheduled* time), which may not match when the whistle actually
+    /// blew.
+    KickOff,
+    HalfTime,
+    /// Kickoff of the second half — no clock gap is assumed between this and
+    /// `HalfTime`, so added time in the first half is preserved automatically
+    /// (the second half's clock continues from wherever the first half's
+    /// left off, not from a fixed 45').
+    SecondHalfKickOff,
+    FullTime,
+    ExtraTimeHalfTime,
+    ExtraTimeFullTime,
+    PenaltiesComplete,
 }

--- a/agon_service/src/detailed_score/football.rs
+++ b/agon_service/src/detailed_score/football.rs
@@ -73,7 +73,7 @@ pub struct FootballSubstitutionEvent {
     pub minute: Option<u32>,
 }
 
-#[derive(Enum, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Enum, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[oai(rename_all = "snake_case")]
 pub enum FootballPeriod {
     /// Kickoff — the moment the match clock actually starts. Recorded once,

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -166,15 +166,16 @@ pub fn derive_state(
     // Only the last innings — the one actually open, or just-finished if the
     // match is between innings — needs its ball-by-ball log kept: it's the
     // only one the live view (the "this over" row, next-ball context) ever
-    // reads. Earlier innings in this same match only need their totals here,
-    // which keeps this whole state (recomputed and cached as one record on
-    // every single delivery — see `put_live_state`) bounded to roughly one
-    // innings' worth of balls rather than growing with the match's full
-    // history. A finished match's complete run-progression graph reads the
-    // raw event log directly instead of this cache (see
+    // reads, both for `GET /live` and for a device folding its own offline
+    // queue the same way. Earlier innings in this same match only need their
+    // totals here, which keeps every `GET /live`/append response (this is
+    // derived fresh on each one — see `derive_live_snapshot`, no cache
+    // involved) bounded to roughly one innings' worth of balls rather than
+    // the match's full history. A finished match's complete run-progression
+    // graph instead reads the raw event log directly (see
     // `agon_ui/src/lib/cricketScore.ts`'s `inningsDeliveriesFromEvents`),
-    // since that log has no such ceiling — it's one item per ball, not one
-    // item per match.
+    // which has no such reason to bound — one item per ball, not one item
+    // (or one response) per match.
     if let Some(last) = innings.len().checked_sub(1) {
         for (i, inn) in innings.iter_mut().enumerate() {
             if i != last {

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -1,8 +1,10 @@
 use poem_openapi::{Enum, Object, Union};
 
 use crate::detailed_score::cricket::{
-    CricketDelivery, CricketDismissal, CricketDismissalKind, CricketExtraKind, CricketFallOfWicket,
-    CricketInnings, Overs, balls_to_overs, is_legal_delivery,
+    CricketBattingEntry, CricketBowlingEntry, CricketDelivery, CricketDetail, CricketDismissal,
+    CricketDismissalKind, CricketExtraKind, CricketFallOfWicket, CricketInnings, NextBallContext,
+    Overs, RECENT_DELIVERIES_LIMIT, balls_to_overs, dismissal_credited_to_bowler,
+    is_legal_delivery, runs_charged_to_bowler,
 };
 
 /// Cricket live-scoring events, nested under the outer sport union
@@ -51,72 +53,54 @@ pub struct CricketInningsEndEvent {
     pub reason: InningsEndReason,
 }
 
-/// How many balls back the live summary keeps for the "this over"/recent-balls
-/// row — enough to show a bit more than the current over, nowhere near a
-/// whole innings.
-pub const RECENT_DELIVERIES_LIMIT: usize = 18;
-
-/// One innings' totals — no batting/bowling cards, no ball-by-ball log.
-/// Deliberately the same trimmed shape as `main::CricketScoreInnings`
-/// (`Score::Cricket`'s confirmed-result equivalent), kept as its own type
-/// since the two serve unrelated endpoints that shouldn't need to change
-/// together.
-#[derive(Object, Clone)]
-pub struct CricketInningsTotals {
-    pub batting_side_id: String,
-    pub bowling_side_id: String,
-    pub runs: u32,
-    pub wickets: u32,
-    pub overs: Overs,
-    pub declared: bool,
-}
-
-/// What's known about who's at the crease/bowling for the *next* delivery,
-/// folded incrementally from the current innings' events as they're
-/// recorded. A `None` field means the scorer needs to pick someone before
-/// the next ball can be recorded — either a fresh innings (nothing bowled
-/// yet), a wicket just fell (the dismissed batter's slot is open), or an
-/// over just completed (a new bowler is required; the same bowler can't
-/// bowl consecutive overs).
-///
-/// Mirrors `agon_ui/src/lib/cricketScore.ts`'s `NextBallContext` and
-/// `nextBallContext` field-for-field and step-for-step — kept in sync by
-/// hand. The frontend runs the identical fold offline, against deliveries a
-/// device has recorded locally but not yet synced, which is exactly the case
-/// this incremental (one delivery at a time) shape is built for: apply one
-/// step to the last-known context, don't replay history.
-#[derive(Object, Clone)]
-pub struct NextBallContext {
-    pub striker_player_id: Option<String>,
-    pub non_striker_player_id: Option<String>,
-    pub bowler_player_id: Option<String>,
-    /// 0-based over index the next delivery belongs to.
-    pub over: u32,
-    /// 1-based ball number within that over.
-    pub ball: u32,
-    /// The bowler who just finished an over — excluded from the next-bowler
-    /// picker. `None` unless a bowler pick is actually needed.
-    pub previous_over_bowler_player_id: Option<String>,
-}
-
-impl NextBallContext {
-    /// The state before any delivery has been recorded in an innings.
-    fn opening() -> Self {
-        NextBallContext {
-            striker_player_id: None,
-            non_striker_player_id: None,
-            bowler_player_id: None,
-            over: 0,
-            ball: 1,
-            previous_over_bowler_player_id: None,
-        }
+fn batter<'a>(
+    batting: &'a mut Vec<CricketBattingEntry>,
+    player_id: &str,
+) -> &'a mut CricketBattingEntry {
+    if let Some(pos) = batting.iter().position(|b| b.player_id == player_id) {
+        &mut batting[pos]
+    } else {
+        batting.push(CricketBattingEntry {
+            player_id: player_id.to_string(),
+            runs: 0,
+            balls_faced: 0,
+            fours: 0,
+            sixes: 0,
+            dismissal: None,
+            batting_position: Some(batting.len() as u32 + 1),
+        });
+        batting.last_mut().unwrap()
     }
 }
 
-/// Folds one delivery into the running next-ball context. The whole
-/// incremental step: called once per new delivery on the append path, and
-/// repeatedly from `NextBallContext::opening()` to bootstrap/recover a
-/// summary from the full event log (see `CricketLiveState::from_events`).
+fn bowler<'a>(
+    bowling: &'a mut Vec<CricketBowlingEntry>,
+    player_id: &str,
+) -> &'a mut CricketBowlingEntry {
+    if let Some(pos) = bowling.iter().position(|b| b.player_id == player_id) {
+        &mut bowling[pos]
+    } else {
+        bowling.push(CricketBowlingEntry {
+            player_id: player_id.to_string(),
+            overs: Overs { overs: 0, balls: 0 },
+            maidens: 0,
+            runs_conceded: 0,
+            wickets: 0,
+            wides: 0,
+            no_balls: 0,
+        });
+        bowling.last_mut().unwrap()
+    }
+}
+
+/// Folds one delivery into an innings already in progress — updates totals,
+/// the batting/bowling cards, extras, and fall-of-wickets in place — and
+/// returns the next-ball context that follows it. The whole incremental
+/// step: called once per new delivery on the append path, and repeatedly
+/// from `CricketInnings::opening`/`NextBallContext::opening` to bootstrap or
+/// recover a `CricketDetail` from the full event log (see
+/// `CricketDetail::from_events`) — one implementation either way, so the two
+/// paths can't disagree.
 ///
 /// Strike rotates on an odd number of the ball's rotating runs (off the bat,
 /// or byes/leg-byes — wides/no-balls don't rotate strike) and always at the
@@ -124,20 +108,102 @@ impl NextBallContext {
 /// on that same ball (e.g. dismissed on the over's final ball): the swap
 /// still applies to whichever slot the survivor occupies, so the vacancy
 /// lands in the correct slot for the next ball rather than always defaulting
-/// to "striker".
-fn apply_delivery_to_context(
-    prev: &NextBallContext,
+/// to "striker". A maiden is credited to whoever bowled the over that just
+/// completed, using `runs_conceded_this_over` — tracked alongside the
+/// context rather than recomputed by scanning deliveries.
+pub fn apply_delivery(
+    innings: &mut CricketInnings,
+    context: &NextBallContext,
     d: &CricketDelivery,
     balls_per_over: u32,
     wide_is_extra_ball: bool,
     no_ball_is_extra_ball: bool,
 ) -> NextBallContext {
+    let legal = is_legal_delivery(d, wide_is_extra_ball, no_ball_is_extra_ball);
+    let charged = runs_charged_to_bowler(d);
+    let extra_runs = d.extra.as_ref().map(|e| e.runs).unwrap_or(0);
+
+    innings.runs += d.runs_off_bat + extra_runs;
+    if legal {
+        let legal_balls = innings.overs.overs * balls_per_over + innings.overs.balls + 1;
+        innings.overs = balls_to_overs(legal_balls, balls_per_over);
+    }
+
+    // Batting: striker is credited runs off the bat and faces legal balls
+    // and no-balls (but not wides).
+    {
+        let b = batter(&mut innings.batting, &d.striker_player_id);
+        b.runs += d.runs_off_bat;
+        let faced_ball = !matches!(
+            d.extra.as_ref().map(|e| &e.kind),
+            Some(CricketExtraKind::Wide)
+        );
+        if faced_ball {
+            b.balls_faced += 1;
+        }
+        match d.runs_off_bat {
+            4 => b.fours += 1,
+            6 => b.sixes += 1,
+            _ => {}
+        }
+    }
+
+    // Bowling figures.
+    {
+        let bw = bowler(&mut innings.bowling, &d.bowler_player_id);
+        bw.runs_conceded += charged;
+        if let Some(extra) = &d.extra {
+            match extra.kind {
+                CricketExtraKind::Wide => bw.wides += 1,
+                CricketExtraKind::NoBall => bw.no_balls += 1,
+                _ => {}
+            }
+        }
+        if legal {
+            let legal_balls = bw.overs.overs * balls_per_over + bw.overs.balls + 1;
+            bw.overs = balls_to_overs(legal_balls, balls_per_over);
+        }
+    }
+
+    // Extras breakdown.
+    if let Some(extra) = &d.extra {
+        match extra.kind {
+            CricketExtraKind::Bye => innings.extras.byes += extra.runs,
+            CricketExtraKind::LegBye => innings.extras.leg_byes += extra.runs,
+            CricketExtraKind::Wide => innings.extras.wides += extra.runs,
+            CricketExtraKind::NoBall => innings.extras.no_balls += extra.runs,
+            CricketExtraKind::Penalty => innings.extras.penalty += extra.runs,
+        }
+    }
+
+    // Wicket.
+    if let Some(wicket) = &d.wicket {
+        innings.wickets += 1;
+        innings.fall_of_wickets.push(CricketFallOfWicket {
+            wicket: innings.wickets,
+            runs: innings.runs,
+            player_id: wicket.dismissed_player_id.clone(),
+            overs: Some(innings.overs),
+        });
+        if dismissal_credited_to_bowler(&wicket.kind) {
+            bowler(&mut innings.bowling, &d.bowler_player_id).wickets += 1;
+        }
+        let b = batter(&mut innings.batting, &wicket.dismissed_player_id);
+        b.dismissal = Some(CricketDismissal {
+            kind: wicket.kind.clone(),
+            bowler_player_id: wicket.bowler_player_id.clone(),
+            fielder_player_id: wicket.fielder_player_id.clone(),
+        });
+    }
+
+    // Next-ball context, folded from the previous one.
     let mut striker = Some(d.striker_player_id.clone());
     let mut non_striker = Some(d.non_striker_player_id.clone());
-    let mut bowler = Some(d.bowler_player_id.clone());
+    let mut bowler_id = Some(d.bowler_player_id.clone());
     let mut previous_over_bowler: Option<String> = None;
-    let mut legal_in_over = prev.ball.saturating_sub(1);
-    let mut over = prev.over;
+    let mut legal_in_over = context.ball.saturating_sub(1);
+    let mut over = context.over;
+    let mut runs_conceded_this_over = context.runs_conceded_this_over + charged;
 
     if let Some(wicket) = &d.wicket {
         if striker.as_deref() == Some(wicket.dismissed_player_id.as_str()) {
@@ -147,13 +213,11 @@ fn apply_delivery_to_context(
         }
     }
 
-    if is_legal_delivery(d, wide_is_extra_ball, no_ball_is_extra_ball) {
+    if legal {
         legal_in_over += 1;
         let rotating_runs = d.runs_off_bat
             + match d.extra.as_ref().map(|e| &e.kind) {
-                Some(CricketExtraKind::Bye) | Some(CricketExtraKind::LegBye) => {
-                    d.extra.as_ref().map(|e| e.runs).unwrap_or(0)
-                }
+                Some(CricketExtraKind::Bye) | Some(CricketExtraKind::LegBye) => extra_runs,
                 _ => 0,
             };
         if rotating_runs % 2 == 1 {
@@ -161,81 +225,60 @@ fn apply_delivery_to_context(
         }
         if legal_in_over == balls_per_over {
             std::mem::swap(&mut striker, &mut non_striker);
-            previous_over_bowler = bowler.take();
+            if runs_conceded_this_over == 0
+                && let Some(over_bowler_id) = &bowler_id
+            {
+                bowler(&mut innings.bowling, over_bowler_id).maidens += 1;
+            }
+            previous_over_bowler = bowler_id.take();
             over += 1;
             legal_in_over = 0;
+            runs_conceded_this_over = 0;
         }
     }
 
     NextBallContext {
         striker_player_id: striker,
         non_striker_player_id: non_striker,
-        bowler_player_id: bowler,
+        bowler_player_id: bowler_id,
         over,
         ball: legal_in_over + 1,
         previous_over_bowler_player_id: previous_over_bowler,
+        runs_conceded_this_over,
     }
 }
 
-/// The live-scoring summary, folded from a match's cricket event log — fixed
-/// size regardless of how long the match runs or how many events its log
-/// holds, so it's safe to cache and update on every single delivery (see
-/// `agon_core::dao::live_score_ops`). `innings` totals cover the whole match
-/// so far; `recent_deliveries` and `next_ball_context` only ever describe the
-/// current (open, or just-finished) innings — a finished match's complete
-/// ball-by-ball history reads the raw event log instead (paginated —
-/// `GET /matches/:id/live/events`, folded client-side by
-/// `inningsDeliveriesFromEvents`).
-#[derive(Object, Clone)]
-pub struct CricketLiveState {
-    pub innings: Vec<CricketInningsTotals>,
-    /// The current innings' most recent deliveries, oldest first, capped at
-    /// `RECENT_DELIVERIES_LIMIT`. Empty between innings.
-    pub recent_deliveries: Vec<CricketDelivery>,
-    /// `None` between innings — there's no next ball to give context for.
-    pub next_ball_context: Option<NextBallContext>,
-    /// True once the log's last innings has an `InningsEnd` and no following
-    /// `InningsStart` has opened a new one yet (i.e. between innings, or the
-    /// log is empty).
-    pub awaiting_next_innings: bool,
-}
-
-impl CricketLiveState {
-    fn empty() -> Self {
-        CricketLiveState {
-            innings: Vec::new(),
-            recent_deliveries: Vec::new(),
-            next_ball_context: None,
-            awaiting_next_innings: true,
-        }
-    }
-
-    /// Folds the whole event log into a summary from scratch — the slow
-    /// path, used to bootstrap a match's first summary, recover from a
-    /// missing/unparseable cache, or rebuild after a correction (an
-    /// arbitrary-position delete/amend can't be applied as a single
-    /// incremental step). Just `apply_event` run once per event in order;
-    /// the fast (single-event) and slow (whole-log) paths share the exact
-    /// same fold, so they can't disagree.
+impl CricketDetail {
+    /// Folds the whole event log into a `CricketDetail` from scratch — the
+    /// slow path, used to bootstrap a match's first detail, recover from a
+    /// missing/unparseable cache, or rebuild after undoing the last event.
+    /// Just `apply_event` run once per event in order; the fast
+    /// (single-event) and slow (whole-log) paths share the exact same fold,
+    /// so they can't disagree.
     pub fn from_events(
         events: &[CricketLiveEvent],
         balls_per_over: u32,
         wide_is_extra_ball: bool,
         no_ball_is_extra_ball: bool,
     ) -> Self {
-        let mut state = CricketLiveState::empty();
+        let mut detail = CricketDetail {
+            innings: Vec::new(),
+            recent_deliveries: None,
+            next_ball_context: None,
+            awaiting_next_innings: true,
+        };
         for event in events {
-            state.apply_event(
+            detail.apply_event(
                 event,
                 balls_per_over,
                 wide_is_extra_ball,
                 no_ball_is_extra_ball,
             );
         }
-        state
+        detail
     }
 
-    /// Folds one new event into this summary in place — the fast path, run
+    /// Folds one new event into this detail in place — the fast path, run
     /// on every append.
     pub fn apply_event(
         &mut self,
@@ -246,52 +289,78 @@ impl CricketLiveState {
     ) {
         match event {
             CricketLiveEvent::InningsStart(start) => {
-                self.innings.push(CricketInningsTotals {
-                    batting_side_id: start.batting_side_id.clone(),
-                    bowling_side_id: start.bowling_side_id.clone(),
-                    runs: 0,
-                    wickets: 0,
-                    overs: Overs { overs: 0, balls: 0 },
-                    declared: false,
-                });
-                self.recent_deliveries.clear();
+                self.innings.push(CricketInnings::opening(
+                    start.batting_side_id.clone(),
+                    start.bowling_side_id.clone(),
+                ));
+                self.recent_deliveries = Some(Vec::new());
                 self.next_ball_context = Some(NextBallContext::opening());
                 self.awaiting_next_innings = false;
             }
             CricketLiveEvent::Delivery(d) => {
-                if let Some(current) = self.innings.last_mut() {
-                    let extra_runs = d.extra.as_ref().map(|e| e.runs).unwrap_or(0);
-                    current.runs += d.runs_off_bat + extra_runs;
-                    if is_legal_delivery(d, wide_is_extra_ball, no_ball_is_extra_ball) {
-                        let legal_balls =
-                            current.overs.overs * balls_per_over + current.overs.balls + 1;
-                        current.overs = balls_to_overs(legal_balls, balls_per_over);
-                    }
-                    if d.wicket.is_some() {
-                        current.wickets += 1;
-                    }
-                }
-                self.recent_deliveries.push(d.clone());
-                if self.recent_deliveries.len() > RECENT_DELIVERIES_LIMIT {
-                    self.recent_deliveries.remove(0);
-                }
-                let prev = self
+                let Some(current) = self.innings.last_mut() else {
+                    // A delivery with no open innings is malformed input —
+                    // there's nothing to fold it into.
+                    return;
+                };
+                let context = self
                     .next_ball_context
                     .clone()
                     .unwrap_or_else(NextBallContext::opening);
-                self.next_ball_context = Some(apply_delivery_to_context(
-                    &prev,
+                let next_context = apply_delivery(
+                    current,
+                    &context,
                     d,
                     balls_per_over,
                     wide_is_extra_ball,
                     no_ball_is_extra_ball,
-                ));
+                );
+                self.next_ball_context = Some(next_context);
+
+                let deliveries = self.recent_deliveries.get_or_insert_with(Vec::new);
+                deliveries.push(d.clone());
+                if deliveries.len() > RECENT_DELIVERIES_LIMIT {
+                    deliveries.remove(0);
+                }
             }
             CricketLiveEvent::Retire(r) => {
-                if r.retired_out
-                    && let Some(current) = self.innings.last_mut()
-                {
+                let Some(current) = self.innings.last_mut() else {
+                    return;
+                };
+                let Some(entry) = current
+                    .batting
+                    .iter_mut()
+                    .find(|b| b.player_id == r.batter_player_id)
+                else {
+                    // Retired without ever facing a ball — no batting-card
+                    // row exists yet to annotate. Rare enough not to
+                    // synthesize one.
+                    return;
+                };
+                if entry.dismissal.is_some() {
+                    // A later real dismissal (from a delivery) always takes
+                    // precedence over an earlier retirement note — and by
+                    // the time we're processing events in order, that's
+                    // already reflected here.
+                    return;
+                }
+                entry.dismissal = Some(CricketDismissal {
+                    kind: if r.retired_out {
+                        CricketDismissalKind::RetiredOut
+                    } else {
+                        CricketDismissalKind::RetiredHurt
+                    },
+                    bowler_player_id: None,
+                    fielder_player_id: None,
+                });
+                if r.retired_out {
                     current.wickets += 1;
+                    current.fall_of_wickets.push(CricketFallOfWicket {
+                        wicket: current.wickets,
+                        runs: current.runs,
+                        player_id: r.batter_player_id.clone(),
+                        overs: Some(current.overs),
+                    });
                 }
                 if let Some(ctx) = &mut self.next_ball_context {
                     if ctx.striker_player_id.as_deref() == Some(r.batter_player_id.as_str()) {
@@ -307,7 +376,7 @@ impl CricketLiveState {
                 if let Some(current) = self.innings.last_mut() {
                     current.declared = matches!(end.reason, InningsEndReason::Declared);
                 }
-                self.recent_deliveries.clear();
+                self.recent_deliveries = None;
                 self.next_ball_context = None;
                 self.awaiting_next_innings = true;
             }
@@ -315,153 +384,10 @@ impl CricketLiveState {
     }
 }
 
-struct OpenInnings {
-    batting_side_id: String,
-    bowling_side_id: String,
-    deliveries: Vec<CricketDelivery>,
-    retirements: Vec<(String, bool)>,
-}
-
-/// Folds a match's whole cricket event log into its full per-innings
-/// scorecard (batting/bowling cards, extras, fall-of-wickets) — the same
-/// shape `detailed_score` persists. Internal only: the one place this runs
-/// is server-side, once, when a live-scored cricket match is marked
-/// complete without an explicit `detailed_score` (see `update_match`), to
-/// derive and persist it from the authoritative log. Never exposed on a
-/// hot/polled path — `GET /live` serves `CricketLiveState` instead, which
-/// carries totals only plus a bounded recent-deliveries window.
-///
-/// Innings boundaries come entirely from `InningsStart`/`InningsEnd`
-/// markers, not a stored index — so deleting a wrongly-placed boundary
-/// automatically re-flows every event after it back into the earlier
-/// innings on the next fold, with nothing to rewrite.
-/// `balls_per_over`, `wide_is_extra_ball` and `no_ball_is_extra_ball` are the
-/// match's configured over length and extra-ball rules (see
-/// `agon_service::match_format::CricketFormat`); callers without a
-/// configured format pass the standard defaults (6, true, true).
-pub fn fold_full_scorecard(
-    events: &[CricketLiveEvent],
-    balls_per_over: u32,
-    wide_is_extra_ball: bool,
-    no_ball_is_extra_ball: bool,
-) -> Vec<CricketInnings> {
-    let mut innings: Vec<CricketInnings> = Vec::new();
-    let mut current: Option<OpenInnings> = None;
-
-    let finish = |open: OpenInnings, declared: bool| {
-        finish_innings(
-            open,
-            declared,
-            balls_per_over,
-            wide_is_extra_ball,
-            no_ball_is_extra_ball,
-        )
-    };
-
-    for event in events {
-        match event {
-            CricketLiveEvent::InningsStart(start) => {
-                // Close out anything left open without an explicit End,
-                // rather than losing it — shouldn't normally happen.
-                if let Some(open) = current.take() {
-                    innings.push(finish(open, false));
-                }
-                current = Some(OpenInnings {
-                    batting_side_id: start.batting_side_id.clone(),
-                    bowling_side_id: start.bowling_side_id.clone(),
-                    deliveries: Vec::new(),
-                    retirements: Vec::new(),
-                });
-            }
-            CricketLiveEvent::Delivery(d) => {
-                if let Some(open) = &mut current {
-                    open.deliveries.push(d.clone());
-                }
-            }
-            CricketLiveEvent::Retire(r) => {
-                if let Some(open) = &mut current {
-                    open.retirements
-                        .push((r.batter_player_id.clone(), r.retired_out));
-                }
-            }
-            CricketLiveEvent::InningsEnd(end) => {
-                if let Some(open) = current.take() {
-                    let declared = matches!(end.reason, InningsEndReason::Declared);
-                    innings.push(finish(open, declared));
-                }
-            }
-        }
-    }
-
-    if let Some(open) = current {
-        innings.push(finish(open, false));
-    }
-
-    innings
-}
-
-fn finish_innings(
-    open: OpenInnings,
-    declared: bool,
-    balls_per_over: u32,
-    wide_is_extra_ball: bool,
-    no_ball_is_extra_ball: bool,
-) -> CricketInnings {
-    let mut built = CricketInnings::from_deliveries(
-        open.batting_side_id,
-        open.bowling_side_id,
-        declared,
-        &open.deliveries,
-        balls_per_over,
-        wide_is_extra_ball,
-        no_ball_is_extra_ball,
-    );
-    apply_retirements(&mut built, &open.retirements);
-    built
-}
-
-/// Annotates the batting card with retirements that never went through a
-/// delivery-based dismissal. A later real dismissal (from a delivery) always
-/// takes precedence over an earlier retirement note for the same batter.
-fn apply_retirements(innings: &mut CricketInnings, retirements: &[(String, bool)]) {
-    for (player_id, retired_out) in retirements {
-        let Some(entry) = innings
-            .batting
-            .iter_mut()
-            .find(|b| &b.player_id == player_id)
-        else {
-            // The batter retired without ever facing a ball (e.g. injured
-            // before their first delivery) — no batting-card row exists yet
-            // to annotate. Rare enough in practice not to synthesize one.
-            continue;
-        };
-        if entry.dismissal.is_some() {
-            continue;
-        }
-        entry.dismissal = Some(CricketDismissal {
-            kind: if *retired_out {
-                CricketDismissalKind::RetiredOut
-            } else {
-                CricketDismissalKind::RetiredHurt
-            },
-            bowler_player_id: None,
-            fielder_player_id: None,
-        });
-        if *retired_out {
-            innings.wickets += 1;
-            innings.fall_of_wickets.push(CricketFallOfWicket {
-                wicket: innings.wickets,
-                runs: innings.runs,
-                player_id: player_id.clone(),
-                overs: Some(innings.overs),
-            });
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::detailed_score::cricket::CricketDeliveryWicket;
 
     fn ball(bowler: &str, striker: &str, non_striker: &str, runs: u32) -> CricketDelivery {
         CricketDelivery {
@@ -476,12 +402,12 @@ mod tests {
         }
     }
 
-    fn summary(events: &[CricketLiveEvent]) -> CricketLiveState {
-        CricketLiveState::from_events(events, 6, true, true)
+    fn detail(events: &[CricketLiveEvent]) -> CricketDetail {
+        CricketDetail::from_events(events, 6, true, true)
     }
 
     #[test]
-    fn tracks_runs_wickets_overs_per_innings() {
+    fn tracks_runs_wickets_overs_and_cards_per_innings() {
         let events = vec![
             CricketLiveEvent::InningsStart(CricketInningsStartEvent {
                 batting_side_id: "warriors".into(),
@@ -489,7 +415,7 @@ mod tests {
             }),
             CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 4)),
             CricketLiveEvent::Delivery(CricketDelivery {
-                wicket: Some(crate::detailed_score::cricket::CricketDeliveryWicket {
+                wicket: Some(CricketDeliveryWicket {
                     kind: CricketDismissalKind::Bowled,
                     dismissed_player_id: "sharma".into(),
                     bowler_player_id: Some("patel".into()),
@@ -499,12 +425,75 @@ mod tests {
             }),
         ];
 
-        let state = summary(&events);
-        assert_eq!(state.innings.len(), 1);
-        assert_eq!(state.innings[0].runs, 4);
-        assert_eq!(state.innings[0].wickets, 1);
-        assert_eq!(state.innings[0].overs, Overs { overs: 0, balls: 2 });
-        assert!(!state.awaiting_next_innings);
+        let d = detail(&events);
+        assert_eq!(d.innings.len(), 1);
+        assert_eq!(d.innings[0].runs, 4);
+        assert_eq!(d.innings[0].wickets, 1);
+        assert_eq!(d.innings[0].overs, Overs { overs: 0, balls: 2 });
+        assert!(!d.awaiting_next_innings);
+
+        let sharma = d.innings[0]
+            .batting
+            .iter()
+            .find(|b| b.player_id == "sharma")
+            .unwrap();
+        assert_eq!(sharma.runs, 4);
+        assert!(matches!(
+            sharma.dismissal.as_ref().map(|w| &w.kind),
+            Some(CricketDismissalKind::Bowled)
+        ));
+
+        let patel = d.innings[0]
+            .bowling
+            .iter()
+            .find(|b| b.player_id == "patel")
+            .unwrap();
+        assert_eq!(patel.runs_conceded, 4);
+        assert_eq!(patel.wickets, 1);
+    }
+
+    #[test]
+    fn a_wicketless_over_is_a_maiden() {
+        let mut events = vec![CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+            batting_side_id: "warriors".into(),
+            bowling_side_id: "mill_lane".into(),
+        })];
+        for _ in 0..6 {
+            events.push(CricketLiveEvent::Delivery(ball(
+                "patel", "sharma", "verma", 0,
+            )));
+        }
+        let d = detail(&events);
+        let patel = d.innings[0]
+            .bowling
+            .iter()
+            .find(|b| b.player_id == "patel")
+            .unwrap();
+        assert_eq!(patel.maidens, 1);
+        assert_eq!(patel.overs, Overs { overs: 1, balls: 0 });
+    }
+
+    #[test]
+    fn a_single_run_breaks_the_maiden() {
+        let mut events = vec![CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+            batting_side_id: "warriors".into(),
+            bowling_side_id: "mill_lane".into(),
+        })];
+        events.push(CricketLiveEvent::Delivery(ball(
+            "patel", "sharma", "verma", 1,
+        )));
+        for _ in 0..5 {
+            events.push(CricketLiveEvent::Delivery(ball(
+                "patel", "verma", "sharma", 0,
+            )));
+        }
+        let d = detail(&events);
+        let patel = d.innings[0]
+            .bowling
+            .iter()
+            .find(|b| b.player_id == "patel")
+            .unwrap();
+        assert_eq!(patel.maidens, 0);
     }
 
     #[test]
@@ -518,17 +507,20 @@ mod tests {
                 "patel", "sharma", "verma", 1,
             )));
         }
-        let state = summary(&events);
-        assert_eq!(state.recent_deliveries.len(), RECENT_DELIVERIES_LIMIT);
-        assert_eq!(state.innings[0].runs, RECENT_DELIVERIES_LIMIT as u32 + 5);
+        let d = detail(&events);
+        assert_eq!(
+            d.recent_deliveries.as_ref().map(Vec::len),
+            Some(RECENT_DELIVERIES_LIMIT)
+        );
+        assert_eq!(d.innings[0].runs, RECENT_DELIVERIES_LIMIT as u32 + 5);
 
         events.push(CricketLiveEvent::InningsEnd(CricketInningsEndEvent {
             reason: InningsEndReason::Declared,
         }));
-        let state = summary(&events);
-        assert!(state.recent_deliveries.is_empty());
-        assert!(state.next_ball_context.is_none());
-        assert!(state.awaiting_next_innings);
+        let d = detail(&events);
+        assert!(d.recent_deliveries.is_none());
+        assert!(d.next_ball_context.is_none());
+        assert!(d.awaiting_next_innings);
     }
 
     #[test]
@@ -540,7 +532,7 @@ mod tests {
             }),
             CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 1)),
         ];
-        let ctx = summary(&events).next_ball_context.unwrap();
+        let ctx = detail(&events).next_ball_context.unwrap();
         assert_eq!(ctx.striker_player_id.as_deref(), Some("verma"));
         assert_eq!(ctx.non_striker_player_id.as_deref(), Some("sharma"));
         assert_eq!(ctx.bowler_player_id.as_deref(), Some("patel"));
@@ -553,7 +545,7 @@ mod tests {
                 "patel", "verma", "sharma", 0,
             )));
         }
-        let ctx = summary(&all_events).next_ball_context.unwrap();
+        let ctx = detail(&all_events).next_ball_context.unwrap();
         assert_eq!(
             ctx.over, 1,
             "over completes after 6 legal balls (with the standard 6-ball-over default)"
@@ -578,7 +570,7 @@ mod tests {
                 bowling_side_id: "mill_lane".into(),
             }),
             CricketLiveEvent::Delivery(CricketDelivery {
-                wicket: Some(crate::detailed_score::cricket::CricketDeliveryWicket {
+                wicket: Some(CricketDeliveryWicket {
                     kind: CricketDismissalKind::Bowled,
                     dismissed_player_id: "sharma".into(),
                     bowler_player_id: Some("patel".into()),
@@ -587,13 +579,13 @@ mod tests {
                 ..ball("patel", "sharma", "verma", 0)
             }),
         ];
-        let ctx = summary(&events).next_ball_context.unwrap();
+        let ctx = detail(&events).next_ball_context.unwrap();
         assert!(ctx.striker_player_id.is_none());
         assert_eq!(ctx.non_striker_player_id.as_deref(), Some("verma"));
     }
 
     #[test]
-    fn retiring_hurt_vacates_the_slot_without_a_wicket() {
+    fn retiring_hurt_lets_the_same_batter_resume_without_a_wicket() {
         let events = vec![
             CricketLiveEvent::InningsStart(CricketInningsStartEvent {
                 batting_side_id: "warriors".into(),
@@ -604,12 +596,34 @@ mod tests {
                 batter_player_id: "sharma".into(),
                 retired_out: false,
             }),
+            // Sharma comes back and faces another ball — same player_id, no
+            // extra event needed for the "resume" side of things.
+            CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 1)),
         ];
-        let state = summary(&events);
-        assert_eq!(state.innings[0].wickets, 0);
-        let ctx = state.next_ball_context.unwrap();
-        assert!(ctx.striker_player_id.is_none());
-        assert_eq!(ctx.non_striker_player_id.as_deref(), Some("verma"));
+
+        let d = detail(&events);
+        assert_eq!(d.innings.len(), 1);
+        assert_eq!(
+            d.innings[0].wickets, 0,
+            "retiring hurt must not count as a wicket"
+        );
+        let sharma = d.innings[0]
+            .batting
+            .iter()
+            .find(|b| b.player_id == "sharma")
+            .unwrap();
+        assert_eq!(
+            sharma.runs, 5,
+            "runs from before and after the retirement both count"
+        );
+        assert!(matches!(
+            sharma.dismissal.as_ref().map(|w| &w.kind),
+            Some(CricketDismissalKind::RetiredHurt)
+        ));
+        assert!(
+            !d.awaiting_next_innings,
+            "the innings is still open (no InningsEnd), so we're not \"awaiting\" the next one"
+        );
     }
 
     #[test]
@@ -625,8 +639,11 @@ mod tests {
                 retired_out: true,
             }),
         ];
-        let state = summary(&events);
-        assert_eq!(state.innings[0].wickets, 1);
+
+        let d = detail(&events);
+        assert_eq!(d.innings[0].wickets, 1);
+        assert_eq!(d.innings[0].fall_of_wickets.len(), 1);
+        assert_eq!(d.innings[0].fall_of_wickets[0].player_id, "sharma");
     }
 
     #[test]
@@ -647,14 +664,14 @@ mod tests {
             CricketLiveEvent::Delivery(ball("sharma", "cole", "adeyemi", 1)),
         ];
 
-        let state = summary(&events);
-        assert_eq!(state.innings.len(), 2);
-        assert_eq!(state.innings[0].batting_side_id, "warriors");
-        assert_eq!(state.innings[0].runs, 4);
-        assert!(state.innings[0].declared);
-        assert_eq!(state.innings[1].batting_side_id, "mill_lane");
-        assert_eq!(state.innings[1].runs, 1);
-        assert!(!state.awaiting_next_innings);
+        let d = detail(&events);
+        assert_eq!(d.innings.len(), 2);
+        assert_eq!(d.innings[0].batting_side_id, "warriors");
+        assert_eq!(d.innings[0].runs, 4);
+        assert!(d.innings[0].declared);
+        assert_eq!(d.innings[1].batting_side_id, "mill_lane");
+        assert_eq!(d.innings[1].runs, 1);
+        assert!(!d.awaiting_next_innings);
     }
 
     #[test]
@@ -675,40 +692,60 @@ mod tests {
             CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 2)),
         ];
 
-        let state = summary(&events);
+        let d = detail(&events);
         assert_eq!(
-            state.innings.len(),
+            d.innings.len(),
             1,
             "the deleted end must not have split the log into two innings"
         );
-        assert_eq!(state.innings[0].runs, 6);
-        assert!(!state.awaiting_next_innings);
+        assert_eq!(d.innings[0].runs, 6);
+        assert!(!d.awaiting_next_innings);
     }
 
     #[test]
-    fn fold_full_scorecard_produces_batting_and_bowling_cards() {
+    fn incremental_and_full_fold_agree() {
         let events = vec![
             CricketLiveEvent::InningsStart(CricketInningsStartEvent {
                 batting_side_id: "warriors".into(),
                 bowling_side_id: "mill_lane".into(),
             }),
             CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 4)),
-            CricketLiveEvent::Retire(CricketRetireEvent {
-                batter_player_id: "sharma".into(),
-                retired_out: true,
+            CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 1)),
+            CricketLiveEvent::Delivery(CricketDelivery {
+                wicket: Some(CricketDeliveryWicket {
+                    kind: CricketDismissalKind::Caught,
+                    dismissed_player_id: "verma".into(),
+                    bowler_player_id: Some("patel".into()),
+                    fielder_player_id: Some("khan".into()),
+                }),
+                ..ball("patel", "verma", "sharma", 0)
             }),
         ];
-        let innings = fold_full_scorecard(&events, 6, true, true);
-        assert_eq!(innings.len(), 1);
-        assert_eq!(innings[0].wickets, 1);
-        let sharma = innings[0]
-            .batting
-            .iter()
-            .find(|b| b.player_id == "sharma")
-            .unwrap();
-        assert!(matches!(
-            sharma.dismissal.as_ref().map(|d| &d.kind),
-            Some(CricketDismissalKind::RetiredOut)
-        ));
+
+        let full = CricketDetail::from_events(&events, 6, true, true);
+
+        // Apply the same events one at a time, incrementally, and check the
+        // final state matches the full fold exactly.
+        let mut incremental = CricketDetail {
+            innings: Vec::new(),
+            recent_deliveries: None,
+            next_ball_context: None,
+            awaiting_next_innings: true,
+        };
+        for event in &events {
+            incremental.apply_event(event, 6, true, true);
+        }
+
+        assert_eq!(incremental.innings.len(), full.innings.len());
+        assert_eq!(incremental.innings[0].runs, full.innings[0].runs);
+        assert_eq!(incremental.innings[0].wickets, full.innings[0].wickets);
+        assert_eq!(
+            incremental.innings[0].batting.len(),
+            full.innings[0].batting.len()
+        );
+        assert_eq!(
+            incremental.innings[0].bowling.len(),
+            full.innings[0].bowling.len()
+        );
     }
 }

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -163,6 +163,26 @@ pub fn derive_state(
         innings.push(finish(open, false));
     }
 
+    // Only the last innings — the one actually open, or just-finished if the
+    // match is between innings — needs its ball-by-ball log kept: it's the
+    // only one the live view (the "this over" row, next-ball context) ever
+    // reads. Earlier innings in this same match only need their totals here,
+    // which keeps this whole state (recomputed and cached as one record on
+    // every single delivery — see `put_live_state`) bounded to roughly one
+    // innings' worth of balls rather than growing with the match's full
+    // history. A finished match's complete run-progression graph reads the
+    // raw event log directly instead of this cache (see
+    // `agon_ui/src/lib/cricketScore.ts`'s `inningsDeliveriesFromEvents`),
+    // since that log has no such ceiling — it's one item per ball, not one
+    // item per match.
+    if let Some(last) = innings.len().checked_sub(1) {
+        for (i, inn) in innings.iter_mut().enumerate() {
+            if i != last {
+                inn.deliveries.clear();
+            }
+        }
+    }
+
     CricketLiveState {
         innings,
         awaiting_next_innings,
@@ -351,6 +371,59 @@ mod tests {
             !state.awaiting_next_innings,
             "second innings is still open (no matching InningsEnd)"
         );
+    }
+
+    #[test]
+    fn only_the_last_innings_keeps_its_deliveries() {
+        // Three innings, the first two finished (declared) and the third
+        // still open — only the last one should carry its ball-by-ball log;
+        // the earlier two keep their totals/cards but not the deliveries
+        // that produced them (see `derive_state`'s bounding pass).
+        let events = vec![
+            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                bowling_side_id: "mill_lane".into(),
+            }),
+            CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 4)),
+            CricketLiveEvent::InningsEnd(CricketInningsEndEvent {
+                reason: InningsEndReason::Declared,
+            }),
+            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+                batting_side_id: "mill_lane".into(),
+                bowling_side_id: "warriors".into(),
+            }),
+            CricketLiveEvent::Delivery(ball("sharma", "cole", "adeyemi", 1)),
+            CricketLiveEvent::InningsEnd(CricketInningsEndEvent {
+                reason: InningsEndReason::AllOut,
+            }),
+            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                bowling_side_id: "mill_lane".into(),
+            }),
+            CricketLiveEvent::Delivery(ball("adeyemi", "patel", "verma", 6)),
+        ];
+
+        let state = derive_state(&events, 6, true, true);
+        assert_eq!(state.innings.len(), 3);
+
+        assert!(
+            state.innings[0].deliveries.is_empty(),
+            "first (finished) innings should have its deliveries cleared"
+        );
+        assert_eq!(state.innings[0].runs, 4, "totals survive the clearing");
+
+        assert!(
+            state.innings[1].deliveries.is_empty(),
+            "second (finished) innings should have its deliveries cleared"
+        );
+        assert_eq!(state.innings[1].runs, 1);
+
+        assert_eq!(
+            state.innings[2].deliveries.len(),
+            1,
+            "third (still open) innings is the last one, so it keeps its log"
+        );
+        assert_eq!(state.innings[2].runs, 6);
     }
 
     #[test]

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -1,7 +1,8 @@
 use poem_openapi::{Enum, Object, Union};
 
 use crate::detailed_score::cricket::{
-    CricketDelivery, CricketDismissal, CricketDismissalKind, CricketFallOfWicket, CricketInnings,
+    CricketBattingEntry, CricketBowlingEntry, CricketDelivery, CricketDismissal,
+    CricketDismissalKind, CricketExtras, CricketFallOfWicket, CricketInnings, Overs,
 };
 
 /// Cricket live-scoring events, nested under the outer sport union
@@ -51,16 +52,36 @@ pub struct CricketInningsEndEvent {
 }
 
 /// The live-scoring state derived by folding a match's cricket event log.
-/// `innings` reuses `detailed_score::cricket::CricketInnings` verbatim, one
-/// entry per `InningsStart`...`InningsEnd` span (plus a still-open trailing
-/// innings, if the match is mid-innings).
+/// One `CricketLiveInnings` per `InningsStart`...`InningsEnd` span (plus a
+/// still-open trailing innings, if the match is mid-innings).
 #[derive(Object)]
 pub struct CricketLiveState {
-    pub innings: Vec<CricketInnings>,
+    pub innings: Vec<CricketLiveInnings>,
     /// True once the log's last innings has an `InningsEnd` and no following
     /// `InningsStart` has opened a new one yet (i.e. between innings, or the
     /// log is empty).
     pub awaiting_next_innings: bool,
+}
+
+/// A `detailed_score::cricket::CricketInnings` overview plus the ball-by-ball
+/// log it was folded from — everything a live-scoring view needs (the "this
+/// over" ball row, striker/non-striker/bowler for the next delivery) that
+/// the persisted overview alone can't answer. Exists only in the live
+/// snapshot, derived fresh from the event log on each read; nothing this
+/// large is ever written back to a single stored record.
+#[derive(Object)]
+pub struct CricketLiveInnings {
+    pub batting_side_id: String,
+    pub bowling_side_id: String,
+    pub runs: u32,
+    pub wickets: u32,
+    pub overs: Overs,
+    pub declared: bool,
+    pub batting: Vec<CricketBattingEntry>,
+    pub bowling: Vec<CricketBowlingEntry>,
+    pub extras: CricketExtras,
+    pub fall_of_wickets: Vec<CricketFallOfWicket>,
+    pub deliveries: Vec<CricketDelivery>,
 }
 
 struct OpenInnings {
@@ -89,7 +110,7 @@ pub fn derive_state(
     wide_is_extra_ball: bool,
     no_ball_is_extra_ball: bool,
 ) -> CricketLiveState {
-    let mut innings: Vec<CricketInnings> = Vec::new();
+    let mut innings: Vec<CricketLiveInnings> = Vec::new();
     let mut current: Option<OpenInnings> = None;
 
     let finish = |open: OpenInnings, declared: bool| {
@@ -154,16 +175,29 @@ fn finish_innings(
     balls_per_over: u32,
     wide_is_extra_ball: bool,
     no_ball_is_extra_ball: bool,
-) -> CricketInnings {
-    let mut built = CricketInnings::from_deliveries(
+) -> CricketLiveInnings {
+    let overview = CricketInnings::from_deliveries(
         open.batting_side_id,
         open.bowling_side_id,
         declared,
-        open.deliveries,
+        &open.deliveries,
         balls_per_over,
         wide_is_extra_ball,
         no_ball_is_extra_ball,
     );
+    let mut built = CricketLiveInnings {
+        batting_side_id: overview.batting_side_id,
+        bowling_side_id: overview.bowling_side_id,
+        runs: overview.runs,
+        wickets: overview.wickets,
+        overs: overview.overs,
+        declared: overview.declared,
+        batting: overview.batting,
+        bowling: overview.bowling,
+        extras: overview.extras,
+        fall_of_wickets: overview.fall_of_wickets,
+        deliveries: open.deliveries,
+    };
     apply_retirements(&mut built, &open.retirements);
     built
 }
@@ -171,7 +205,7 @@ fn finish_innings(
 /// Annotates the batting card with retirements that never went through a
 /// delivery-based dismissal. A later real dismissal (from a delivery) always
 /// takes precedence over an earlier retirement note for the same batter.
-fn apply_retirements(innings: &mut CricketInnings, retirements: &[(String, bool)]) {
+fn apply_retirements(innings: &mut CricketLiveInnings, retirements: &[(String, bool)]) {
     for (player_id, retired_out) in retirements {
         let Some(entry) = innings
             .batting

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -1,15 +1,15 @@
 use poem_openapi::{Enum, Object, Union};
 
 use crate::detailed_score::cricket::{
-    CricketBattingEntry, CricketBowlingEntry, CricketDelivery, CricketDismissal,
-    CricketDismissalKind, CricketExtras, CricketFallOfWicket, CricketInnings, Overs,
+    CricketDelivery, CricketDismissal, CricketDismissalKind, CricketExtraKind, CricketFallOfWicket,
+    CricketInnings, Overs, balls_to_overs, is_legal_delivery,
 };
 
 /// Cricket live-scoring events, nested under the outer sport union
 /// (`LiveEventInput::Cricket`), discriminated by `kind`. Corrections are
 /// handled by directly deleting or amending the stored event (see
 /// `DELETE`/`PATCH /matches/:id/live/events/:seq`), not a variant here.
-#[derive(Union)]
+#[derive(Union, Clone)]
 #[oai(one_of, discriminator_name = "kind")]
 pub enum CricketLiveEvent {
     /// One ball. Reuses `detailed_score::cricket::CricketDelivery` verbatim —
@@ -21,7 +21,7 @@ pub enum CricketLiveEvent {
     InningsEnd(CricketInningsEndEvent),
 }
 
-#[derive(Object)]
+#[derive(Object, Clone)]
 pub struct CricketRetireEvent {
     pub batter_player_id: String,
     /// True: counts as a wicket (fall-of-wickets, team tally) and the batter
@@ -31,7 +31,7 @@ pub struct CricketRetireEvent {
     pub retired_out: bool,
 }
 
-#[derive(Object)]
+#[derive(Object, Clone)]
 pub struct CricketInningsStartEvent {
     pub batting_side_id: String,
     pub bowling_side_id: String,
@@ -46,42 +46,273 @@ pub enum InningsEndReason {
     TargetReached,
 }
 
-#[derive(Object)]
+#[derive(Object, Clone)]
 pub struct CricketInningsEndEvent {
     pub reason: InningsEndReason,
 }
 
-/// The live-scoring state derived by folding a match's cricket event log.
-/// One `CricketLiveInnings` per `InningsStart`...`InningsEnd` span (plus a
-/// still-open trailing innings, if the match is mid-innings).
-#[derive(Object)]
-pub struct CricketLiveState {
-    pub innings: Vec<CricketLiveInnings>,
-    /// True once the log's last innings has an `InningsEnd` and no following
-    /// `InningsStart` has opened a new one yet (i.e. between innings, or the
-    /// log is empty).
-    pub awaiting_next_innings: bool,
-}
+/// How many balls back the live summary keeps for the "this over"/recent-balls
+/// row — enough to show a bit more than the current over, nowhere near a
+/// whole innings.
+pub const RECENT_DELIVERIES_LIMIT: usize = 18;
 
-/// A `detailed_score::cricket::CricketInnings` overview plus the ball-by-ball
-/// log it was folded from — everything a live-scoring view needs (the "this
-/// over" ball row, striker/non-striker/bowler for the next delivery) that
-/// the persisted overview alone can't answer. Exists only in the live
-/// snapshot, derived fresh from the event log on each read; nothing this
-/// large is ever written back to a single stored record.
-#[derive(Object)]
-pub struct CricketLiveInnings {
+/// One innings' totals — no batting/bowling cards, no ball-by-ball log.
+/// Deliberately the same trimmed shape as `main::CricketScoreInnings`
+/// (`Score::Cricket`'s confirmed-result equivalent), kept as its own type
+/// since the two serve unrelated endpoints that shouldn't need to change
+/// together.
+#[derive(Object, Clone)]
+pub struct CricketInningsTotals {
     pub batting_side_id: String,
     pub bowling_side_id: String,
     pub runs: u32,
     pub wickets: u32,
     pub overs: Overs,
     pub declared: bool,
-    pub batting: Vec<CricketBattingEntry>,
-    pub bowling: Vec<CricketBowlingEntry>,
-    pub extras: CricketExtras,
-    pub fall_of_wickets: Vec<CricketFallOfWicket>,
-    pub deliveries: Vec<CricketDelivery>,
+}
+
+/// What's known about who's at the crease/bowling for the *next* delivery,
+/// folded incrementally from the current innings' events as they're
+/// recorded. A `None` field means the scorer needs to pick someone before
+/// the next ball can be recorded — either a fresh innings (nothing bowled
+/// yet), a wicket just fell (the dismissed batter's slot is open), or an
+/// over just completed (a new bowler is required; the same bowler can't
+/// bowl consecutive overs).
+///
+/// Mirrors `agon_ui/src/lib/cricketScore.ts`'s `NextBallContext` and
+/// `nextBallContext` field-for-field and step-for-step — kept in sync by
+/// hand. The frontend runs the identical fold offline, against deliveries a
+/// device has recorded locally but not yet synced, which is exactly the case
+/// this incremental (one delivery at a time) shape is built for: apply one
+/// step to the last-known context, don't replay history.
+#[derive(Object, Clone)]
+pub struct NextBallContext {
+    pub striker_player_id: Option<String>,
+    pub non_striker_player_id: Option<String>,
+    pub bowler_player_id: Option<String>,
+    /// 0-based over index the next delivery belongs to.
+    pub over: u32,
+    /// 1-based ball number within that over.
+    pub ball: u32,
+    /// The bowler who just finished an over — excluded from the next-bowler
+    /// picker. `None` unless a bowler pick is actually needed.
+    pub previous_over_bowler_player_id: Option<String>,
+}
+
+impl NextBallContext {
+    /// The state before any delivery has been recorded in an innings.
+    fn opening() -> Self {
+        NextBallContext {
+            striker_player_id: None,
+            non_striker_player_id: None,
+            bowler_player_id: None,
+            over: 0,
+            ball: 1,
+            previous_over_bowler_player_id: None,
+        }
+    }
+}
+
+/// Folds one delivery into the running next-ball context. The whole
+/// incremental step: called once per new delivery on the append path, and
+/// repeatedly from `NextBallContext::opening()` to bootstrap/recover a
+/// summary from the full event log (see `CricketLiveState::from_events`).
+///
+/// Strike rotates on an odd number of the ball's rotating runs (off the bat,
+/// or byes/leg-byes — wides/no-balls don't rotate strike) and always at the
+/// end of an over — including when one slot is already vacant from a wicket
+/// on that same ball (e.g. dismissed on the over's final ball): the swap
+/// still applies to whichever slot the survivor occupies, so the vacancy
+/// lands in the correct slot for the next ball rather than always defaulting
+/// to "striker".
+fn apply_delivery_to_context(
+    prev: &NextBallContext,
+    d: &CricketDelivery,
+    balls_per_over: u32,
+    wide_is_extra_ball: bool,
+    no_ball_is_extra_ball: bool,
+) -> NextBallContext {
+    let mut striker = Some(d.striker_player_id.clone());
+    let mut non_striker = Some(d.non_striker_player_id.clone());
+    let mut bowler = Some(d.bowler_player_id.clone());
+    let mut previous_over_bowler: Option<String> = None;
+    let mut legal_in_over = prev.ball.saturating_sub(1);
+    let mut over = prev.over;
+
+    if let Some(wicket) = &d.wicket {
+        if striker.as_deref() == Some(wicket.dismissed_player_id.as_str()) {
+            striker = None;
+        } else if non_striker.as_deref() == Some(wicket.dismissed_player_id.as_str()) {
+            non_striker = None;
+        }
+    }
+
+    if is_legal_delivery(d, wide_is_extra_ball, no_ball_is_extra_ball) {
+        legal_in_over += 1;
+        let rotating_runs = d.runs_off_bat
+            + match d.extra.as_ref().map(|e| &e.kind) {
+                Some(CricketExtraKind::Bye) | Some(CricketExtraKind::LegBye) => {
+                    d.extra.as_ref().map(|e| e.runs).unwrap_or(0)
+                }
+                _ => 0,
+            };
+        if rotating_runs % 2 == 1 {
+            std::mem::swap(&mut striker, &mut non_striker);
+        }
+        if legal_in_over == balls_per_over {
+            std::mem::swap(&mut striker, &mut non_striker);
+            previous_over_bowler = bowler.take();
+            over += 1;
+            legal_in_over = 0;
+        }
+    }
+
+    NextBallContext {
+        striker_player_id: striker,
+        non_striker_player_id: non_striker,
+        bowler_player_id: bowler,
+        over,
+        ball: legal_in_over + 1,
+        previous_over_bowler_player_id: previous_over_bowler,
+    }
+}
+
+/// The live-scoring summary, folded from a match's cricket event log — fixed
+/// size regardless of how long the match runs or how many events its log
+/// holds, so it's safe to cache and update on every single delivery (see
+/// `agon_core::dao::live_score_ops`). `innings` totals cover the whole match
+/// so far; `recent_deliveries` and `next_ball_context` only ever describe the
+/// current (open, or just-finished) innings — a finished match's complete
+/// ball-by-ball history reads the raw event log instead (paginated —
+/// `GET /matches/:id/live/events`, folded client-side by
+/// `inningsDeliveriesFromEvents`).
+#[derive(Object, Clone)]
+pub struct CricketLiveState {
+    pub innings: Vec<CricketInningsTotals>,
+    /// The current innings' most recent deliveries, oldest first, capped at
+    /// `RECENT_DELIVERIES_LIMIT`. Empty between innings.
+    pub recent_deliveries: Vec<CricketDelivery>,
+    /// `None` between innings — there's no next ball to give context for.
+    pub next_ball_context: Option<NextBallContext>,
+    /// True once the log's last innings has an `InningsEnd` and no following
+    /// `InningsStart` has opened a new one yet (i.e. between innings, or the
+    /// log is empty).
+    pub awaiting_next_innings: bool,
+}
+
+impl CricketLiveState {
+    fn empty() -> Self {
+        CricketLiveState {
+            innings: Vec::new(),
+            recent_deliveries: Vec::new(),
+            next_ball_context: None,
+            awaiting_next_innings: true,
+        }
+    }
+
+    /// Folds the whole event log into a summary from scratch — the slow
+    /// path, used to bootstrap a match's first summary, recover from a
+    /// missing/unparseable cache, or rebuild after a correction (an
+    /// arbitrary-position delete/amend can't be applied as a single
+    /// incremental step). Just `apply_event` run once per event in order;
+    /// the fast (single-event) and slow (whole-log) paths share the exact
+    /// same fold, so they can't disagree.
+    pub fn from_events(
+        events: &[CricketLiveEvent],
+        balls_per_over: u32,
+        wide_is_extra_ball: bool,
+        no_ball_is_extra_ball: bool,
+    ) -> Self {
+        let mut state = CricketLiveState::empty();
+        for event in events {
+            state.apply_event(
+                event,
+                balls_per_over,
+                wide_is_extra_ball,
+                no_ball_is_extra_ball,
+            );
+        }
+        state
+    }
+
+    /// Folds one new event into this summary in place — the fast path, run
+    /// on every append.
+    pub fn apply_event(
+        &mut self,
+        event: &CricketLiveEvent,
+        balls_per_over: u32,
+        wide_is_extra_ball: bool,
+        no_ball_is_extra_ball: bool,
+    ) {
+        match event {
+            CricketLiveEvent::InningsStart(start) => {
+                self.innings.push(CricketInningsTotals {
+                    batting_side_id: start.batting_side_id.clone(),
+                    bowling_side_id: start.bowling_side_id.clone(),
+                    runs: 0,
+                    wickets: 0,
+                    overs: Overs { overs: 0, balls: 0 },
+                    declared: false,
+                });
+                self.recent_deliveries.clear();
+                self.next_ball_context = Some(NextBallContext::opening());
+                self.awaiting_next_innings = false;
+            }
+            CricketLiveEvent::Delivery(d) => {
+                if let Some(current) = self.innings.last_mut() {
+                    let extra_runs = d.extra.as_ref().map(|e| e.runs).unwrap_or(0);
+                    current.runs += d.runs_off_bat + extra_runs;
+                    if is_legal_delivery(d, wide_is_extra_ball, no_ball_is_extra_ball) {
+                        let legal_balls =
+                            current.overs.overs * balls_per_over + current.overs.balls + 1;
+                        current.overs = balls_to_overs(legal_balls, balls_per_over);
+                    }
+                    if d.wicket.is_some() {
+                        current.wickets += 1;
+                    }
+                }
+                self.recent_deliveries.push(d.clone());
+                if self.recent_deliveries.len() > RECENT_DELIVERIES_LIMIT {
+                    self.recent_deliveries.remove(0);
+                }
+                let prev = self
+                    .next_ball_context
+                    .clone()
+                    .unwrap_or_else(NextBallContext::opening);
+                self.next_ball_context = Some(apply_delivery_to_context(
+                    &prev,
+                    d,
+                    balls_per_over,
+                    wide_is_extra_ball,
+                    no_ball_is_extra_ball,
+                ));
+            }
+            CricketLiveEvent::Retire(r) => {
+                if r.retired_out
+                    && let Some(current) = self.innings.last_mut()
+                {
+                    current.wickets += 1;
+                }
+                if let Some(ctx) = &mut self.next_ball_context {
+                    if ctx.striker_player_id.as_deref() == Some(r.batter_player_id.as_str()) {
+                        ctx.striker_player_id = None;
+                    } else if ctx.non_striker_player_id.as_deref()
+                        == Some(r.batter_player_id.as_str())
+                    {
+                        ctx.non_striker_player_id = None;
+                    }
+                }
+            }
+            CricketLiveEvent::InningsEnd(end) => {
+                if let Some(current) = self.innings.last_mut() {
+                    current.declared = matches!(end.reason, InningsEndReason::Declared);
+                }
+                self.recent_deliveries.clear();
+                self.next_ball_context = None;
+                self.awaiting_next_innings = true;
+            }
+        }
+    }
 }
 
 struct OpenInnings {
@@ -91,26 +322,30 @@ struct OpenInnings {
     retirements: Vec<(String, bool)>,
 }
 
-/// Folds an ordered list of events into the derived live state. Callers pass
-/// whatever the DAO currently has on record — a deleted event is simply
-/// absent from that list, and an amended one shows up with its corrected
-/// content, so this never needs to know a correction happened at all.
+/// Folds a match's whole cricket event log into its full per-innings
+/// scorecard (batting/bowling cards, extras, fall-of-wickets) — the same
+/// shape `detailed_score` persists. Internal only: the one place this runs
+/// is server-side, once, when a live-scored cricket match is marked
+/// complete without an explicit `detailed_score` (see `update_match`), to
+/// derive and persist it from the authoritative log. Never exposed on a
+/// hot/polled path — `GET /live` serves `CricketLiveState` instead, which
+/// carries totals only plus a bounded recent-deliveries window.
 ///
-/// Innings boundaries come entirely from `InningsStart`/`InningsEnd` markers,
-/// not a stored index — so deleting a wrongly-placed boundary automatically
-/// re-flows every event after it back into the earlier innings on the next
-/// fold, with nothing to rewrite.
+/// Innings boundaries come entirely from `InningsStart`/`InningsEnd`
+/// markers, not a stored index — so deleting a wrongly-placed boundary
+/// automatically re-flows every event after it back into the earlier
+/// innings on the next fold, with nothing to rewrite.
 /// `balls_per_over`, `wide_is_extra_ball` and `no_ball_is_extra_ball` are the
 /// match's configured over length and extra-ball rules (see
 /// `agon_service::match_format::CricketFormat`); callers without a
 /// configured format pass the standard defaults (6, true, true).
-pub fn derive_state(
+pub fn fold_full_scorecard(
     events: &[CricketLiveEvent],
     balls_per_over: u32,
     wide_is_extra_ball: bool,
     no_ball_is_extra_ball: bool,
-) -> CricketLiveState {
-    let mut innings: Vec<CricketLiveInnings> = Vec::new();
+) -> Vec<CricketInnings> {
+    let mut innings: Vec<CricketInnings> = Vec::new();
     let mut current: Option<OpenInnings> = None;
 
     let finish = |open: OpenInnings, declared: bool| {
@@ -158,36 +393,11 @@ pub fn derive_state(
         }
     }
 
-    let awaiting_next_innings = current.is_none();
     if let Some(open) = current {
         innings.push(finish(open, false));
     }
 
-    // Only the last innings — the one actually open, or just-finished if the
-    // match is between innings — needs its ball-by-ball log kept: it's the
-    // only one the live view (the "this over" row, next-ball context) ever
-    // reads, both for `GET /live` and for a device folding its own offline
-    // queue the same way. Earlier innings in this same match only need their
-    // totals here, which keeps every `GET /live`/append response (this is
-    // derived fresh on each one — see `derive_live_snapshot`, no cache
-    // involved) bounded to roughly one innings' worth of balls rather than
-    // the match's full history. A finished match's complete run-progression
-    // graph instead reads the raw event log directly (see
-    // `agon_ui/src/lib/cricketScore.ts`'s `inningsDeliveriesFromEvents`),
-    // which has no such reason to bound — one item per ball, not one item
-    // (or one response) per match.
-    if let Some(last) = innings.len().checked_sub(1) {
-        for (i, inn) in innings.iter_mut().enumerate() {
-            if i != last {
-                inn.deliveries.clear();
-            }
-        }
-    }
-
-    CricketLiveState {
-        innings,
-        awaiting_next_innings,
-    }
+    innings
 }
 
 fn finish_innings(
@@ -196,8 +406,8 @@ fn finish_innings(
     balls_per_over: u32,
     wide_is_extra_ball: bool,
     no_ball_is_extra_ball: bool,
-) -> CricketLiveInnings {
-    let overview = CricketInnings::from_deliveries(
+) -> CricketInnings {
+    let mut built = CricketInnings::from_deliveries(
         open.batting_side_id,
         open.bowling_side_id,
         declared,
@@ -206,19 +416,6 @@ fn finish_innings(
         wide_is_extra_ball,
         no_ball_is_extra_ball,
     );
-    let mut built = CricketLiveInnings {
-        batting_side_id: overview.batting_side_id,
-        bowling_side_id: overview.bowling_side_id,
-        runs: overview.runs,
-        wickets: overview.wickets,
-        overs: overview.overs,
-        declared: overview.declared,
-        batting: overview.batting,
-        bowling: overview.bowling,
-        extras: overview.extras,
-        fall_of_wickets: overview.fall_of_wickets,
-        deliveries: open.deliveries,
-    };
     apply_retirements(&mut built, &open.retirements);
     built
 }
@@ -226,7 +423,7 @@ fn finish_innings(
 /// Annotates the batting card with retirements that never went through a
 /// delivery-based dismissal. A later real dismissal (from a delivery) always
 /// takes precedence over an earlier retirement note for the same batter.
-fn apply_retirements(innings: &mut CricketLiveInnings, retirements: &[(String, bool)]) {
+fn apply_retirements(innings: &mut CricketInnings, retirements: &[(String, bool)]) {
     for (player_id, retired_out) in retirements {
         let Some(entry) = innings
             .batting
@@ -279,8 +476,124 @@ mod tests {
         }
     }
 
+    fn summary(events: &[CricketLiveEvent]) -> CricketLiveState {
+        CricketLiveState::from_events(events, 6, true, true)
+    }
+
     #[test]
-    fn retiring_hurt_lets_the_same_batter_resume_without_a_wicket() {
+    fn tracks_runs_wickets_overs_per_innings() {
+        let events = vec![
+            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                bowling_side_id: "mill_lane".into(),
+            }),
+            CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 4)),
+            CricketLiveEvent::Delivery(CricketDelivery {
+                wicket: Some(crate::detailed_score::cricket::CricketDeliveryWicket {
+                    kind: CricketDismissalKind::Bowled,
+                    dismissed_player_id: "sharma".into(),
+                    bowler_player_id: Some("patel".into()),
+                    fielder_player_id: None,
+                }),
+                ..ball("patel", "sharma", "verma", 0)
+            }),
+        ];
+
+        let state = summary(&events);
+        assert_eq!(state.innings.len(), 1);
+        assert_eq!(state.innings[0].runs, 4);
+        assert_eq!(state.innings[0].wickets, 1);
+        assert_eq!(state.innings[0].overs, Overs { overs: 0, balls: 2 });
+        assert!(!state.awaiting_next_innings);
+    }
+
+    #[test]
+    fn recent_deliveries_is_capped_and_cleared_between_innings() {
+        let mut events = vec![CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+            batting_side_id: "warriors".into(),
+            bowling_side_id: "mill_lane".into(),
+        })];
+        for _ in 0..(RECENT_DELIVERIES_LIMIT + 5) {
+            events.push(CricketLiveEvent::Delivery(ball(
+                "patel", "sharma", "verma", 1,
+            )));
+        }
+        let state = summary(&events);
+        assert_eq!(state.recent_deliveries.len(), RECENT_DELIVERIES_LIMIT);
+        assert_eq!(state.innings[0].runs, RECENT_DELIVERIES_LIMIT as u32 + 5);
+
+        events.push(CricketLiveEvent::InningsEnd(CricketInningsEndEvent {
+            reason: InningsEndReason::Declared,
+        }));
+        let state = summary(&events);
+        assert!(state.recent_deliveries.is_empty());
+        assert!(state.next_ball_context.is_none());
+        assert!(state.awaiting_next_innings);
+    }
+
+    #[test]
+    fn next_ball_context_rotates_strike_on_odd_runs_and_over_boundary() {
+        let events = vec![
+            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                bowling_side_id: "mill_lane".into(),
+            }),
+            CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 1)),
+        ];
+        let ctx = summary(&events).next_ball_context.unwrap();
+        assert_eq!(ctx.striker_player_id.as_deref(), Some("verma"));
+        assert_eq!(ctx.non_striker_player_id.as_deref(), Some("sharma"));
+        assert_eq!(ctx.bowler_player_id.as_deref(), Some("patel"));
+        assert_eq!(ctx.ball, 2);
+        assert_eq!(ctx.over, 0);
+
+        let mut all_events = events;
+        for _ in 0..5 {
+            all_events.push(CricketLiveEvent::Delivery(ball(
+                "patel", "verma", "sharma", 0,
+            )));
+        }
+        let ctx = summary(&all_events).next_ball_context.unwrap();
+        assert_eq!(
+            ctx.over, 1,
+            "over completes after 6 legal balls (with the standard 6-ball-over default)"
+        );
+        assert_eq!(ctx.ball, 1);
+        assert_eq!(
+            ctx.previous_over_bowler_player_id.as_deref(),
+            Some("patel"),
+            "the over's bowler can't be picked again for the next one"
+        );
+        assert!(
+            ctx.bowler_player_id.is_none(),
+            "a new bowler must be picked for the next over"
+        );
+    }
+
+    #[test]
+    fn a_wicket_vacates_the_dismissed_batters_slot() {
+        let events = vec![
+            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                bowling_side_id: "mill_lane".into(),
+            }),
+            CricketLiveEvent::Delivery(CricketDelivery {
+                wicket: Some(crate::detailed_score::cricket::CricketDeliveryWicket {
+                    kind: CricketDismissalKind::Bowled,
+                    dismissed_player_id: "sharma".into(),
+                    bowler_player_id: Some("patel".into()),
+                    fielder_player_id: None,
+                }),
+                ..ball("patel", "sharma", "verma", 0)
+            }),
+        ];
+        let ctx = summary(&events).next_ball_context.unwrap();
+        assert!(ctx.striker_player_id.is_none());
+        assert_eq!(ctx.non_striker_player_id.as_deref(), Some("verma"));
+    }
+
+    #[test]
+    fn retiring_hurt_vacates_the_slot_without_a_wicket() {
         let events = vec![
             CricketLiveEvent::InningsStart(CricketInningsStartEvent {
                 batting_side_id: "warriors".into(),
@@ -291,35 +604,12 @@ mod tests {
                 batter_player_id: "sharma".into(),
                 retired_out: false,
             }),
-            // Sharma comes back and faces another ball — same player_id, no
-            // extra event needed for the "resume" side of things.
-            CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 1)),
         ];
-
-        let state = derive_state(&events, 6, true, true);
-        assert_eq!(state.innings.len(), 1);
-        let innings = &state.innings[0];
-        assert_eq!(
-            innings.wickets, 0,
-            "retiring hurt must not count as a wicket"
-        );
-        let sharma = innings
-            .batting
-            .iter()
-            .find(|b| b.player_id == "sharma")
-            .unwrap();
-        assert_eq!(
-            sharma.runs, 5,
-            "runs from before and after the retirement both count"
-        );
-        assert!(matches!(
-            sharma.dismissal.as_ref().map(|d| &d.kind),
-            Some(CricketDismissalKind::RetiredHurt)
-        ));
-        assert!(
-            !state.awaiting_next_innings,
-            "the innings is still open (no InningsEnd), so we're not \"awaiting\" the next one"
-        );
+        let state = summary(&events);
+        assert_eq!(state.innings[0].wickets, 0);
+        let ctx = state.next_ball_context.unwrap();
+        assert!(ctx.striker_player_id.is_none());
+        assert_eq!(ctx.non_striker_player_id.as_deref(), Some("verma"));
     }
 
     #[test]
@@ -335,16 +625,12 @@ mod tests {
                 retired_out: true,
             }),
         ];
-
-        let state = derive_state(&events, 6, true, true);
-        let innings = &state.innings[0];
-        assert_eq!(innings.wickets, 1);
-        assert_eq!(innings.fall_of_wickets.len(), 1);
-        assert_eq!(innings.fall_of_wickets[0].player_id, "sharma");
+        let state = summary(&events);
+        assert_eq!(state.innings[0].wickets, 1);
     }
 
     #[test]
-    fn innings_end_and_start_split_deliveries_by_inferred_index_not_a_stored_field() {
+    fn innings_end_and_start_split_totals_by_inferred_index_not_a_stored_field() {
         let events = vec![
             CricketLiveEvent::InningsStart(CricketInningsStartEvent {
                 batting_side_id: "warriors".into(),
@@ -361,77 +647,21 @@ mod tests {
             CricketLiveEvent::Delivery(ball("sharma", "cole", "adeyemi", 1)),
         ];
 
-        let state = derive_state(&events, 6, true, true);
+        let state = summary(&events);
         assert_eq!(state.innings.len(), 2);
         assert_eq!(state.innings[0].batting_side_id, "warriors");
         assert_eq!(state.innings[0].runs, 4);
         assert!(state.innings[0].declared);
         assert_eq!(state.innings[1].batting_side_id, "mill_lane");
         assert_eq!(state.innings[1].runs, 1);
-        assert!(
-            !state.awaiting_next_innings,
-            "second innings is still open (no matching InningsEnd)"
-        );
-    }
-
-    #[test]
-    fn only_the_last_innings_keeps_its_deliveries() {
-        // Three innings, the first two finished (declared) and the third
-        // still open — only the last one should carry its ball-by-ball log;
-        // the earlier two keep their totals/cards but not the deliveries
-        // that produced them (see `derive_state`'s bounding pass).
-        let events = vec![
-            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
-                batting_side_id: "warriors".into(),
-                bowling_side_id: "mill_lane".into(),
-            }),
-            CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 4)),
-            CricketLiveEvent::InningsEnd(CricketInningsEndEvent {
-                reason: InningsEndReason::Declared,
-            }),
-            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
-                batting_side_id: "mill_lane".into(),
-                bowling_side_id: "warriors".into(),
-            }),
-            CricketLiveEvent::Delivery(ball("sharma", "cole", "adeyemi", 1)),
-            CricketLiveEvent::InningsEnd(CricketInningsEndEvent {
-                reason: InningsEndReason::AllOut,
-            }),
-            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
-                batting_side_id: "warriors".into(),
-                bowling_side_id: "mill_lane".into(),
-            }),
-            CricketLiveEvent::Delivery(ball("adeyemi", "patel", "verma", 6)),
-        ];
-
-        let state = derive_state(&events, 6, true, true);
-        assert_eq!(state.innings.len(), 3);
-
-        assert!(
-            state.innings[0].deliveries.is_empty(),
-            "first (finished) innings should have its deliveries cleared"
-        );
-        assert_eq!(state.innings[0].runs, 4, "totals survive the clearing");
-
-        assert!(
-            state.innings[1].deliveries.is_empty(),
-            "second (finished) innings should have its deliveries cleared"
-        );
-        assert_eq!(state.innings[1].runs, 1);
-
-        assert_eq!(
-            state.innings[2].deliveries.len(),
-            1,
-            "third (still open) innings is the last one, so it keeps its log"
-        );
-        assert_eq!(state.innings[2].runs, 6);
+        assert!(!state.awaiting_next_innings);
     }
 
     #[test]
     fn deleting_a_wrongly_placed_innings_end_re_flows_events_into_the_earlier_innings() {
         // A scorer wrongly taps "end innings" after one ball and deletes that
         // event (DELETE /matches/:id/live/events/:seq) rather than voiding
-        // it — from derive_state's point of view that's indistinguishable
+        // it — from a full refold's point of view that's indistinguishable
         // from it never having been recorded: the deleted event is just
         // absent from the list it's given.
         let events = vec![
@@ -445,8 +675,7 @@ mod tests {
             CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 2)),
         ];
 
-        let state = derive_state(&events, 6, true, true);
-
+        let state = summary(&events);
         assert_eq!(
             state.innings.len(),
             1,
@@ -454,5 +683,32 @@ mod tests {
         );
         assert_eq!(state.innings[0].runs, 6);
         assert!(!state.awaiting_next_innings);
+    }
+
+    #[test]
+    fn fold_full_scorecard_produces_batting_and_bowling_cards() {
+        let events = vec![
+            CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                bowling_side_id: "mill_lane".into(),
+            }),
+            CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 4)),
+            CricketLiveEvent::Retire(CricketRetireEvent {
+                batter_player_id: "sharma".into(),
+                retired_out: true,
+            }),
+        ];
+        let innings = fold_full_scorecard(&events, 6, true, true);
+        assert_eq!(innings.len(), 1);
+        assert_eq!(innings[0].wickets, 1);
+        let sharma = innings[0]
+            .batting
+            .iter()
+            .find(|b| b.player_id == "sharma")
+            .unwrap();
+        assert!(matches!(
+            sharma.dismissal.as_ref().map(|d| &d.kind),
+            Some(CricketDismissalKind::RetiredOut)
+        ));
     }
 }

--- a/agon_service/src/live_score/football.rs
+++ b/agon_service/src/live_score/football.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use poem_openapi::{Object, Union};
 
 use crate::detailed_score::football::{
@@ -36,10 +38,7 @@ pub fn derive_detail(
     events: &[(chrono::DateTime<chrono::Utc>, FootballLiveEvent)],
 ) -> FootballDetail {
     let mut period = None;
-    let mut kickoff_at = None;
-    let mut half_time_at = None;
-    let mut second_half_kickoff_at = None;
-    let mut full_time_at = None;
+    let mut period_times = HashMap::new();
     let mut score: Vec<FootballSideGoals> = Vec::new();
     let mut goals = Vec::new();
     let mut cards = Vec::new();
@@ -65,20 +64,8 @@ pub fn derive_detail(
                 substitutions.push(sub.clone());
             }
             FootballLiveEvent::Period(p) => {
-                match p.period {
-                    FootballPeriod::KickOff => kickoff_at = Some(*occurred_at),
-                    FootballPeriod::HalfTime => half_time_at = Some(*occurred_at),
-                    FootballPeriod::SecondHalfKickOff => {
-                        second_half_kickoff_at = Some(*occurred_at)
-                    }
-                    FootballPeriod::FullTime => full_time_at = Some(*occurred_at),
-                    // Extra time / penalties aren't clocked yet — only the
-                    // marker itself is tracked, same as before.
-                    FootballPeriod::ExtraTimeHalfTime
-                    | FootballPeriod::ExtraTimeFullTime
-                    | FootballPeriod::PenaltiesComplete => {}
-                }
-                period = Some(p.period.clone());
+                period_times.insert(p.period, *occurred_at);
+                period = Some(p.period);
             }
         }
     }
@@ -89,10 +76,7 @@ pub fn derive_detail(
         cards,
         substitutions,
         period,
-        kickoff_at,
-        half_time_at,
-        second_half_kickoff_at,
-        full_time_at,
+        period_times,
     }
 }
 
@@ -167,7 +151,10 @@ mod tests {
         assert_eq!(detail.cards.len(), 1);
         assert_eq!(detail.substitutions.len(), 1);
         assert!(matches!(detail.period, Some(FootballPeriod::FullTime)));
-        assert_eq!(detail.full_time_at, Some(ts(94)));
+        assert_eq!(
+            detail.period_times.get(&FootballPeriod::FullTime),
+            Some(&ts(94))
+        );
         assert!(detail.goals[1].own_goal);
         assert_eq!(detail.substitutions[0].player_out_id, "khan");
     }
@@ -197,13 +184,61 @@ mod tests {
 
         let detail = derive_detail(&events);
 
-        assert_eq!(detail.kickoff_at, Some(ts(0)));
-        assert_eq!(detail.half_time_at, Some(ts(46)));
-        assert_eq!(detail.second_half_kickoff_at, Some(ts(60)));
-        assert_eq!(detail.full_time_at, None);
+        assert_eq!(
+            detail.period_times.get(&FootballPeriod::KickOff),
+            Some(&ts(0))
+        );
+        assert_eq!(
+            detail.period_times.get(&FootballPeriod::HalfTime),
+            Some(&ts(46))
+        );
+        assert_eq!(
+            detail.period_times.get(&FootballPeriod::SecondHalfKickOff),
+            Some(&ts(60))
+        );
+        assert_eq!(detail.period_times.get(&FootballPeriod::FullTime), None);
         assert!(matches!(
             detail.period,
             Some(FootballPeriod::SecondHalfKickOff)
         ));
+    }
+
+    #[test]
+    fn extra_time_and_penalties_markers_get_timestamps_too() {
+        let events = vec![
+            (
+                ts(120),
+                FootballLiveEvent::Period(FootballPeriodEvent {
+                    period: FootballPeriod::ExtraTimeHalfTime,
+                }),
+            ),
+            (
+                ts(150),
+                FootballLiveEvent::Period(FootballPeriodEvent {
+                    period: FootballPeriod::ExtraTimeFullTime,
+                }),
+            ),
+            (
+                ts(160),
+                FootballLiveEvent::Period(FootballPeriodEvent {
+                    period: FootballPeriod::PenaltiesComplete,
+                }),
+            ),
+        ];
+
+        let detail = derive_detail(&events);
+
+        assert_eq!(
+            detail.period_times.get(&FootballPeriod::ExtraTimeHalfTime),
+            Some(&ts(120))
+        );
+        assert_eq!(
+            detail.period_times.get(&FootballPeriod::ExtraTimeFullTime),
+            Some(&ts(150))
+        );
+        assert_eq!(
+            detail.period_times.get(&FootballPeriod::PenaltiesComplete),
+            Some(&ts(160))
+        );
     }
 }

--- a/agon_service/src/live_score/football.rs
+++ b/agon_service/src/live_score/football.rs
@@ -1,131 +1,49 @@
-use poem_openapi::{Enum, Object, Union};
+use poem_openapi::{Object, Union};
 
-use crate::detailed_score::football::{FootballEvent, FootballEventKind};
+use crate::detailed_score::football::{
+    FootballCardEvent, FootballDetail, FootballGoalEvent, FootballPeriod, FootballSideGoals,
+    FootballSubstitutionEvent,
+};
 
 /// Football live-scoring events, nested under the outer sport union
 /// (`LiveEventInput::Football`), discriminated by `kind`. Corrections are
 /// handled by directly deleting or amending the stored event (see
 /// `DELETE`/`PATCH /matches/:id/live/events/:seq`), not a variant here.
-#[derive(Union)]
+#[derive(Union, Clone)]
 #[oai(one_of, discriminator_name = "kind")]
 pub enum FootballLiveEvent {
+    /// Reuses `detailed_score::football::FootballGoalEvent` verbatim — see
+    /// `CricketLiveEvent::Delivery`'s doc comment for why.
     Goal(FootballGoalEvent),
     Card(FootballCardEvent),
     Substitution(FootballSubstitutionEvent),
     Period(FootballPeriodEvent),
 }
 
-#[derive(Object)]
-pub struct FootballGoalEvent {
-    /// The side this goal counts for.
-    pub side_id: String,
-    /// None for an own goal with no recorded scorer.
-    pub scorer_player_id: Option<String>,
-    pub assist_player_id: Option<String>,
-    pub own_goal: bool,
-    pub penalty: bool,
-    pub minute: Option<u32>,
-}
-
-#[derive(Enum, Clone)]
-#[oai(rename_all = "snake_case")]
-pub enum FootballCardColor {
-    Yellow,
-    Red,
-}
-
-#[derive(Object)]
-pub struct FootballCardEvent {
-    pub side_id: String,
-    pub player_id: String,
-    pub color: FootballCardColor,
-    pub minute: Option<u32>,
-}
-
-#[derive(Object)]
-pub struct FootballSubstitutionEvent {
-    pub side_id: String,
-    pub player_in_id: String,
-    pub player_out_id: String,
-    pub minute: Option<u32>,
-}
-
-#[derive(Enum, Clone, PartialEq)]
-#[oai(rename_all = "snake_case")]
-pub enum FootballPeriod {
-    /// Kickoff — the moment the match clock actually starts. Recorded once,
-    /// when the scorer starts live scoring; distinct from `Match.starts_at`
-    /// (the *scheduled* time), which may not match when the whistle actually
-    /// blew.
-    KickOff,
-    HalfTime,
-    /// Kickoff of the second half — no clock gap is assumed between this and
-    /// `HalfTime`, so added time in the first half is preserved automatically
-    /// (the second half's clock continues from wherever the first half's
-    /// left off, not from a fixed 45').
-    SecondHalfKickOff,
-    FullTime,
-    ExtraTimeHalfTime,
-    ExtraTimeFullTime,
-    PenaltiesComplete,
-}
-
-#[derive(Object)]
+#[derive(Object, Clone)]
 pub struct FootballPeriodEvent {
     pub period: FootballPeriod,
 }
 
-/// A side's running goal tally, derived from the event log (a convenience for
-/// cheap reads — e.g. a feed card — that don't want to re-derive it from
-/// `events` themselves).
-#[derive(Object)]
-pub struct FootballSideGoals {
-    pub side_id: String,
-    pub goals: u32,
-}
-
-/// The live-scoring state derived by folding a match's football event log.
-/// `events` reuses `detailed_score::football::FootballEvent` verbatim — this
-/// *is* that timeline, just built up incrementally.
-///
-/// The `*_at` fields are the wall-clock moments each phase boundary was
-/// actually recorded (each period marker's own `occurred_at`), not derived
-/// from `Match.starts_at` — a scorer may start the clock later than the
-/// scheduled kickoff. Together they let every client — the scorer's device
-/// and any other viewer alike — compute the same running match minute
-/// without needing a clock of their own: `now - kickoff_at` while in the
-/// first half, `now - second_half_kickoff_at` plus the first half's length
-/// once the second half is under way, frozen at the relevant boundary during
-/// half-time/full-time.
-#[derive(Object)]
-pub struct FootballLiveState {
-    /// The most recent period marker seen, if any.
-    pub period: Option<FootballPeriod>,
-    pub kickoff_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub half_time_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub second_half_kickoff_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub full_time_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub score: Vec<FootballSideGoals>,
-    pub events: Vec<FootballEvent>,
-}
-
-/// Folds an ordered, timestamped list of events into the derived live state.
-/// Callers pass whatever the DAO currently has on record — a deleted event is
-/// simply absent from that list, and an amended one shows up with its
-/// corrected content, so this never needs to know a correction happened at
-/// all. Each event is paired with its own `occurred_at` (not `recorded_at`)
-/// so a period marker's timestamp reflects when the half actually
-/// started/ended on the pitch, not when the server received it.
-pub fn derive_state(
+/// Folds an ordered, timestamped list of events into the match's full
+/// detail — cheap enough to do on every read; football's event volume
+/// (goals, cards, subs) never approaches cricket's ball-by-ball scale, so
+/// there's no bounding or incremental-caching concern here the way there is
+/// for cricket. Each event is paired with its own `occurred_at` (not
+/// `recorded_at`) so a period marker's timestamp reflects when the half
+/// actually started/ended on the pitch, not when the server received it.
+pub fn derive_detail(
     events: &[(chrono::DateTime<chrono::Utc>, FootballLiveEvent)],
-) -> FootballLiveState {
+) -> FootballDetail {
     let mut period = None;
     let mut kickoff_at = None;
     let mut half_time_at = None;
     let mut second_half_kickoff_at = None;
     let mut full_time_at = None;
     let mut score: Vec<FootballSideGoals> = Vec::new();
-    let mut out = Vec::new();
+    let mut goals = Vec::new();
+    let mut cards = Vec::new();
+    let mut substitutions = Vec::new();
 
     for (occurred_at, event) in events {
         match event {
@@ -138,44 +56,13 @@ pub fn derive_state(
                         goals: 1,
                     });
                 }
-                let kind = if g.own_goal {
-                    FootballEventKind::OwnGoal
-                } else if g.penalty {
-                    FootballEventKind::Penalty
-                } else {
-                    FootballEventKind::Goal
-                };
-                out.push(FootballEvent {
-                    kind,
-                    side_id: g.side_id.clone(),
-                    minute: g.minute,
-                    player_id: g.scorer_player_id.clone(),
-                    assist_player_id: g.assist_player_id.clone(),
-                    substituted_player_id: None,
-                });
+                goals.push(g.clone());
             }
             FootballLiveEvent::Card(c) => {
-                out.push(FootballEvent {
-                    kind: match c.color {
-                        FootballCardColor::Yellow => FootballEventKind::YellowCard,
-                        FootballCardColor::Red => FootballEventKind::RedCard,
-                    },
-                    side_id: c.side_id.clone(),
-                    minute: c.minute,
-                    player_id: Some(c.player_id.clone()),
-                    assist_player_id: None,
-                    substituted_player_id: None,
-                });
+                cards.push(c.clone());
             }
             FootballLiveEvent::Substitution(sub) => {
-                out.push(FootballEvent {
-                    kind: FootballEventKind::Substitution,
-                    side_id: sub.side_id.clone(),
-                    minute: sub.minute,
-                    player_id: Some(sub.player_in_id.clone()),
-                    assist_player_id: None,
-                    substituted_player_id: Some(sub.player_out_id.clone()),
-                });
+                substitutions.push(sub.clone());
             }
             FootballLiveEvent::Period(p) => {
                 match p.period {
@@ -196,20 +83,23 @@ pub fn derive_state(
         }
     }
 
-    FootballLiveState {
+    FootballDetail {
+        score,
+        goals,
+        cards,
+        substitutions,
         period,
         kickoff_at,
         half_time_at,
         second_half_kickoff_at,
         full_time_at,
-        score,
-        events: out,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::detailed_score::football::FootballCardColor;
     use chrono::{DateTime, TimeZone, Utc};
 
     fn ts(minute: i64) -> DateTime<Utc> {
@@ -217,7 +107,7 @@ mod tests {
     }
 
     #[test]
-    fn derives_score_and_events_from_goals_cards_and_subs() {
+    fn derives_score_goals_cards_and_substitutions() {
         let events = vec![
             (
                 ts(41),
@@ -268,19 +158,18 @@ mod tests {
             ),
         ];
 
-        let state = derive_state(&events);
+        let detail = derive_detail(&events);
 
-        assert_eq!(state.score.len(), 1);
-        assert_eq!(state.score[0].side_id, "riverside");
-        assert_eq!(state.score[0].goals, 2);
-        assert_eq!(state.events.len(), 4);
-        assert!(matches!(state.period, Some(FootballPeriod::FullTime)));
-        assert_eq!(state.full_time_at, Some(ts(94)));
-        assert!(matches!(state.events[2].kind, FootballEventKind::OwnGoal));
-        assert!(matches!(
-            state.events[3].kind,
-            FootballEventKind::Substitution
-        ));
+        assert_eq!(detail.score.len(), 1);
+        assert_eq!(detail.score[0].side_id, "riverside");
+        assert_eq!(detail.score[0].goals, 2);
+        assert_eq!(detail.goals.len(), 2);
+        assert_eq!(detail.cards.len(), 1);
+        assert_eq!(detail.substitutions.len(), 1);
+        assert!(matches!(detail.period, Some(FootballPeriod::FullTime)));
+        assert_eq!(detail.full_time_at, Some(ts(94)));
+        assert!(detail.goals[1].own_goal);
+        assert_eq!(detail.substitutions[0].player_out_id, "khan");
     }
 
     #[test]
@@ -306,14 +195,14 @@ mod tests {
             ),
         ];
 
-        let state = derive_state(&events);
+        let detail = derive_detail(&events);
 
-        assert_eq!(state.kickoff_at, Some(ts(0)));
-        assert_eq!(state.half_time_at, Some(ts(46)));
-        assert_eq!(state.second_half_kickoff_at, Some(ts(60)));
-        assert_eq!(state.full_time_at, None);
+        assert_eq!(detail.kickoff_at, Some(ts(0)));
+        assert_eq!(detail.half_time_at, Some(ts(46)));
+        assert_eq!(detail.second_half_kickoff_at, Some(ts(60)));
+        assert_eq!(detail.full_time_at, None);
         assert!(matches!(
-            state.period,
+            detail.period,
             Some(FootballPeriod::SecondHalfKickOff)
         ));
     }

--- a/agon_service/src/live_score/football.rs
+++ b/agon_service/src/live_score/football.rs
@@ -27,56 +27,61 @@ pub struct FootballPeriodEvent {
     pub period: FootballPeriod,
 }
 
-/// Folds an ordered, timestamped list of events into the match's full
-/// detail — cheap enough to do on every read; football's event volume
-/// (goals, cards, subs) never approaches cricket's ball-by-ball scale, so
-/// there's no bounding or incremental-caching concern here the way there is
-/// for cricket. Each event is paired with its own `occurred_at` (not
-/// `recorded_at`) so a period marker's timestamp reflects when the half
-/// actually started/ended on the pitch, not when the server received it.
-pub fn derive_detail(
-    events: &[(chrono::DateTime<chrono::Utc>, FootballLiveEvent)],
-) -> FootballDetail {
-    let mut period = None;
-    let mut period_times = HashMap::new();
-    let mut score: Vec<FootballSideGoals> = Vec::new();
-    let mut goals = Vec::new();
-    let mut cards = Vec::new();
-    let mut substitutions = Vec::new();
+impl FootballDetail {
+    /// Folds the whole event log into a `FootballDetail` from scratch — the
+    /// slow path, used to bootstrap a match's first detail or recover from a
+    /// missing/unparseable persisted record. Just `apply_event` run once per
+    /// event in order; the fast (single-event) and slow (whole-log) paths
+    /// share the exact same fold, so they can't disagree — same pattern as
+    /// `CricketDetail::from_events`.
+    pub fn from_events(events: &[(chrono::DateTime<chrono::Utc>, FootballLiveEvent)]) -> Self {
+        let mut detail = FootballDetail {
+            score: Vec::new(),
+            goals: Vec::new(),
+            cards: Vec::new(),
+            substitutions: Vec::new(),
+            period: None,
+            period_times: HashMap::new(),
+        };
+        for (occurred_at, event) in events {
+            detail.apply_event(*occurred_at, event);
+        }
+        detail
+    }
 
-    for (occurred_at, event) in events {
+    /// Folds one new event into this detail in place — the fast path, run on
+    /// every append. `occurred_at` (not `recorded_at`) is threaded through
+    /// separately from `event` so a period marker's timestamp reflects when
+    /// the half actually started/ended on the pitch, not when the server
+    /// received it.
+    pub fn apply_event(
+        &mut self,
+        occurred_at: chrono::DateTime<chrono::Utc>,
+        event: &FootballLiveEvent,
+    ) {
         match event {
             FootballLiveEvent::Goal(g) => {
-                if let Some(s) = score.iter_mut().find(|s| s.side_id == g.side_id) {
+                if let Some(s) = self.score.iter_mut().find(|s| s.side_id == g.side_id) {
                     s.goals += 1;
                 } else {
-                    score.push(FootballSideGoals {
+                    self.score.push(FootballSideGoals {
                         side_id: g.side_id.clone(),
                         goals: 1,
                     });
                 }
-                goals.push(g.clone());
+                self.goals.push(g.clone());
             }
             FootballLiveEvent::Card(c) => {
-                cards.push(c.clone());
+                self.cards.push(c.clone());
             }
             FootballLiveEvent::Substitution(sub) => {
-                substitutions.push(sub.clone());
+                self.substitutions.push(sub.clone());
             }
             FootballLiveEvent::Period(p) => {
-                period_times.insert(p.period, *occurred_at);
-                period = Some(p.period);
+                self.period_times.insert(p.period, occurred_at);
+                self.period = Some(p.period);
             }
         }
-    }
-
-    FootballDetail {
-        score,
-        goals,
-        cards,
-        substitutions,
-        period,
-        period_times,
     }
 }
 
@@ -142,7 +147,7 @@ mod tests {
             ),
         ];
 
-        let detail = derive_detail(&events);
+        let detail = FootballDetail::from_events(&events);
 
         assert_eq!(detail.score.len(), 1);
         assert_eq!(detail.score[0].side_id, "riverside");
@@ -182,7 +187,7 @@ mod tests {
             ),
         ];
 
-        let detail = derive_detail(&events);
+        let detail = FootballDetail::from_events(&events);
 
         assert_eq!(
             detail.period_times.get(&FootballPeriod::KickOff),
@@ -226,7 +231,7 @@ mod tests {
             ),
         ];
 
-        let detail = derive_detail(&events);
+        let detail = FootballDetail::from_events(&events);
 
         assert_eq!(
             detail.period_times.get(&FootballPeriod::ExtraTimeHalfTime),
@@ -240,5 +245,58 @@ mod tests {
             detail.period_times.get(&FootballPeriod::PenaltiesComplete),
             Some(&ts(160))
         );
+    }
+
+    #[test]
+    fn incremental_and_full_fold_agree() {
+        let events = vec![
+            (
+                ts(0),
+                FootballLiveEvent::Period(FootballPeriodEvent {
+                    period: FootballPeriod::KickOff,
+                }),
+            ),
+            (
+                ts(12),
+                FootballLiveEvent::Goal(FootballGoalEvent {
+                    side_id: "riverside".into(),
+                    scorer_player_id: Some("alvarez".into()),
+                    assist_player_id: None,
+                    own_goal: false,
+                    penalty: false,
+                    minute: Some(12),
+                }),
+            ),
+            (
+                ts(58),
+                FootballLiveEvent::Card(FootballCardEvent {
+                    side_id: "oak_park".into(),
+                    player_id: "khan".into(),
+                    color: FootballCardColor::Yellow,
+                    minute: Some(58),
+                }),
+            ),
+        ];
+
+        let full = FootballDetail::from_events(&events);
+
+        // Apply the same events one at a time, incrementally, and check the
+        // final state matches the full fold exactly.
+        let mut incremental = FootballDetail {
+            score: Vec::new(),
+            goals: Vec::new(),
+            cards: Vec::new(),
+            substitutions: Vec::new(),
+            period: None,
+            period_times: HashMap::new(),
+        };
+        for (occurred_at, event) in &events {
+            incremental.apply_event(*occurred_at, event);
+        }
+
+        assert_eq!(incremental.score.len(), full.score.len());
+        assert_eq!(incremental.goals.len(), full.goals.len());
+        assert_eq!(incremental.cards.len(), full.cards.len());
+        assert_eq!(incremental.period_times, full.period_times);
     }
 }

--- a/agon_service/src/live_score/mod.rs
+++ b/agon_service/src/live_score/mod.rs
@@ -3,18 +3,19 @@
 //! goal-by-goal, card-by-card, ...) in real time — possibly in batches, from a
 //! device catching up after being offline.
 //!
-//! Distinct from `detailed_score`, which is the *resolved* scorecard read off
-//! the derived state. This module is the write-side vocabulary, plus the pure
-//! functions (in `football`/`cricket`) that fold an ordered event log into
-//! that derived state — the same shapes `detailed_score` already defines,
-//! since a live match's final scorecard is exactly what live scoring builds
-//! up to.
+//! This is the write-side vocabulary, plus the pure functions (in
+//! `football`/`cricket`) that fold an ordered event log into
+//! `detailed_score`'s shapes — there's no separate "live" read shape
+//! anymore: `GET /matches/:id/detailed-score` serves the same
+//! `DetailedScore` whether the match is still being scored or long
+//! finished (see `detailed_score`'s module docs for why that's one shape
+//! now, not two).
 //!
-//! Corrections are direct mutations of the log, not layered on top of it:
-//! `DELETE /matches/:id/live/events/:seq` removes an event outright, `PATCH`
-//! overwrites one seq's content in place. There's no soft-delete/void marker
-//! to filter out on every fold — `derive_state` folds whatever the DAO
-//! actually returns, in order.
+//! Corrections are restricted to undoing the most recently recorded event —
+//! `DELETE /matches/:id/live/events/:seq` only succeeds when `seq` is the
+//! current tip. An arbitrary-position edit would need real conflict
+//! resolution to reconcile against a device's own offline queue; undoing
+//! only the tip doesn't (see the DELETE handler's doc comment).
 
 use poem_openapi::{Object, Union};
 
@@ -72,28 +73,21 @@ pub struct LiveEvent {
     pub event: LiveEventInput,
 }
 
-/// The derived live-scoring state for a match, sport-first discriminated like
-/// `LiveEventInput`. A full fold of the event log — the same shape
-/// `detailed_score` exposes once a match is done, just kept live.
-#[derive(Union)]
-#[oai(one_of, discriminator_name = "sport")]
-pub enum LiveScoreState {
-    Football(football::FootballLiveState),
-    Cricket(cricket::CricketLiveState),
-}
-
-/// `LiveScoreState` plus the log position it was derived from, so a client
-/// can tell whether its own queued-but-unsynced events are already reflected.
+/// A `DetailedScore` plus the log position it reflects, so a client can tell
+/// whether its own queued-but-unsynced events are already applied. Returned
+/// by every endpoint that touches the live event log (append, delete) —
+/// `GET /matches/:id/detailed-score` itself doesn't need this wrapper, since
+/// a plain read has no "position I was expecting" to compare against.
 #[derive(Object)]
 pub struct LiveScoreSnapshot {
     pub last_seq: u32,
-    pub state: LiveScoreState,
+    pub detail: crate::detailed_score::DetailedScore,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::live_score::football::{FootballCardColor, FootballCardEvent};
+    use crate::detailed_score::football::{FootballCardColor, FootballCardEvent};
     use poem_openapi::types::{ParseFromJSON, ToJSON};
 
     /// The outer (`sport`) and inner (`kind`) unions must serialize as one

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -36,7 +36,7 @@ use auth::{JwtClaims, JwtVerifier};
 // Boundary mapping between API models and DAO records.
 mod mapping;
 use mapping::{
-    comment_from_record, dao_internal, derive_live_score_state, detailed_score_from_record,
+    comment_from_record, dao_internal, derive_live_detail, detailed_score_from_record,
     detailed_score_to_record, invitation_detail_from_record, invitation_from_record,
     invitation_status_from_str, invitation_status_str, live_event_from_record,
     match_format_sport_tag, match_format_to_record, match_from_records, match_status_str,
@@ -55,14 +55,13 @@ use match_format::MatchFormat;
 mod detailed_score;
 use detailed_score::{
     DetailedScore,
-    cricket::{CricketDetail, Overs},
-    football::{FootballDetail, FootballEvent, FootballEventKind},
+    cricket::Overs,
+    football::{FootballDetail, FootballGoalEvent, FootballPeriod, FootballSideGoals},
 };
 
 mod live_score;
 use live_score::{
-    AppendLiveEventsInput, LiveEvent, LiveEventInput, LiveScoreSnapshot, LiveScoreState,
-    NewLiveEventInput,
+    AppendLiveEventsInput, LiveEvent, LiveEventInput, LiveScoreSnapshot, NewLiveEventInput,
 };
 
 mod membership;
@@ -1028,16 +1027,6 @@ enum AppendLiveEventsResponse {
     /// should re-fetch the log/state and reconcile before retrying.
     #[oai(status = 409)]
     Conflict(PlainText<String>),
-}
-
-#[derive(ApiResponse)]
-enum GetLiveScoreResponse {
-    #[oai(status = 200)]
-    State(Json<LiveScoreSnapshot>),
-
-    /// The match exists but has no live events recorded yet.
-    #[oai(status = 404)]
-    NotFound(PlainText<String>),
 }
 
 /// One page of a match's live event log, oldest first. `next_cursor` absent
@@ -2133,52 +2122,17 @@ impl Api {
             }
         }
 
-        // Persist a supplied detailed score, or — for a cricket match that
-        // was actually scored live and is completing without the caller
-        // supplying one — derive it ourselves from the event log (the
-        // authoritative source; the caller's own `GET /live` only ever sees
-        // a bounded live summary now, not the full batting/bowling cards, so
-        // it has nothing full to submit). One-time cost at completion, not a
-        // hot path, so folding the whole log here is fine.
+        // Persist a manually-supplied detailed score (a match entered
+        // directly, without live scoring). For a live-scored match, there's
+        // nothing to do here even at completion: `GET /matches/:id/detailed-
+        // score` reads the same record live scoring has been keeping
+        // incrementally up to date all along (see `append_live_events`),
+        // so completing the match is just the status flip below.
         if let Some(ds) = &input.detailed_score {
-            let record = detailed_score_to_record(ds);
+            let record = detailed_score_to_record(ds, None);
             dao.put_match_detailed_score(&match_id, &record)
                 .await
                 .map_err(dao_internal)?;
-        } else {
-            let final_status = status_override.unwrap_or(agg.match_.status.as_str());
-            if final_status == "completed" && agg.match_.match_type == "cricket" {
-                let records = dao
-                    .list_live_events(&match_id)
-                    .await
-                    .map_err(dao_internal)?;
-                if !records.is_empty() {
-                    let events: Vec<live_score::cricket::CricketLiveEvent> = records
-                        .iter()
-                        .filter_map(|r| match &r.payload {
-                            dao::records::LiveEventPayloadRecord::Cricket(c) => {
-                                Some(mapping::cricket_live_event_from_record(c))
-                            }
-                            dao::records::LiveEventPayloadRecord::Football(_) => None,
-                        })
-                        .collect();
-                    let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
-                        mapping::cricket_format_args(agg.match_.format.as_ref());
-                    let innings = live_score::cricket::fold_full_scorecard(
-                        &events,
-                        balls_per_over,
-                        wide_is_extra_ball,
-                        no_ball_is_extra_ball,
-                    );
-                    if !innings.is_empty() {
-                        let ds = DetailedScore::Cricket(CricketDetail { innings });
-                        let record = detailed_score_to_record(&ds);
-                        dao.put_match_detailed_score(&match_id, &record)
-                            .await
-                            .map_err(dao_internal)?;
-                    }
-                }
-            }
         }
 
         // Apply metadata + resolved score in one update.
@@ -2257,6 +2211,16 @@ impl Api {
         Ok(UpdateMatchResponse::Match(Json(m)))
     }
 
+    /// Football's derived detail is cheap to fold (goals/cards/subs, not
+    /// deliveries) and nothing keeps a persisted football record in sync
+    /// with corrections the way cricket's incremental live-scoring path
+    /// does — so whenever a live log exists, this always re-derives fresh
+    /// from it rather than risk serving a stale persisted copy. Cricket is
+    /// the opposite: its persisted record is kept incrementally correct by
+    /// every live-scoring append (see `apply_cricket_events_incrementally`),
+    /// so it's trusted directly, with a full refold only as a recovery path
+    /// for a missing or unparseable record. Manual entry (no live log at
+    /// all, either sport) always reads the persisted record.
     #[oai(path = "/matches/:match_id/detailed-score", method = "get")]
     async fn get_match_detailed_score(
         &self,
@@ -2266,9 +2230,6 @@ impl Api {
     ) -> Result<GetMatchDetailedScoreResponse> {
         info!("Getting detailed score for match {match_id}");
 
-        // The detailed score is stored under `DETAIL#<sport>`, so we need the
-        // match's sport tag to address it. Fetch the match aggregate (meta) for
-        // the sport; 404 if the match itself is missing.
         let agg = match dao.get_match(&match_id).await.map_err(dao_internal)? {
             Some(a) => a,
             None => {
@@ -2277,16 +2238,61 @@ impl Api {
                 )));
             }
         };
+        let sport = agg.match_.match_type.as_str();
+
+        if sport == "football" {
+            let records = dao
+                .list_live_events(&match_id)
+                .await
+                .map_err(dao_internal)?;
+            let ds = if !records.is_empty() {
+                derive_live_detail(sport, &records, agg.match_.format.as_ref())
+            } else {
+                dao.get_match_detailed_score(&match_id, sport)
+                    .await
+                    .map_err(dao_internal)?
+                    .as_ref()
+                    .and_then(detailed_score_from_record)
+            };
+            return match ds {
+                Some(ds) => Ok(GetMatchDetailedScoreResponse::DetailedScore(Json(ds))),
+                None => Ok(GetMatchDetailedScoreResponse::NotFound(PlainText(
+                    "match has no detailed score".into(),
+                ))),
+            };
+        }
+
         let record = dao
-            .get_match_detailed_score(&match_id, &agg.match_.match_type)
+            .get_match_detailed_score(&match_id, sport)
             .await
             .map_err(dao_internal)?;
-        match record.as_ref().and_then(detailed_score_from_record) {
-            Some(ds) => Ok(GetMatchDetailedScoreResponse::DetailedScore(Json(ds))),
-            None => Ok(GetMatchDetailedScoreResponse::NotFound(PlainText(
-                "match has no detailed score".into(),
-            ))),
+        if let Some(ds) = record.as_ref().and_then(detailed_score_from_record) {
+            return Ok(GetMatchDetailedScoreResponse::DetailedScore(Json(ds)));
         }
+
+        // No usable persisted record — recover by folding the event log, if
+        // there is one (e.g. a live-scored cricket match whose record was
+        // somehow missing or unparseable). Persist the result so subsequent
+        // reads, and the next incremental append, have a fresh checkpoint to
+        // build on.
+        let records = dao
+            .list_live_events(&match_id)
+            .await
+            .map_err(dao_internal)?;
+        if records.is_empty() {
+            return Ok(GetMatchDetailedScoreResponse::NotFound(PlainText(
+                "match has no detailed score".into(),
+            )));
+        }
+        let last_seq = records.iter().map(|r| r.seq).max().unwrap_or(0);
+        let Some(ds) = derive_live_detail(sport, &records, agg.match_.format.as_ref()) else {
+            return Ok(GetMatchDetailedScoreResponse::NotFound(PlainText(
+                "match has no detailed score".into(),
+            )));
+        };
+        self.persist_detailed_score(dao, &match_id, &ds, Some(last_seq))
+            .await;
+        Ok(GetMatchDetailedScoreResponse::DetailedScore(Json(ds)))
     }
 
     /// Append a batch of live-scoring events (1 to
@@ -2442,15 +2448,17 @@ impl Api {
         expected_last_seq: u32,
         new_last_seq: u32,
     ) -> Result<Option<LiveScoreSnapshot>> {
-        let Some(cached) = dao.get_live_state(match_id).await.map_err(dao_internal)? else {
+        let Some(record) = dao
+            .get_match_detailed_score(match_id, "cricket")
+            .await
+            .map_err(dao_internal)?
+        else {
             return Ok(None);
         };
-        if cached.last_seq != expected_last_seq {
+        if record.last_seq != Some(expected_last_seq) {
             return Ok(None);
         }
-        let Ok(LiveScoreState::Cricket(mut state)) =
-            poem_openapi::types::ParseFromJSON::parse_from_json(Some(cached.state))
-        else {
+        let Some(DetailedScore::Cricket(mut detail)) = detailed_score_from_record(&record) else {
             return Ok(None);
         };
 
@@ -2462,7 +2470,7 @@ impl Api {
                 // `append_live_events`; unreachable here in practice.
                 return Ok(None);
             };
-            state.apply_event(
+            detail.apply_event(
                 event,
                 balls_per_over,
                 wide_is_extra_ball,
@@ -2470,64 +2478,14 @@ impl Api {
             );
         }
 
-        let new_state = LiveScoreState::Cricket(state);
-        self.refresh_cricket_live_state_cache(dao, match_id, &new_state, new_last_seq)
+        let ds = DetailedScore::Cricket(detail);
+        self.persist_detailed_score(dao, match_id, &ds, Some(new_last_seq))
             .await;
 
         Ok(Some(LiveScoreSnapshot {
             last_seq: new_last_seq,
-            state: new_state,
+            detail: ds,
         }))
-    }
-
-    /// The current derived live-scoring state (score/clock/scorecard so
-    /// far), for a feed card or the scorer's own view to poll. For cricket,
-    /// served from the `#LIVESTATE` cache when present (fixed-size regardless
-    /// of match length — see `agon_core::dao::live_score_ops`), falling back
-    /// to a full refold on a miss; football has no cache and always folds
-    /// fresh (its event count stays small — goals/cards/subs, not deliveries).
-    #[oai(path = "/matches/:match_id/live", method = "get")]
-    async fn get_live_score(
-        &self,
-        Data(dao): Data<&dao::Dao>,
-        AuthSchema(_jwt_data): AuthSchema,
-        Path(match_id): Path<String>,
-    ) -> Result<GetLiveScoreResponse> {
-        let agg = match dao.get_match(&match_id).await.map_err(dao_internal)? {
-            Some(a) => a,
-            None => {
-                return Ok(GetLiveScoreResponse::NotFound(PlainText(
-                    "match not found".into(),
-                )));
-            }
-        };
-
-        if let Some(cached) = dao.get_live_state(&match_id).await.map_err(dao_internal)?
-            && let Ok(state) =
-                poem_openapi::types::ParseFromJSON::parse_from_json(Some(cached.state))
-        {
-            return Ok(GetLiveScoreResponse::State(Json(LiveScoreSnapshot {
-                last_seq: cached.last_seq,
-                state,
-            })));
-            // Otherwise fall through to a full refold — it's just a cache,
-            // never trusted blindly if it's somehow unparseable.
-        }
-
-        match self
-            .derive_live_snapshot(
-                dao,
-                &match_id,
-                &agg.match_.match_type,
-                agg.match_.format.as_ref(),
-            )
-            .await?
-        {
-            Some(snapshot) => Ok(GetLiveScoreResponse::State(Json(snapshot))),
-            None => Ok(GetLiveScoreResponse::NotFound(PlainText(
-                "match has no live events recorded yet".into(),
-            ))),
-        }
     }
 
     /// The raw live event log, oldest first — for reconstructing the full
@@ -2569,11 +2527,14 @@ impl Api {
         })))
     }
 
-    /// Delete a single live event outright — "this never happened" (a
-    /// duplicate, a wrong-match entry). History is genuinely removed, not
-    /// marked; the returned state reflects the log as if it had never been
-    /// recorded (e.g. deleting a wrongly-placed innings boundary re-flows the
-    /// surrounding deliveries back into one innings automatically).
+    /// Delete a single live event outright — but only the current tip
+    /// ("undo the last thing I recorded"). An arbitrary-position delete
+    /// would need real conflict resolution to reconcile against a device's
+    /// own offline queue (see `live_score`'s module docs); undoing only the
+    /// tip doesn't, since there's nothing downstream of it that could have
+    /// been built on the thing being removed. History is genuinely removed,
+    /// not marked; the returned detail reflects the log as if the event had
+    /// never been recorded.
     #[oai(path = "/matches/:match_id/live/events/:seq", method = "delete")]
     async fn delete_live_event(
         &self,
@@ -2593,6 +2554,12 @@ impl Api {
                 )));
             }
         };
+
+        if seq != agg.match_.live_seq {
+            return Ok(DeleteLiveEventResponse::ValidationError(PlainText(
+                "only the most recently recorded event can be undone".into(),
+            )));
+        }
 
         match dao.delete_live_event(&match_id, seq).await {
             Ok(()) => {}
@@ -2623,76 +2590,38 @@ impl Api {
         }
     }
 
-    /// Overwrite a single live event's content in place — "this happened,
-    /// but I recorded the wrong facts" (wrong bowler, wrong runs, wrong
-    /// dismissal). Keeps its position in the log; can even change kind (e.g.
-    /// "that wasn't a goal, it was a card").
+    /// Amending an event in place isn't supported: it would need real
+    /// conflict resolution to reconcile against a device's own offline
+    /// queue, the way appends and tip-only deletes don't. The correction
+    /// path for "recorded the wrong facts" is delete-and-reappend, currently
+    /// restricted to the tip — see `delete_live_event`.
     #[oai(path = "/matches/:match_id/live/events/:seq", method = "patch")]
     async fn amend_live_event(
         &self,
         Data(dao): Data<&dao::Dao>,
         AuthSchema(jwt_data): AuthSchema,
-        Path(match_id): Path<String>,
-        Path(seq): Path<u32>,
-        input: Json<LiveEventInput>,
+        Path(_match_id): Path<String>,
+        Path(_seq): Path<u32>,
+        _input: Json<LiveEventInput>,
     ) -> Result<AmendLiveEventResponse> {
         self.require_uid(dao, &jwt_data).await?;
-        let input = input.0;
-        info!("Amending live event {seq} on match {match_id}");
-
-        let agg = match dao.get_match(&match_id).await.map_err(dao_internal)? {
-            Some(a) => a,
-            None => {
-                return Ok(AmendLiveEventResponse::NotFound(PlainText(
-                    "match not found".into(),
-                )));
-            }
-        };
-
-        let tag = mapping::live_event_sport_tag(&input);
-        if tag != agg.match_.match_type {
-            return Ok(AmendLiveEventResponse::ValidationError(PlainText(format!(
-                "event has sport `{tag}` but match is `{}`",
-                agg.match_.match_type
-            ))));
-        }
-
-        let payload = mapping::live_event_input_to_record(&input);
-        match dao.amend_live_event(&match_id, seq, &payload).await {
-            Ok(()) => {}
-            Err(dao::DaoError::NotFound(_)) => {
-                return Ok(AmendLiveEventResponse::NotFound(PlainText(
-                    "live event not found".into(),
-                )));
-            }
-            Err(e) => return Err(dao_internal(e)),
-        }
-
-        match self
-            .derive_live_snapshot(
-                dao,
-                &match_id,
-                &agg.match_.match_type,
-                agg.match_.format.as_ref(),
-            )
-            .await?
-        {
-            Some(snapshot) => Ok(AmendLiveEventResponse::Ok(Json(snapshot))),
-            None => Ok(AmendLiveEventResponse::ValidationError(PlainText(format!(
-                "sport `{}` does not support live scoring",
-                agg.match_.match_type
-            )))),
-        }
+        Ok(AmendLiveEventResponse::ValidationError(PlainText(
+            "amending a live event in place isn't supported; delete and re-append instead \
+             (only the most recently recorded event can be deleted)"
+                .into(),
+        )))
     }
 
-    /// Derives the current live state by folding the full event log — the
-    /// slow path: bootstrapping a match's first cricket summary, recovering
-    /// from a missing/unparseable cache, and rebuilding after a correction
-    /// (an arbitrary-position delete/amend can't be applied as a single
-    /// incremental step — see `append_live_events` for the fast path).
-    /// Refreshes the `#LIVESTATE` cache for cricket; football has no cache
-    /// to refresh (see `agon_core::dao::live_score_ops`'s module docs).
-    /// Returns `None` if `sport` doesn't support live scoring.
+    /// Derives the current detail by folding the full event log — the slow
+    /// path: bootstrapping a match's first detailed score, recovering from a
+    /// missing or unparseable persisted record, and rebuilding after an undo
+    /// (removing the tip isn't a single incremental step the way appending
+    /// is — see `apply_cricket_events_incrementally` for that fast path).
+    /// Persists the result for cricket, whose record is meant to stay
+    /// incrementally in sync with every append; football's `GET
+    /// /detailed-score` always re-derives from the log itself when one
+    /// exists, so there's nothing to keep in sync for it here. Returns
+    /// `None` if `sport` doesn't support live scoring.
     async fn derive_live_snapshot(
         &self,
         dao: &dao::Dao,
@@ -2703,43 +2632,32 @@ impl Api {
         let records = dao.list_live_events(match_id).await.map_err(dao_internal)?;
         let last_seq = records.iter().map(|r| r.seq).max().unwrap_or(0);
 
-        let Some(state) = derive_live_score_state(sport, &records, format) else {
+        let Some(detail) = derive_live_detail(sport, &records, format) else {
             return Ok(None);
         };
 
-        if let LiveScoreState::Cricket(_) = &state {
-            self.refresh_cricket_live_state_cache(dao, match_id, &state, last_seq)
+        if sport == "cricket" {
+            self.persist_detailed_score(dao, match_id, &detail, Some(last_seq))
                 .await;
         }
 
-        Ok(Some(LiveScoreSnapshot { last_seq, state }))
+        Ok(Some(LiveScoreSnapshot { last_seq, detail }))
     }
 
-    /// Best-effort cache write, shared by the full-refold path and the
-    /// incremental append path — never fails the caller's request; the
-    /// cache is always safely recomputable from the event log if this is
-    /// lost or goes stale.
-    async fn refresh_cricket_live_state_cache(
+    /// Best-effort persisted-record write, shared by the incremental append
+    /// path and the full-refold path — never fails the caller's request;
+    /// the record is always safely recomputable from the event log if this
+    /// write is lost or the record goes stale.
+    async fn persist_detailed_score(
         &self,
         dao: &dao::Dao,
         match_id: &str,
-        state: &LiveScoreState,
-        last_seq: u32,
+        ds: &DetailedScore,
+        last_seq: Option<u32>,
     ) {
-        let state_json =
-            poem_openapi::types::ToJSON::to_json(state).unwrap_or(serde_json::Value::Null);
-        if let Err(e) = dao
-            .put_live_state(
-                match_id,
-                &dao::records::LiveStateRecord {
-                    sport: "cricket".to_string(),
-                    state: state_json,
-                    last_seq,
-                },
-            )
-            .await
-        {
-            error!("Failed to refresh live-state cache for match {match_id}: {e}");
+        let record = detailed_score_to_record(ds, last_seq);
+        if let Err(e) = dao.put_match_detailed_score(match_id, &record).await {
+            error!("Failed to persist detailed score for match {match_id}: {e}");
         }
     }
 
@@ -4638,40 +4556,57 @@ fn mock_match(id: String) -> Match {
 /// Builds a mock football detailed score matching the mock match's 3-1 result.
 fn mock_football_detailed_score() -> DetailedScore {
     DetailedScore::Football(FootballDetail {
-        events: vec![
-            FootballEvent {
-                kind: FootballEventKind::Goal,
+        score: vec![
+            FootballSideGoals {
                 side_id: String::from("side_red"),
-                minute: Some(12),
-                player_id: Some(String::from("player_red_1")),
-                assist_player_id: Some(String::from("player_red_2")),
-                substituted_player_id: None,
+                goals: 3,
             },
-            FootballEvent {
-                kind: FootballEventKind::Goal,
+            FootballSideGoals {
                 side_id: String::from("side_blue"),
-                minute: Some(34),
-                player_id: Some(String::from("player_blue_1")),
-                assist_player_id: None,
-                substituted_player_id: None,
-            },
-            FootballEvent {
-                kind: FootballEventKind::Goal,
-                side_id: String::from("side_red"),
-                minute: Some(58),
-                player_id: Some(String::from("player_red_2")),
-                assist_player_id: Some(String::from("player_red_1")),
-                substituted_player_id: None,
-            },
-            FootballEvent {
-                kind: FootballEventKind::Penalty,
-                side_id: String::from("side_red"),
-                minute: Some(81),
-                player_id: Some(String::from("player_red_1")),
-                assist_player_id: None,
-                substituted_player_id: None,
+                goals: 1,
             },
         ],
+        goals: vec![
+            FootballGoalEvent {
+                side_id: String::from("side_red"),
+                scorer_player_id: Some(String::from("player_red_1")),
+                assist_player_id: Some(String::from("player_red_2")),
+                own_goal: false,
+                penalty: false,
+                minute: Some(12),
+            },
+            FootballGoalEvent {
+                side_id: String::from("side_blue"),
+                scorer_player_id: Some(String::from("player_blue_1")),
+                assist_player_id: None,
+                own_goal: false,
+                penalty: false,
+                minute: Some(34),
+            },
+            FootballGoalEvent {
+                side_id: String::from("side_red"),
+                scorer_player_id: Some(String::from("player_red_2")),
+                assist_player_id: Some(String::from("player_red_1")),
+                own_goal: false,
+                penalty: false,
+                minute: Some(58),
+            },
+            FootballGoalEvent {
+                side_id: String::from("side_red"),
+                scorer_player_id: Some(String::from("player_red_1")),
+                assist_player_id: None,
+                own_goal: false,
+                penalty: true,
+                minute: Some(81),
+            },
+        ],
+        cards: vec![],
+        substitutions: vec![],
+        period: Some(FootballPeriod::FullTime),
+        kickoff_at: None,
+        half_time_at: None,
+        second_half_kickoff_at: None,
+        full_time_at: None,
     })
 }
 

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2600,11 +2600,12 @@ impl Api {
         &self,
         Data(dao): Data<&dao::Dao>,
         AuthSchema(jwt_data): AuthSchema,
-        Path(_match_id): Path<String>,
-        Path(_seq): Path<u32>,
-        _input: Json<LiveEventInput>,
+        Path(match_id): Path<String>,
+        Path(seq): Path<u32>,
+        input: Json<LiveEventInput>,
     ) -> Result<AmendLiveEventResponse> {
         self.require_uid(dao, &jwt_data).await?;
+        let _ = (match_id, seq, input);
         Ok(AmendLiveEventResponse::ValidationError(PlainText(
             "amending a live event in place isn't supported; delete and re-append instead \
              (only the most recently recorded event can be deleted)"

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -55,12 +55,15 @@ use match_format::MatchFormat;
 mod detailed_score;
 use detailed_score::{
     DetailedScore,
-    cricket::Overs,
+    cricket::{CricketDetail, Overs},
     football::{FootballDetail, FootballEvent, FootballEventKind},
 };
 
 mod live_score;
-use live_score::{AppendLiveEventsInput, LiveEvent, LiveEventInput, LiveScoreSnapshot};
+use live_score::{
+    AppendLiveEventsInput, LiveEvent, LiveEventInput, LiveScoreSnapshot, LiveScoreState,
+    NewLiveEventInput,
+};
 
 mod membership;
 use membership::{
@@ -1037,10 +1040,18 @@ enum GetLiveScoreResponse {
     NotFound(PlainText<String>),
 }
 
+/// One page of a match's live event log, oldest first. `next_cursor` absent
+/// => end.
+#[derive(Object)]
+struct LiveEventPage {
+    items: Vec<LiveEvent>,
+    next_cursor: Option<String>,
+}
+
 #[derive(ApiResponse)]
 enum ListLiveEventsResponse {
     #[oai(status = 200)]
-    Events(Json<Vec<LiveEvent>>),
+    Events(Json<LiveEventPage>),
 
     #[oai(status = 404)]
     NotFound(PlainText<String>),
@@ -2122,12 +2133,52 @@ impl Api {
             }
         }
 
-        // Persist a supplied detailed score.
+        // Persist a supplied detailed score, or — for a cricket match that
+        // was actually scored live and is completing without the caller
+        // supplying one — derive it ourselves from the event log (the
+        // authoritative source; the caller's own `GET /live` only ever sees
+        // a bounded live summary now, not the full batting/bowling cards, so
+        // it has nothing full to submit). One-time cost at completion, not a
+        // hot path, so folding the whole log here is fine.
         if let Some(ds) = &input.detailed_score {
             let record = detailed_score_to_record(ds);
             dao.put_match_detailed_score(&match_id, &record)
                 .await
                 .map_err(dao_internal)?;
+        } else {
+            let final_status = status_override.unwrap_or(agg.match_.status.as_str());
+            if final_status == "completed" && agg.match_.match_type == "cricket" {
+                let records = dao
+                    .list_live_events(&match_id)
+                    .await
+                    .map_err(dao_internal)?;
+                if !records.is_empty() {
+                    let events: Vec<live_score::cricket::CricketLiveEvent> = records
+                        .iter()
+                        .filter_map(|r| match &r.payload {
+                            dao::records::LiveEventPayloadRecord::Cricket(c) => {
+                                Some(mapping::cricket_live_event_from_record(c))
+                            }
+                            dao::records::LiveEventPayloadRecord::Football(_) => None,
+                        })
+                        .collect();
+                    let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
+                        mapping::cricket_format_args(agg.match_.format.as_ref());
+                    let innings = live_score::cricket::fold_full_scorecard(
+                        &events,
+                        balls_per_over,
+                        wide_is_extra_ball,
+                        no_ball_is_extra_ball,
+                    );
+                    if !innings.is_empty() {
+                        let ds = DetailedScore::Cricket(CricketDetail { innings });
+                        let record = detailed_score_to_record(&ds);
+                        dao.put_match_detailed_score(&match_id, &record)
+                            .await
+                            .map_err(dao_internal)?;
+                    }
+                }
+            }
         }
 
         // Apply metadata + resolved score in one update.
@@ -2306,16 +2357,16 @@ impl Api {
             .map(|e| new_live_event_to_dao(e, &uid, &recorded_at))
             .collect();
 
-        match dao
+        let new_last_seq = match dao
             .append_live_events(&match_id, input.expected_last_seq, &new_events)
             .await
         {
-            Ok(_) => {}
+            Ok(new_last_seq) => new_last_seq,
             Err(dao::DaoError::Conflict(msg)) => {
                 return Ok(AppendLiveEventsResponse::Conflict(PlainText(msg)));
             }
             Err(e) => return Err(dao_internal(e)),
-        }
+        };
 
         // Recording a live event is what "starting" a match means, whatever
         // the sport (kickoff for football, the first ball for cricket) — flip
@@ -2337,10 +2388,37 @@ impl Api {
             .map_err(dao_internal)?;
         }
 
-        match self
-            .derive_live_snapshot(dao, &match_id, &sport, agg.match_.format.as_ref())
-            .await?
-        {
+        // Cricket's cache supports a genuine incremental update (apply just
+        // the new events to the last-known checkpoint) since it's the one
+        // whose per-ball hot path this exists for; football always takes the
+        // full-refold path (cheap enough at its event volumes, and there's no
+        // cache for it to update). Falls back to a full refold itself if the
+        // cache is missing or behind (e.g. this is the innings' first ball,
+        // or a correction landed between the last append and this one).
+        let snapshot = if sport == "cricket" {
+            match self
+                .apply_cricket_events_incrementally(
+                    dao,
+                    &match_id,
+                    agg.match_.format.as_ref(),
+                    &input.events,
+                    input.expected_last_seq,
+                    new_last_seq,
+                )
+                .await?
+            {
+                Some(snapshot) => Some(snapshot),
+                None => {
+                    self.derive_live_snapshot(dao, &match_id, &sport, agg.match_.format.as_ref())
+                        .await?
+                }
+            }
+        } else {
+            self.derive_live_snapshot(dao, &match_id, &sport, agg.match_.format.as_ref())
+                .await?
+        };
+
+        match snapshot {
             Some(snapshot) => Ok(AppendLiveEventsResponse::Ok(Json(snapshot))),
             None => Ok(AppendLiveEventsResponse::ValidationError(PlainText(
                 format!("sport `{sport}` does not support live scoring"),
@@ -2348,11 +2426,66 @@ impl Api {
         }
     }
 
+    /// The incremental fast path for a cricket append: applies just the
+    /// newly-appended events to the cached checkpoint, rather than refolding
+    /// the whole log. Returns `None` (meaning "fall back to a full refold")
+    /// when there's no usable checkpoint to build on — missing, unparseable,
+    /// or not caught up to exactly the start of this batch (a correction
+    /// landing between the last append and this one, or the very first event
+    /// this match has ever recorded).
+    async fn apply_cricket_events_incrementally(
+        &self,
+        dao: &dao::Dao,
+        match_id: &str,
+        format: Option<&dao::records::MatchFormatRecord>,
+        new_events: &[NewLiveEventInput],
+        expected_last_seq: u32,
+        new_last_seq: u32,
+    ) -> Result<Option<LiveScoreSnapshot>> {
+        let Some(cached) = dao.get_live_state(match_id).await.map_err(dao_internal)? else {
+            return Ok(None);
+        };
+        if cached.last_seq != expected_last_seq {
+            return Ok(None);
+        }
+        let Ok(LiveScoreState::Cricket(mut state)) =
+            poem_openapi::types::ParseFromJSON::parse_from_json(Some(cached.state))
+        else {
+            return Ok(None);
+        };
+
+        let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
+            mapping::cricket_format_args(format);
+        for e in new_events {
+            let LiveEventInput::Cricket(event) = &e.event else {
+                // Sport mismatch is already rejected earlier in
+                // `append_live_events`; unreachable here in practice.
+                return Ok(None);
+            };
+            state.apply_event(
+                event,
+                balls_per_over,
+                wide_is_extra_ball,
+                no_ball_is_extra_ball,
+            );
+        }
+
+        let new_state = LiveScoreState::Cricket(state);
+        self.refresh_cricket_live_state_cache(dao, match_id, &new_state, new_last_seq)
+            .await;
+
+        Ok(Some(LiveScoreSnapshot {
+            last_seq: new_last_seq,
+            state: new_state,
+        }))
+    }
+
     /// The current derived live-scoring state (score/clock/scorecard so
-    /// far), for a feed card or the scorer's own view to poll. Derived fresh
-    /// from the event log on every call — no separate cache to go stale or
-    /// risk a size cap of its own; folding the log is cheap enough not to
-    /// need one (see `agon_core::dao::live_score_ops`).
+    /// far), for a feed card or the scorer's own view to poll. For cricket,
+    /// served from the `#LIVESTATE` cache when present (fixed-size regardless
+    /// of match length — see `agon_core::dao::live_score_ops`), falling back
+    /// to a full refold on a miss; football has no cache and always folds
+    /// fresh (its event count stays small — goals/cards/subs, not deliveries).
     #[oai(path = "/matches/:match_id/live", method = "get")]
     async fn get_live_score(
         &self,
@@ -2368,6 +2501,18 @@ impl Api {
                 )));
             }
         };
+
+        if let Some(cached) = dao.get_live_state(&match_id).await.map_err(dao_internal)?
+            && let Ok(state) =
+                poem_openapi::types::ParseFromJSON::parse_from_json(Some(cached.state))
+        {
+            return Ok(GetLiveScoreResponse::State(Json(LiveScoreSnapshot {
+                last_seq: cached.last_seq,
+                state,
+            })));
+            // Otherwise fall through to a full refold — it's just a cache,
+            // never trusted blindly if it's somehow unparseable.
+        }
 
         match self
             .derive_live_snapshot(
@@ -2385,20 +2530,22 @@ impl Api {
         }
     }
 
-    /// The raw live event log, in order — for reconstructing the full
+    /// The raw live event log, oldest first — for reconstructing the full
     /// scorecard client-side (see `inningsDeliveriesFromEvents`, used by a
     /// completed match's run-progression graph) or for the scorer's own
-    /// delete/amend picker. Not paginated at this level: the DAO already
-    /// drains every underlying query page, and a match's log, however long,
-    /// is many small items rather than one large one, so there's no
-    /// per-request size cap being worked around here — just none of the
-    /// usual reasons to add a cursor.
+    /// delete/amend picker. Paginated: a full multi-innings, unlimited-overs
+    /// match can run to thousands of events, which is fine for the
+    /// per-item-safe log itself but not something to ship as one response.
     #[oai(path = "/matches/:match_id/live/events", method = "get")]
     async fn list_live_events(
         &self,
         Data(dao): Data<&dao::Dao>,
         AuthSchema(_jwt_data): AuthSchema,
         Path(match_id): Path<String>,
+        /// Opaque cursor from the previous page's `next_cursor`. Omit for the first page.
+        Query(cursor): Query<Option<String>>,
+        /// Maximum number of items to return (defaults to 20, capped at 50).
+        Query(limit): Query<Option<u32>>,
     ) -> Result<ListLiveEventsResponse> {
         if dao
             .get_match(&match_id)
@@ -2411,12 +2558,15 @@ impl Api {
             )));
         }
 
-        let records = dao
-            .list_live_events(&match_id)
+        let page = dao
+            .list_live_events_page(&match_id, cursor.as_deref(), page_limit(limit))
             .await
             .map_err(dao_internal)?;
-        let events: Vec<LiveEvent> = records.iter().map(live_event_from_record).collect();
-        Ok(ListLiveEventsResponse::Events(Json(events)))
+        let items: Vec<LiveEvent> = page.items.iter().map(live_event_from_record).collect();
+        Ok(ListLiveEventsResponse::Events(Json(LiveEventPage {
+            items,
+            next_cursor: page.next_cursor,
+        })))
     }
 
     /// Delete a single live event outright — "this never happened" (a
@@ -2535,8 +2685,13 @@ impl Api {
         }
     }
 
-    /// Derives the current live state by folding the full event log — no
-    /// cache involved (see `agon_core::dao::live_score_ops`'s module docs).
+    /// Derives the current live state by folding the full event log — the
+    /// slow path: bootstrapping a match's first cricket summary, recovering
+    /// from a missing/unparseable cache, and rebuilding after a correction
+    /// (an arbitrary-position delete/amend can't be applied as a single
+    /// incremental step — see `append_live_events` for the fast path).
+    /// Refreshes the `#LIVESTATE` cache for cricket; football has no cache
+    /// to refresh (see `agon_core::dao::live_score_ops`'s module docs).
     /// Returns `None` if `sport` doesn't support live scoring.
     async fn derive_live_snapshot(
         &self,
@@ -2552,7 +2707,40 @@ impl Api {
             return Ok(None);
         };
 
+        if let LiveScoreState::Cricket(_) = &state {
+            self.refresh_cricket_live_state_cache(dao, match_id, &state, last_seq)
+                .await;
+        }
+
         Ok(Some(LiveScoreSnapshot { last_seq, state }))
+    }
+
+    /// Best-effort cache write, shared by the full-refold path and the
+    /// incremental append path — never fails the caller's request; the
+    /// cache is always safely recomputable from the event log if this is
+    /// lost or goes stale.
+    async fn refresh_cricket_live_state_cache(
+        &self,
+        dao: &dao::Dao,
+        match_id: &str,
+        state: &LiveScoreState,
+        last_seq: u32,
+    ) {
+        let state_json =
+            poem_openapi::types::ToJSON::to_json(state).unwrap_or(serde_json::Value::Null);
+        if let Err(e) = dao
+            .put_live_state(
+                match_id,
+                &dao::records::LiveStateRecord {
+                    sport: "cricket".to_string(),
+                    state: state_json,
+                    last_seq,
+                },
+            )
+            .await
+        {
+            error!("Failed to refresh live-state cache for match {match_id}: {e}");
+        }
     }
 
     #[oai(path = "/matches/:match_id/score-submissions", method = "get")]

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -4604,10 +4604,7 @@ fn mock_football_detailed_score() -> DetailedScore {
         cards: vec![],
         substitutions: vec![],
         period: Some(FootballPeriod::FullTime),
-        kickoff_at: None,
-        half_time_at: None,
-        second_half_kickoff_at: None,
-        full_time_at: None,
+        period_times: std::collections::HashMap::new(),
     })
 }
 

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2211,16 +2211,12 @@ impl Api {
         Ok(UpdateMatchResponse::Match(Json(m)))
     }
 
-    /// Football's derived detail is cheap to fold (goals/cards/subs, not
-    /// deliveries) and nothing keeps a persisted football record in sync
-    /// with corrections the way cricket's incremental live-scoring path
-    /// does — so whenever a live log exists, this always re-derives fresh
-    /// from it rather than risk serving a stale persisted copy. Cricket is
-    /// the opposite: its persisted record is kept incrementally correct by
-    /// every live-scoring append (see `apply_cricket_events_incrementally`),
-    /// so it's trusted directly, with a full refold only as a recovery path
-    /// for a missing or unparseable record. Manual entry (no live log at
-    /// all, either sport) always reads the persisted record.
+    /// Both sports' persisted records are kept incrementally correct by
+    /// every live-scoring append (see `apply_live_events_incrementally`), so
+    /// this trusts the persisted record directly, with a full refold only as
+    /// a recovery path for a missing or unparseable record. Manual entry (no
+    /// live log at all) always reads the persisted record too — there's
+    /// nothing else for it to be caught up with.
     #[oai(path = "/matches/:match_id/detailed-score", method = "get")]
     async fn get_match_detailed_score(
         &self,
@@ -2240,28 +2236,6 @@ impl Api {
         };
         let sport = agg.match_.match_type.as_str();
 
-        if sport == "football" {
-            let records = dao
-                .list_live_events(&match_id)
-                .await
-                .map_err(dao_internal)?;
-            let ds = if !records.is_empty() {
-                derive_live_detail(sport, &records, agg.match_.format.as_ref())
-            } else {
-                dao.get_match_detailed_score(&match_id, sport)
-                    .await
-                    .map_err(dao_internal)?
-                    .as_ref()
-                    .and_then(detailed_score_from_record)
-            };
-            return match ds {
-                Some(ds) => Ok(GetMatchDetailedScoreResponse::DetailedScore(Json(ds))),
-                None => Ok(GetMatchDetailedScoreResponse::NotFound(PlainText(
-                    "match has no detailed score".into(),
-                ))),
-            };
-        }
-
         let record = dao
             .get_match_detailed_score(&match_id, sport)
             .await
@@ -2271,10 +2245,10 @@ impl Api {
         }
 
         // No usable persisted record — recover by folding the event log, if
-        // there is one (e.g. a live-scored cricket match whose record was
-        // somehow missing or unparseable). Persist the result so subsequent
-        // reads, and the next incremental append, have a fresh checkpoint to
-        // build on.
+        // there is one (e.g. a live-scored match whose record was somehow
+        // missing or unparseable). Persist the result so subsequent reads,
+        // and the next incremental append, have a fresh checkpoint to build
+        // on.
         let records = dao
             .list_live_events(&match_id)
             .await
@@ -2394,34 +2368,27 @@ impl Api {
             .map_err(dao_internal)?;
         }
 
-        // Cricket's cache supports a genuine incremental update (apply just
-        // the new events to the last-known checkpoint) since it's the one
-        // whose per-ball hot path this exists for; football always takes the
-        // full-refold path (cheap enough at its event volumes, and there's no
-        // cache for it to update). Falls back to a full refold itself if the
-        // cache is missing or behind (e.g. this is the innings' first ball,
-        // or a correction landed between the last append and this one).
-        let snapshot = if sport == "cricket" {
-            match self
-                .apply_cricket_events_incrementally(
-                    dao,
-                    &match_id,
-                    agg.match_.format.as_ref(),
-                    &input.events,
-                    input.expected_last_seq,
-                    new_last_seq,
-                )
-                .await?
-            {
-                Some(snapshot) => Some(snapshot),
-                None => {
-                    self.derive_live_snapshot(dao, &match_id, &sport, agg.match_.format.as_ref())
-                        .await?
-                }
+        // Applies just the new events to the last-known checkpoint, whatever
+        // the sport — falls back to a full refold itself if the checkpoint
+        // is missing or behind (e.g. this is the match's first event, or a
+        // correction landed between the last append and this one).
+        let snapshot = match self
+            .apply_live_events_incrementally(
+                dao,
+                &match_id,
+                &sport,
+                agg.match_.format.as_ref(),
+                &input.events,
+                input.expected_last_seq,
+                new_last_seq,
+            )
+            .await?
+        {
+            Some(snapshot) => Some(snapshot),
+            None => {
+                self.derive_live_snapshot(dao, &match_id, &sport, agg.match_.format.as_ref())
+                    .await?
             }
-        } else {
-            self.derive_live_snapshot(dao, &match_id, &sport, agg.match_.format.as_ref())
-                .await?
         };
 
         match snapshot {
@@ -2432,24 +2399,25 @@ impl Api {
         }
     }
 
-    /// The incremental fast path for a cricket append: applies just the
-    /// newly-appended events to the cached checkpoint, rather than refolding
-    /// the whole log. Returns `None` (meaning "fall back to a full refold")
-    /// when there's no usable checkpoint to build on — missing, unparseable,
-    /// or not caught up to exactly the start of this batch (a correction
-    /// landing between the last append and this one, or the very first event
-    /// this match has ever recorded).
-    async fn apply_cricket_events_incrementally(
+    /// The incremental fast path for an append, either sport: applies just
+    /// the newly-appended events to the persisted checkpoint, rather than
+    /// refolding the whole log. Returns `None` (meaning "fall back to a full
+    /// refold") when there's no usable checkpoint to build on — missing,
+    /// unparseable, or not caught up to exactly the start of this batch (a
+    /// correction landing between the last append and this one, or the very
+    /// first event this match has ever recorded).
+    async fn apply_live_events_incrementally(
         &self,
         dao: &dao::Dao,
         match_id: &str,
+        sport: &str,
         format: Option<&dao::records::MatchFormatRecord>,
         new_events: &[NewLiveEventInput],
         expected_last_seq: u32,
         new_last_seq: u32,
     ) -> Result<Option<LiveScoreSnapshot>> {
         let Some(record) = dao
-            .get_match_detailed_score(match_id, "cricket")
+            .get_match_detailed_score(match_id, sport)
             .await
             .map_err(dao_internal)?
         else {
@@ -2458,27 +2426,38 @@ impl Api {
         if record.last_seq != Some(expected_last_seq) {
             return Ok(None);
         }
-        let Some(DetailedScore::Cricket(mut detail)) = detailed_score_from_record(&record) else {
+        let Some(mut ds) = detailed_score_from_record(&record) else {
             return Ok(None);
         };
 
-        let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
-            mapping::cricket_format_args(format);
-        for e in new_events {
-            let LiveEventInput::Cricket(event) = &e.event else {
-                // Sport mismatch is already rejected earlier in
-                // `append_live_events`; unreachable here in practice.
-                return Ok(None);
-            };
-            detail.apply_event(
-                event,
-                balls_per_over,
-                wide_is_extra_ball,
-                no_ball_is_extra_ball,
-            );
+        match &mut ds {
+            DetailedScore::Cricket(detail) => {
+                let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
+                    mapping::cricket_format_args(format);
+                for e in new_events {
+                    let LiveEventInput::Cricket(event) = &e.event else {
+                        // Sport mismatch is already rejected earlier in
+                        // `append_live_events`; unreachable here in practice.
+                        return Ok(None);
+                    };
+                    detail.apply_event(
+                        event,
+                        balls_per_over,
+                        wide_is_extra_ball,
+                        no_ball_is_extra_ball,
+                    );
+                }
+            }
+            DetailedScore::Football(detail) => {
+                for e in new_events {
+                    let LiveEventInput::Football(event) = &e.event else {
+                        return Ok(None);
+                    };
+                    detail.apply_event(e.occurred_at, event);
+                }
+            }
         }
 
-        let ds = DetailedScore::Cricket(detail);
         self.persist_detailed_score(dao, match_id, &ds, Some(new_last_seq))
             .await;
 
@@ -2617,12 +2596,10 @@ impl Api {
     /// path: bootstrapping a match's first detailed score, recovering from a
     /// missing or unparseable persisted record, and rebuilding after an undo
     /// (removing the tip isn't a single incremental step the way appending
-    /// is — see `apply_cricket_events_incrementally` for that fast path).
-    /// Persists the result for cricket, whose record is meant to stay
-    /// incrementally in sync with every append; football's `GET
-    /// /detailed-score` always re-derives from the log itself when one
-    /// exists, so there's nothing to keep in sync for it here. Returns
-    /// `None` if `sport` doesn't support live scoring.
+    /// is — see `apply_live_events_incrementally` for that fast path).
+    /// Persists the result so subsequent reads and the next incremental
+    /// append have a fresh checkpoint to build on. Returns `None` if `sport`
+    /// doesn't support live scoring.
     async fn derive_live_snapshot(
         &self,
         dao: &dao::Dao,
@@ -2637,10 +2614,8 @@ impl Api {
             return Ok(None);
         };
 
-        if sport == "cricket" {
-            self.persist_detailed_score(dao, match_id, &detail, Some(last_seq))
-                .await;
-        }
+        self.persist_detailed_score(dao, match_id, &detail, Some(last_seq))
+            .await;
 
         Ok(Some(LiveScoreSnapshot { last_seq, detail }))
     }

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2338,7 +2338,7 @@ impl Api {
         }
 
         match self
-            .recompute_live_state(dao, &match_id, &sport, agg.match_.format.as_ref())
+            .derive_live_snapshot(dao, &match_id, &sport, agg.match_.format.as_ref())
             .await?
         {
             Some(snapshot) => Ok(AppendLiveEventsResponse::Ok(Json(snapshot))),
@@ -2349,8 +2349,10 @@ impl Api {
     }
 
     /// The current derived live-scoring state (score/clock/scorecard so
-    /// far), for a feed card or the scorer's own view to poll. Served from
-    /// the `#LIVESTATE` cache, recomputing it from the event log on a miss.
+    /// far), for a feed card or the scorer's own view to poll. Derived fresh
+    /// from the event log on every call — no separate cache to go stale or
+    /// risk a size cap of its own; folding the log is cheap enough not to
+    /// need one (see `agon_core::dao::live_score_ops`).
     #[oai(path = "/matches/:match_id/live", method = "get")]
     async fn get_live_score(
         &self,
@@ -2367,20 +2369,8 @@ impl Api {
             }
         };
 
-        if let Some(cached) = dao.get_live_state(&match_id).await.map_err(dao_internal)?
-            && let Ok(state) =
-                poem_openapi::types::ParseFromJSON::parse_from_json(Some(cached.state))
-        {
-            return Ok(GetLiveScoreResponse::State(Json(LiveScoreSnapshot {
-                last_seq: cached.last_seq,
-                state,
-            })));
-            // Otherwise fall through to a full recompute — it's just a
-            // cache, never trusted blindly if it's somehow unparseable.
-        }
-
         match self
-            .recompute_live_state(
+            .derive_live_snapshot(
                 dao,
                 &match_id,
                 &agg.match_.match_type,
@@ -2396,9 +2386,13 @@ impl Api {
     }
 
     /// The raw live event log, in order — for reconstructing the full
-    /// scorecard client-side or for the scorer's own delete/amend picker. Not
-    /// paginated: a single match's log is small (low hundreds of events at
-    /// most).
+    /// scorecard client-side (see `inningsDeliveriesFromEvents`, used by a
+    /// completed match's run-progression graph) or for the scorer's own
+    /// delete/amend picker. Not paginated at this level: the DAO already
+    /// drains every underlying query page, and a match's log, however long,
+    /// is many small items rather than one large one, so there's no
+    /// per-request size cap being worked around here — just none of the
+    /// usual reasons to add a cursor.
     #[oai(path = "/matches/:match_id/live/events", method = "get")]
     async fn list_live_events(
         &self,
@@ -2461,7 +2455,7 @@ impl Api {
         }
 
         match self
-            .recompute_live_state(
+            .derive_live_snapshot(
                 dao,
                 &match_id,
                 &agg.match_.match_type,
@@ -2525,7 +2519,7 @@ impl Api {
         }
 
         match self
-            .recompute_live_state(
+            .derive_live_snapshot(
                 dao,
                 &match_id,
                 &agg.match_.match_type,
@@ -2541,11 +2535,10 @@ impl Api {
         }
     }
 
-    /// Re-derives the live state from the full event log and refreshes the
-    /// `#LIVESTATE` cache. The cache write is best-effort — it's always
-    /// safely recomputable, so a failure here doesn't fail the caller's
-    /// request. Returns `None` if `sport` doesn't support live scoring.
-    async fn recompute_live_state(
+    /// Derives the current live state by folding the full event log — no
+    /// cache involved (see `agon_core::dao::live_score_ops`'s module docs).
+    /// Returns `None` if `sport` doesn't support live scoring.
+    async fn derive_live_snapshot(
         &self,
         dao: &dao::Dao,
         match_id: &str,
@@ -2558,22 +2551,6 @@ impl Api {
         let Some(state) = derive_live_score_state(sport, &records, format) else {
             return Ok(None);
         };
-
-        let state_json =
-            poem_openapi::types::ToJSON::to_json(&state).unwrap_or(serde_json::Value::Null);
-        if let Err(e) = dao
-            .put_live_state(
-                match_id,
-                &dao::records::LiveStateRecord {
-                    sport: sport.to_string(),
-                    state: state_json,
-                    last_seq,
-                },
-            )
-            .await
-        {
-            error!("Failed to refresh live-state cache for match {match_id}: {e}");
-        }
 
         Ok(Some(LiveScoreSnapshot { last_seq, state }))
     }

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -11,16 +11,17 @@ use crate::detailed_score::cricket::{
     CricketDelivery, CricketDeliveryExtra, CricketDeliveryWicket, CricketDismissalKind,
     CricketExtraKind, Overs,
 };
+use crate::detailed_score::football::{
+    FootballCardColor, FootballCardEvent, FootballGoalEvent, FootballPeriod,
+    FootballSubstitutionEvent,
+};
 use crate::live_score::{
-    LiveEvent, LiveEventInput, LiveScoreState, NewLiveEventInput,
+    LiveEvent, LiveEventInput, NewLiveEventInput,
     cricket::{
         CricketInningsEndEvent, CricketInningsStartEvent, CricketLiveEvent, CricketRetireEvent,
         InningsEndReason,
     },
-    football::{
-        FootballCardColor, FootballCardEvent, FootballGoalEvent, FootballLiveEvent, FootballPeriod,
-        FootballPeriodEvent, FootballSubstitutionEvent,
-    },
+    football::{FootballLiveEvent, FootballPeriodEvent},
 };
 use crate::match_format::{CricketFormat, FootballFormat, MatchFormat};
 use crate::membership::{
@@ -619,14 +620,21 @@ pub fn like_user_id(rec: &MatchLikeRecord) -> String {
 
 /// Serialize a `DetailedScore` union into the `(sport, detail)` record shape.
 /// The sport tag mirrors the union variant so a read can pick the right variant.
-pub fn detailed_score_to_record(ds: &DetailedScore) -> MatchDetailedScoreRecord {
+pub fn detailed_score_to_record(
+    ds: &DetailedScore,
+    last_seq: Option<u32>,
+) -> MatchDetailedScoreRecord {
     let sport = match ds {
         DetailedScore::Football(_) => "football",
         DetailedScore::Cricket(_) => "cricket",
     }
     .to_string();
     let detail = ds.to_json().unwrap_or(serde_json::Value::Null);
-    MatchDetailedScoreRecord { sport, detail }
+    MatchDetailedScoreRecord {
+        sport,
+        detail,
+        last_seq,
+    }
 }
 
 /// Parse a stored detailed-score record back into the `DetailedScore` union.
@@ -1028,18 +1036,18 @@ pub fn live_event_from_record(rec: &LiveEventRecord) -> LiveEvent {
     }
 }
 
-/// Folds a match's live event log into its derived state. `None` if
+/// Folds a match's live event log into its full detail. `None` if
 /// `match_type` isn't a sport live scoring supports yet (only football and
 /// cricket so far — see `LiveEventInput`).
 ///
 /// `records` is whatever the DAO currently has on record, in seq order — a
 /// deleted event is already absent from it and an amended one already shows
 /// its corrected content, so there's no filtering pass needed here.
-pub fn derive_live_score_state(
+pub fn derive_live_detail(
     match_type: &str,
     records: &[LiveEventRecord],
     format: Option<&MatchFormatRecord>,
-) -> Option<LiveScoreState> {
+) -> Option<DetailedScore> {
     match match_type {
         "football" => {
             let events: Vec<(chrono::DateTime<chrono::Utc>, FootballLiveEvent)> = records
@@ -1051,8 +1059,8 @@ pub fn derive_live_score_state(
                     LiveEventPayloadRecord::Cricket(_) => None,
                 })
                 .collect();
-            Some(LiveScoreState::Football(
-                crate::live_score::football::derive_state(&events),
+            Some(DetailedScore::Football(
+                crate::live_score::football::derive_detail(&events),
             ))
         }
         "cricket" => {
@@ -1065,8 +1073,8 @@ pub fn derive_live_score_state(
                 .collect();
             let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
                 cricket_format_args(format);
-            Some(LiveScoreState::Cricket(
-                crate::live_score::cricket::CricketLiveState::from_events(
+            Some(DetailedScore::Cricket(
+                crate::detailed_score::cricket::CricketDetail::from_events(
                     &events,
                     balls_per_over,
                     wide_is_extra_ball,

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -850,7 +850,7 @@ fn cricket_live_event_to_record(event: &CricketLiveEvent) -> CricketLiveEventRec
     }
 }
 
-fn cricket_live_event_from_record(rec: &CricketLiveEventRecord) -> CricketLiveEvent {
+pub fn cricket_live_event_from_record(rec: &CricketLiveEventRecord) -> CricketLiveEvent {
     match rec {
         CricketLiveEventRecord::Delivery(d) => {
             CricketLiveEvent::Delivery(cricket_delivery_from_record(d))
@@ -1063,19 +1063,10 @@ pub fn derive_live_score_state(
                     LiveEventPayloadRecord::Football(_) => None,
                 })
                 .collect();
-            // Standard rules unless the match configured something else: a
-            // 6-ball over (e.g. The Hundred's 5), and both wides and no-balls
-            // as extra (re-bowled) deliveries.
-            let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) = match format {
-                Some(MatchFormatRecord::Cricket(f)) => (
-                    f.balls_per_over,
-                    f.wide_is_extra_ball,
-                    f.no_ball_is_extra_ball,
-                ),
-                _ => (6, true, true),
-            };
+            let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
+                cricket_format_args(format);
             Some(LiveScoreState::Cricket(
-                crate::live_score::cricket::derive_state(
+                crate::live_score::cricket::CricketLiveState::from_events(
                     &events,
                     balls_per_over,
                     wide_is_extra_ball,
@@ -1084,6 +1075,23 @@ pub fn derive_live_score_state(
             ))
         }
         _ => None,
+    }
+}
+
+/// A cricket match's configured over length and extra-ball rules — standard
+/// rules (a 6-ball over, wides/no-balls re-bowled as extras) unless the match
+/// configured something else (e.g. The Hundred's 5-ball over). The only
+/// pieces of match format the DAO-agnostic scoring math actually needs, so
+/// callers thread these three through as plain arguments rather than the
+/// whole format.
+pub fn cricket_format_args(format: Option<&MatchFormatRecord>) -> (u32, bool, bool) {
+    match format {
+        Some(MatchFormatRecord::Cricket(f)) => (
+            f.balls_per_over,
+            f.wide_is_extra_ball,
+            f.no_ball_is_extra_ball,
+        ),
+        _ => (6, true, true),
     }
 }
 

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -1060,7 +1060,7 @@ pub fn derive_live_detail(
                 })
                 .collect();
             Some(DetailedScore::Football(
-                crate::live_score::football::derive_detail(&events),
+                crate::detailed_score::football::FootballDetail::from_events(&events),
             ))
         }
         "cricket" => {

--- a/agon_ui/src/components/agon/CricketScorecard.tsx
+++ b/agon_ui/src/components/agon/CricketScorecard.tsx
@@ -5,7 +5,7 @@ import {
   formatOvers,
   playerNameFor,
   runProgression,
-  type CricketInnings,
+  type CricketLiveInnings,
 } from '@/lib/cricketScore'
 import { cricketFormat } from '@/lib/matchFormat'
 import { CricketRunRateChart, type RunRateSeries } from './CricketRunRateChart'
@@ -25,7 +25,7 @@ function sideNameFor(match: Match, sideId: string): string {
  * cards. Renders nothing if there's no per-innings detail to show (e.g. only
  * a headline score was ever recorded).
  */
-export function CricketScorecard({ match, innings }: { match: Match; innings: CricketInnings[] }) {
+export function CricketScorecard({ match, innings }: { match: Match; innings: CricketLiveInnings[] }) {
   if (innings.length === 0) return null
 
   const format = cricketFormat(match.format)
@@ -56,7 +56,7 @@ export function CricketScorecard({ match, innings }: { match: Match; innings: Cr
   )
 }
 
-function InningsCard({ match, innings }: { match: Match; innings: CricketInnings }) {
+function InningsCard({ match, innings }: { match: Match; innings: CricketLiveInnings }) {
   if (innings.batting.length === 0 && innings.bowling.length === 0) return null
 
   const battingName = sideNameFor(match, innings.batting_side_id)

--- a/agon_ui/src/components/agon/CricketScorecard.tsx
+++ b/agon_ui/src/components/agon/CricketScorecard.tsx
@@ -5,7 +5,9 @@ import {
   formatOvers,
   playerNameFor,
   runProgression,
-  type CricketLiveInnings,
+  type CricketBattingEntry,
+  type CricketBowlingEntry,
+  type CricketInningsWithDeliveries,
 } from '@/lib/cricketScore'
 import { cricketFormat } from '@/lib/matchFormat'
 import { CricketRunRateChart, type RunRateSeries } from './CricketRunRateChart'
@@ -25,7 +27,7 @@ function sideNameFor(match: Match, sideId: string): string {
  * cards. Renders nothing if there's no per-innings detail to show (e.g. only
  * a headline score was ever recorded).
  */
-export function CricketScorecard({ match, innings }: { match: Match; innings: CricketLiveInnings[] }) {
+export function CricketScorecard({ match, innings }: { match: Match; innings: CricketInningsWithDeliveries[] }) {
   if (innings.length === 0) return null
 
   const format = cricketFormat(match.format)
@@ -56,7 +58,7 @@ export function CricketScorecard({ match, innings }: { match: Match; innings: Cr
   )
 }
 
-function InningsCard({ match, innings }: { match: Match; innings: CricketLiveInnings }) {
+function InningsCard({ match, innings }: { match: Match; innings: CricketInningsWithDeliveries }) {
   if (innings.batting.length === 0 && innings.bowling.length === 0) return null
 
   const battingName = sideNameFor(match, innings.batting_side_id)
@@ -83,7 +85,7 @@ function InningsCard({ match, innings }: { match: Match; innings: CricketLiveInn
             </TableRow>
           </TableHeader>
           <TableBody>
-            {innings.batting.map((b) => (
+            {innings.batting.map((b: CricketBattingEntry) => (
               <TableRow key={b.player_id}>
                 <TableCell>
                   <p className="font-medium">{playerNameFor(match, b.player_id)}</p>
@@ -110,7 +112,7 @@ function InningsCard({ match, innings }: { match: Match; innings: CricketLiveInn
             </TableRow>
           </TableHeader>
           <TableBody>
-            {innings.bowling.map((bw) => (
+            {innings.bowling.map((bw: CricketBowlingEntry) => (
               <TableRow key={bw.player_id}>
                 <TableCell className="font-medium">{playerNameFor(match, bw.player_id)}</TableCell>
                 <TableCell className="text-right tabular-nums">{bowlingFigures(bw)}</TableCell>

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -17,10 +17,10 @@ import { LiveMatchBlock } from './live/LiveMatchBlock'
 import { CricketMatchBlock } from './live/CricketMatchBlock'
 import { CricketScoreBlock } from './CricketScoreBlock'
 import { LiveIndicator } from './live/LiveIndicator'
-import { useLiveScore } from '@/hooks/useLiveScore'
-import { footballLiveState } from '@/lib/liveScore'
+import { useMatchDetailedScore } from '@/hooks/useMatchDetailedScore'
+import { footballDetailFrom } from '@/lib/liveScore'
 import {
-  cricketLiveState,
+  cricketDetailFrom,
   cricketProgressFromScore,
   cricketScoreFrom,
   cricketStateDescription,
@@ -203,12 +203,12 @@ export function MatchCard({
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
 
   const isLiveSport = match.match_type === 'football' || match.match_type === 'cricket'
-  const live = useLiveScore(match.id, {
+  const detailedScore = useMatchDetailedScore(match.id, {
     enabled: isLiveSport && match.status === 'in_progress',
     refetchInterval: 20000,
   })
-  const footballState = footballLiveState(live.data)
-  const cricketState = cricketLiveState(live.data)
+  const footballState = footballDetailFrom(detailedScore.data)
+  const cricketState = cricketDetailFrom(detailedScore.data)
   const hasLiveState = !!footballState || !!cricketState
   // A cricket match's confirmed score carries its own per-innings detail once
   // it's been live-scored (`Score::Cricket`; see `finishMatch` in

--- a/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
@@ -11,7 +11,7 @@ import {
   playerNameFor,
   runRate,
   sideNameFor,
-  type CricketLiveState,
+  type CricketDetail,
 } from '@/lib/cricketScore'
 import { cricketFormat } from '@/lib/matchFormat'
 
@@ -36,8 +36,8 @@ function BallChip({ label, kind }: { label: string; kind: 'boundary' | 'wicket' 
 /**
  * The score block + "this over" ball row for a cricket match being scored
  * live (mirrors `LiveMatchBlock`'s role for football). Presentational: the
- * caller fetches the live snapshot (`useLiveScore`) and passes the derived
- * cricket state down.
+ * caller fetches the detailed score (`useMatchDetailedScore`) and passes the
+ * derived cricket detail down.
  */
 export function CricketMatchBlock({
   match,
@@ -45,7 +45,7 @@ export function CricketMatchBlock({
   showDescription = true,
 }: {
   match: Match
-  state: CricketLiveState
+  state: CricketDetail
   /** Whether to show the state-of-game line (target/leading/result) here.
    *  Callers that already surface it elsewhere (the feed card's header)
    *  pass `false` so it isn't said twice — the innings-break heading then
@@ -99,7 +99,7 @@ export function CricketMatchBlock({
   const battingName = sideNameFor(match, innings.batting_side_id)
   const bowlingName = sideNameFor(match, innings.bowling_side_id)
   const next = state.next_ball_context
-  const overBalls = currentOverDeliveries(state.recent_deliveries)
+  const overBalls = currentOverDeliveries(state.recent_deliveries ?? [])
   const crr = runRate(innings.runs, innings.overs, format.balls_per_over)
 
   return (

--- a/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
@@ -2,15 +2,12 @@ import type { components } from '@/types/api'
 import { cn } from '@/lib/utils'
 import { LiveIndicator } from './LiveIndicator'
 import {
-  battingEntryFor,
-  battingLine,
   cricketStateDescription,
   currentInnings,
   currentOverDeliveries,
   deliveryChipLabel,
   formatOvers,
   isChipHighlighted,
-  nextBallContext,
   playerNameFor,
   runRate,
   sideNameFor,
@@ -101,10 +98,8 @@ export function CricketMatchBlock({
 
   const battingName = sideNameFor(match, innings.batting_side_id)
   const bowlingName = sideNameFor(match, innings.bowling_side_id)
-  const next = nextBallContext(innings, format)
-  const striker = battingEntryFor(innings, next.strikerPlayerId)
-  const nonStriker = battingEntryFor(innings, next.nonStrikerPlayerId)
-  const overBalls = currentOverDeliveries(innings)
+  const next = state.next_ball_context
+  const overBalls = currentOverDeliveries(state.recent_deliveries)
   const crr = runRate(innings.runs, innings.overs, format.balls_per_over)
 
   return (
@@ -120,19 +115,11 @@ export function CricketMatchBlock({
               {crr.toFixed(2)})
             </span>
           </p>
-          {(striker || nonStriker) && (
+          {next && (next.striker_player_id || next.non_striker_player_id) && (
             <p className="mt-0.5 truncate text-xs text-muted-foreground">
-              {next.strikerPlayerId && (
-                <>
-                  {playerNameFor(match, next.strikerPlayerId)}* {battingLine(striker)}
-                </>
-              )}
-              {next.strikerPlayerId && next.nonStrikerPlayerId && ' · '}
-              {next.nonStrikerPlayerId && (
-                <>
-                  {playerNameFor(match, next.nonStrikerPlayerId)} {battingLine(nonStriker)}
-                </>
-              )}
+              {next.striker_player_id && <>{playerNameFor(match, next.striker_player_id)}*</>}
+              {next.striker_player_id && next.non_striker_player_id && ' · '}
+              {next.non_striker_player_id && <>{playerNameFor(match, next.non_striker_player_id)}</>}
             </p>
           )}
           {showDescription && description && (

--- a/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
@@ -7,7 +7,7 @@ import {
   eventEmoji,
   liveClockLabel,
   recentEvents,
-  type FootballLiveState,
+  type FootballDetail,
 } from '@/lib/liveScore'
 
 /** How often the clock label re-renders. Minute-granularity, so this just
@@ -24,9 +24,10 @@ function sideName(side: MatchSide | undefined, fallback: string): string {
 /**
  * The score block + mini-ticker for a football match being scored live
  * (mockup "Mini-ticker — last events under the score"). Presentational: the
- * caller fetches the live snapshot (`useLiveScore`) and passes the derived
- * football state down, so `MatchCard` and `MatchDetailPage` can each decide
- * when to show this instead of their normal (confirmed/pending score) block.
+ * caller fetches the detailed score (`useMatchDetailedScore`) and passes the
+ * derived football detail down, so `MatchCard` and `MatchDetailPage` can each
+ * decide when to show this instead of their normal (confirmed/pending score)
+ * block.
  */
 export function LiveMatchBlock({
   match,
@@ -34,7 +35,7 @@ export function LiveMatchBlock({
   tickerLimit = 2,
 }: {
   match: Match
-  state: FootballLiveState
+  state: FootballDetail
   /** How many recent events to show under the score. */
   tickerLimit?: number
 }) {

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -1,81 +1,82 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
+import { matchDetailedScoreQueryKey } from './useMatchDetailedScore'
 
-type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
 type LiveEvent = components['schemas']['LiveEvent']
 type NewLiveEventInput = components['schemas']['NewLiveEventInput']
 type FootballLiveEvent = components['schemas']['FootballLiveEvent']
 type CricketLiveEvent = components['schemas']['CricketLiveEvent']
 
-export function liveScoreQueryKey(matchId: string | undefined) {
-  return ['live', matchId] as const
+/** Drains every page of a match's raw live event log, oldest first. */
+async function drainLiveEvents(matchId: string): Promise<LiveEvent[]> {
+  const events: LiveEvent[] = []
+  let cursor: string | undefined
+  for (;;) {
+    const { data, response } = await fetchClient.GET('/matches/{match_id}/live/events', {
+      params: { path: { match_id: matchId }, query: { cursor, limit: 50 } },
+    })
+    if (response.status === 404) return []
+    if (!data) throw new Error('Failed to load live events')
+    events.push(...data.items)
+    if (!data.next_cursor) break
+    cursor = data.next_cursor
+  }
+  return events
 }
 
 /**
- * A match's derived live-scoring snapshot. `null` (not `undefined`) means the
- * match has no live events recorded yet — a normal state (scoring hasn't
- * started), distinct from "still loading" or "failed to load".
- */
-export function useLiveScore(
-  matchId: string | undefined,
-  options?: { enabled?: boolean; refetchInterval?: number | false },
-) {
-  return useQuery({
-    queryKey: liveScoreQueryKey(matchId),
-    enabled: !!matchId && (options?.enabled ?? true),
-    refetchInterval: options?.refetchInterval,
-    queryFn: async (): Promise<LiveScoreSnapshot | null> => {
-      const { data, response } = await fetchClient.GET('/matches/{match_id}/live', {
-        params: { path: { match_id: matchId! } },
-      })
-      if (response.status === 404) return null
-      if (!data) throw new Error('Failed to load live score')
-      return data
-    },
-  })
-}
-
-/**
- * A match's raw live-scoring event log, in append order — unlike
- * `useLiveScore`'s derived snapshot, this has no size ceiling (one DynamoDB
- * item per event) and stays fully readable regardless of match length or
- * status, so a completed match's full run-progression graph reads deliveries
- * from here (see `inningsDeliveriesFromEvents`) rather than the snapshot,
- * which only ever carries the current innings' totals plus a bounded
- * recent-deliveries window. The endpoint itself is paginated (a long match's
- * log can run to thousands of events), so this drains every page — fine for
- * a one-shot fetch on a match detail page, not meant for polling.
+ * A match's raw live-scoring event log, in append order. Unlike the derived
+ * scorecard (`useMatchDetailedScore`), this has no size ceiling (one
+ * DynamoDB item per event) and stays fully readable regardless of match
+ * length or status, so a completed match's full run-progression graph reads
+ * deliveries from here (see `inningsDeliveriesFromEvents`) rather than the
+ * scorecard, which only ever carries the current innings' totals plus a
+ * bounded recent-deliveries window. The endpoint itself is paginated (a long
+ * match's log can run to thousands of events), so this drains every page —
+ * fine for a one-shot fetch on a match detail page, not meant for polling.
  */
 export function useLiveEvents(matchId: string | undefined, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ['live-events', matchId],
     enabled: !!matchId && (options?.enabled ?? true),
-    queryFn: async (): Promise<LiveEvent[]> => {
-      const events: LiveEvent[] = []
-      let cursor: string | undefined
-      for (;;) {
-        const { data, response } = await fetchClient.GET('/matches/{match_id}/live/events', {
-          params: { path: { match_id: matchId! }, query: { cursor, limit: 50 } },
-        })
-        if (response.status === 404) return []
-        if (!data) throw new Error('Failed to load live events')
-        events.push(...data.items)
-        if (!data.next_cursor) break
-        cursor = data.next_cursor
-      }
-      return events
+    queryFn: () => drainLiveEvents(matchId!),
+  })
+}
+
+export function liveSeqQueryKey(matchId: string | undefined) {
+  return ['live-seq', matchId] as const
+}
+
+/**
+ * The event log's current tip (`seq` of the most recently recorded event, 0
+ * if none yet) — needed only for the optimistic-concurrency
+ * `expected_last_seq` on the next append, not a read of the scorecard itself
+ * (see `useMatchDetailedScore` for that; there's no separate "live state"
+ * endpoint anymore). Seeded once by draining the raw event log, the same
+ * one-shot-fetch pattern as `useLiveEvents`; every append after that updates
+ * the cached value directly from its own response instead of refetching.
+ */
+export function useLiveSeq(matchId: string | undefined, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: liveSeqQueryKey(matchId),
+    enabled: !!matchId && (options?.enabled ?? true),
+    staleTime: Infinity,
+    queryFn: async (): Promise<number> => {
+      const events = await drainLiveEvents(matchId!)
+      return events.reduce((max, e) => Math.max(max, e.seq), 0)
     },
   })
 }
 
 /**
  * Appends one sport-tagged live event to a match's log. Reads
- * `expected_last_seq` off the current cached snapshot (0 if scoring hasn't
- * started yet) so the server can detect a lost update; on success the
- * returned snapshot replaces the cache directly (cheaper and more current
- * than invalidating + refetching). Shared by the per-sport wrappers below —
- * each just tags its event with the right `sport` discriminator.
+ * `expected_last_seq` off the cached tip (0 if scoring hasn't started yet, or
+ * this device hasn't loaded it) so the server can detect a lost update; on
+ * success the returned snapshot's `last_seq` and `detail` replace the tip and
+ * scorecard caches directly (cheaper and more current than invalidating +
+ * refetching). Shared by the per-sport wrappers below — each just tags its
+ * event with the right `sport` discriminator.
  *
  * The server flips a still-`scheduled` match to `in_progress` the first time
  * any live event is recorded, so every append also invalidates the match and
@@ -90,8 +91,7 @@ function useAppendLiveEvent<T extends { kind: string }>(
 
   return useMutation({
     mutationFn: async (event: T) => {
-      const key = liveScoreQueryKey(matchId)
-      const current = queryClient.getQueryData<LiveScoreSnapshot | null>(key)
+      const expected = queryClient.getQueryData<number>(liveSeqQueryKey(matchId)) ?? 0
       const input: NewLiveEventInput = {
         occurred_at: new Date().toISOString(),
         event: { sport, ...event } as NewLiveEventInput['event'],
@@ -99,7 +99,7 @@ function useAppendLiveEvent<T extends { kind: string }>(
       const { data, error } = await fetchClient.POST('/matches/{match_id}/live/events', {
         params: { path: { match_id: matchId } },
         body: {
-          expected_last_seq: current?.last_seq ?? 0,
+          expected_last_seq: expected,
           events: [input],
         },
       })
@@ -107,7 +107,8 @@ function useAppendLiveEvent<T extends { kind: string }>(
       return data
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(liveScoreQueryKey(matchId), data)
+      queryClient.setQueryData(liveSeqQueryKey(matchId), data.last_seq)
+      queryClient.setQueryData(matchDetailedScoreQueryKey(matchId), data.detail)
       queryClient.invalidateQueries({ queryKey: ['match', matchId] })
       queryClient.invalidateQueries({ queryKey: ['feed'] })
     },

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -42,19 +42,29 @@ export function useLiveScore(
  * item per event) and stays fully readable regardless of match length or
  * status, so a completed match's full run-progression graph reads deliveries
  * from here (see `inningsDeliveriesFromEvents`) rather than the snapshot,
- * which only keeps the currently (or most recently) open innings' ball log.
+ * which only ever carries the current innings' totals plus a bounded
+ * recent-deliveries window. The endpoint itself is paginated (a long match's
+ * log can run to thousands of events), so this drains every page — fine for
+ * a one-shot fetch on a match detail page, not meant for polling.
  */
 export function useLiveEvents(matchId: string | undefined, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ['live-events', matchId],
     enabled: !!matchId && (options?.enabled ?? true),
     queryFn: async (): Promise<LiveEvent[]> => {
-      const { data, response } = await fetchClient.GET('/matches/{match_id}/live/events', {
-        params: { path: { match_id: matchId! } },
-      })
-      if (response.status === 404) return []
-      if (!data) throw new Error('Failed to load live events')
-      return data
+      const events: LiveEvent[] = []
+      let cursor: string | undefined
+      for (;;) {
+        const { data, response } = await fetchClient.GET('/matches/{match_id}/live/events', {
+          params: { path: { match_id: matchId! }, query: { cursor, limit: 50 } },
+        })
+        if (response.status === 404) return []
+        if (!data) throw new Error('Failed to load live events')
+        events.push(...data.items)
+        if (!data.next_cursor) break
+        cursor = data.next_cursor
+      }
+      return events
     },
   })
 }

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -3,6 +3,7 @@ import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 
 type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
+type LiveEvent = components['schemas']['LiveEvent']
 type NewLiveEventInput = components['schemas']['NewLiveEventInput']
 type FootballLiveEvent = components['schemas']['FootballLiveEvent']
 type CricketLiveEvent = components['schemas']['CricketLiveEvent']
@@ -30,6 +31,29 @@ export function useLiveScore(
       })
       if (response.status === 404) return null
       if (!data) throw new Error('Failed to load live score')
+      return data
+    },
+  })
+}
+
+/**
+ * A match's raw live-scoring event log, in append order — unlike
+ * `useLiveScore`'s derived snapshot, this has no size ceiling (one DynamoDB
+ * item per event) and stays fully readable regardless of match length or
+ * status, so a completed match's full run-progression graph reads deliveries
+ * from here (see `inningsDeliveriesFromEvents`) rather than the snapshot,
+ * which only keeps the currently (or most recently) open innings' ball log.
+ */
+export function useLiveEvents(matchId: string | undefined, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ['live-events', matchId],
+    enabled: !!matchId && (options?.enabled ?? true),
+    queryFn: async (): Promise<LiveEvent[]> => {
+      const { data, response } = await fetchClient.GET('/matches/{match_id}/live/events', {
+        params: { path: { match_id: matchId! } },
+      })
+      if (response.status === 404) return []
+      if (!data) throw new Error('Failed to load live events')
       return data
     },
   })

--- a/agon_ui/src/hooks/useMatchDetailedScore.ts
+++ b/agon_ui/src/hooks/useMatchDetailedScore.ts
@@ -17,11 +17,12 @@ export function matchDetailedScoreQueryKey(matchId: string | undefined) {
  */
 export function useMatchDetailedScore(
   matchId: string | undefined,
-  options?: { enabled?: boolean },
+  options?: { enabled?: boolean; refetchInterval?: number | false },
 ) {
   return useQuery({
     queryKey: matchDetailedScoreQueryKey(matchId),
     enabled: !!matchId && (options?.enabled ?? true),
+    refetchInterval: options?.refetchInterval,
     queryFn: async (): Promise<DetailedScore | null> => {
       const { data, response } = await fetchClient.GET('/matches/{match_id}/detailed-score', {
         params: { path: { match_id: matchId! } },

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -4,6 +4,7 @@ import type { CricketFormat } from './matchFormat'
 
 export type CricketDelivery = components['schemas']['CricketDelivery']
 export type CricketInnings = components['schemas']['CricketInnings']
+export type CricketLiveInnings = components['schemas']['CricketLiveInnings']
 export type CricketLiveState = components['schemas']['CricketLiveState']
 export type CricketExtraKind = components['schemas']['CricketExtraKind']
 export type CricketDismissalKind = components['schemas']['CricketDismissalKind']
@@ -75,7 +76,7 @@ export function cricketProgressFromScore(score: CricketScore): CricketMatchProgr
 /** The innings currently being played, or `null` when the match hasn't
  *  started its first innings yet, or is between innings (see
  *  `CricketLiveState.awaiting_next_innings`). */
-export function currentInnings(state: CricketLiveState): CricketInnings | null {
+export function currentInnings(state: CricketLiveState): CricketLiveInnings | null {
   if (state.awaiting_next_innings) return null
   return state.innings[state.innings.length - 1] ?? null
 }
@@ -152,7 +153,7 @@ export function runProgression(
 /** This over's deliveries — everything recorded against the innings' latest
  *  over index (we assign `over`/`ball` ourselves on submit, so this is a
  *  simple filter rather than a rolling window). */
-export function currentOverDeliveries(innings: CricketInnings): CricketDelivery[] {
+export function currentOverDeliveries(innings: CricketLiveInnings): CricketDelivery[] {
   const latestOver = innings.deliveries.reduce((max, d) => Math.max(max, d.over), 0)
   return innings.deliveries.filter((d) => d.over === latestOver)
 }
@@ -376,7 +377,7 @@ export interface NextBallContext {
 }
 
 export function nextBallContext(
-  innings: CricketInnings,
+  innings: CricketLiveInnings,
   format: Pick<CricketFormat, 'balls_per_over' | 'wide_is_extra_ball' | 'no_ball_is_extra_ball'>,
 ): NextBallContext {
   let striker: string | null = null

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -13,6 +13,8 @@ export type CricketBowlingEntry = components['schemas']['CricketBowlingEntry']
 export type CricketScore = components['schemas']['CricketScore']
 export type CricketScoreInnings = components['schemas']['CricketScoreInnings']
 export type Overs = components['schemas']['Overs']
+export type CricketLiveEvent = components['schemas']['CricketLiveEvent']
+type LiveEvent = components['schemas']['LiveEvent']
 type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
 type DetailedScore = components['schemas']['DetailedScore']
 type Score = components['schemas']['Score']
@@ -43,6 +45,50 @@ export function cricketDetail(
 ): CricketInnings[] | null {
   if (!detail || detail.type !== 'Cricket') return null
   return detail.innings
+}
+
+/** One innings' ball-by-ball log, recovered by segmenting the raw live event
+ *  log on its `InningsStart`/`InningsEnd` markers. This is the durable
+ *  source for a completed match's full run-progression graph — the live
+ *  snapshot (`CricketLiveState`) only ever keeps deliveries for the innings
+ *  currently open (or just-finished), since that's all the live view itself
+ *  needs; the event log has no such bound (one item per ball, not one item
+ *  per match) and is safe to read in full regardless of match length. */
+export interface InningsDeliveries {
+  batting_side_id: string
+  bowling_side_id: string
+  deliveries: CricketDelivery[]
+}
+
+export function inningsDeliveriesFromEvents(events: LiveEvent[]): InningsDeliveries[] {
+  const innings: InningsDeliveries[] = []
+  let current: InningsDeliveries | null = null
+
+  for (const record of events) {
+    if (record.event.sport !== 'Cricket') continue
+    // `event.sport`'s narrowing erases `kind` on the nested union (the same
+    // openapi-typescript quirk as `Invitation.kind` in `lib/members.ts`) —
+    // cast back to the real union to read it.
+    const event = record.event as unknown as CricketLiveEvent
+    if (event.kind === 'InningsStart') {
+      // Close out anything left open without an explicit End, rather than
+      // silently dropping it — mirrors `derive_state`'s fallback on the
+      // backend (shouldn't normally happen).
+      if (current) innings.push(current)
+      current = {
+        batting_side_id: event.batting_side_id,
+        bowling_side_id: event.bowling_side_id,
+        deliveries: [],
+      }
+    } else if (event.kind === 'Delivery' && current) {
+      current.deliveries.push(event)
+    } else if (event.kind === 'InningsEnd' && current) {
+      innings.push(current)
+      current = null
+    }
+  }
+  if (current) innings.push(current)
+  return innings
 }
 
 /** The minimal per-innings shape match-aggregate math and the state-of-game

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -4,8 +4,7 @@ import type { CricketFormat } from './matchFormat'
 
 export type CricketDelivery = components['schemas']['CricketDelivery']
 export type CricketInnings = components['schemas']['CricketInnings']
-export type CricketInningsTotals = components['schemas']['CricketInningsTotals']
-export type CricketLiveState = components['schemas']['CricketLiveState']
+export type CricketDetail = components['schemas']['CricketDetail']
 export type NextBallContext = components['schemas']['NextBallContext']
 export type CricketExtraKind = components['schemas']['CricketExtraKind']
 export type CricketDismissalKind = components['schemas']['CricketDismissalKind']
@@ -16,18 +15,18 @@ export type CricketScoreInnings = components['schemas']['CricketScoreInnings']
 export type Overs = components['schemas']['Overs']
 export type CricketLiveEvent = components['schemas']['CricketLiveEvent']
 type LiveEvent = components['schemas']['LiveEvent']
-type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
 type DetailedScore = components['schemas']['DetailedScore']
 type Score = components['schemas']['Score']
 type Match = components['schemas']['Match']
 
-/** Narrows a live-score snapshot to its cricket state, or `null` when there's
- *  no snapshot yet or it's for a different sport. */
-export function cricketLiveState(
-  snapshot: LiveScoreSnapshot | null | undefined,
-): CricketLiveState | null {
-  if (!snapshot || snapshot.state.sport !== 'Cricket') return null
-  return snapshot.state
+/** Narrows a match's detailed score to its cricket detail — innings plus,
+ *  while a match is actually being live-scored, the bounded recent-ball
+ *  window and next-ball context (see `CricketDetail`'s doc comment on the
+ *  backend for why it's one merged shape, live or finished). `null` when
+ *  there's none yet or it's for a different sport. */
+export function cricketDetailFrom(detail: DetailedScore | null | undefined): CricketDetail | null {
+  if (!detail || detail.type !== 'Cricket') return null
+  return detail
 }
 
 /** Narrows a match score to its cricket variant, or `null` when there's no
@@ -44,8 +43,7 @@ export function cricketScoreFrom(score: Score | null | undefined): CricketScore 
 export function cricketDetail(
   detail: DetailedScore | null | undefined,
 ): CricketInnings[] | null {
-  if (!detail || detail.type !== 'Cricket') return null
-  return detail.innings
+  return cricketDetailFrom(detail)?.innings ?? null
 }
 
 /** A `detailed_score` innings (batting/bowling cards, totals) with its
@@ -57,11 +55,12 @@ export type CricketInningsWithDeliveries = CricketInnings & { deliveries: Cricke
 
 /** One innings' ball-by-ball log, recovered by segmenting the raw live event
  *  log on its `InningsStart`/`InningsEnd` markers. This is the durable
- *  source for a completed match's full run-progression graph — the live
- *  snapshot (`CricketLiveState`) only ever keeps deliveries for the innings
- *  currently open (or just-finished), since that's all the live view itself
- *  needs; the event log has no such bound (one item per ball, not one item
- *  per match) and is safe to read in full regardless of match length. */
+ *  source for a completed match's full run-progression graph — the detail
+ *  (`CricketDetail.recent_deliveries`) only ever keeps a bounded window for
+ *  the innings currently open (or just-finished), since that's all the live
+ *  view itself needs; the event log has no such bound (one item per ball,
+ *  not one item per match) and is safe to read in full regardless of match
+ *  length. */
 export interface InningsDeliveries {
   batting_side_id: string
   bowling_side_id: string
@@ -100,10 +99,9 @@ export function inningsDeliveriesFromEvents(events: LiveEvent[]): InningsDeliver
 }
 
 /** The minimal per-innings shape match-aggregate math and the state-of-game
- *  sentence need — both `CricketLiveState.innings` (rich, ball-by-ball
- *  derived, while a match is actually being scored) and a confirmed
- *  `CricketScore.innings` (the persisted summary, once it's over) satisfy
- *  this structurally, so the same functions work on either. */
+ *  sentence need — both `CricketDetail.innings` (rich, ball-by-ball derived,
+ *  live or finished) and a confirmed `CricketScore.innings` (the persisted
+ *  summary) satisfy this structurally, so the same functions work on either. */
 interface CricketInningsTotal {
   batting_side_id: string
   bowling_side_id: string
@@ -111,8 +109,8 @@ interface CricketInningsTotal {
   wickets: number
 }
 
-/** Ditto, for the match-level progress shape: a live snapshot's own state, or
- *  a finished match's confirmed score reframed as one (see
+/** Ditto, for the match-level progress shape: a detail's own state, or a
+ *  finished match's confirmed score reframed as one (see
  *  `cricketProgressFromScore`) — it has no notion of "in progress", so it's
  *  always `awaiting_next_innings: true`. */
 export interface CricketMatchProgress {
@@ -129,10 +127,10 @@ export function cricketProgressFromScore(score: CricketScore): CricketMatchProgr
 
 /** The innings currently being played, or `null` when the match hasn't
  *  started its first innings yet, or is between innings (see
- *  `CricketLiveState.awaiting_next_innings`). */
-export function currentInnings(state: CricketLiveState): CricketInningsTotals | null {
-  if (state.awaiting_next_innings) return null
-  return state.innings[state.innings.length - 1] ?? null
+ *  `CricketDetail.awaiting_next_innings`). */
+export function currentInnings(detail: CricketDetail): CricketInnings | null {
+  if (detail.awaiting_next_innings) return null
+  return detail.innings[detail.innings.length - 1] ?? null
 }
 
 /** Whether a delivery counts toward the over. Wides/no-balls don't under the
@@ -204,8 +202,8 @@ export function runProgression(
   })
 }
 
-/** This over's deliveries out of a live snapshot's bounded recent-deliveries
- *  window (`CricketLiveState.recent_deliveries`) — everything recorded
+/** This over's deliveries out of a detail's bounded recent-deliveries window
+ *  (`CricketDetail.recent_deliveries`) — everything recorded
  *  against the latest over index (we assign `over`/`ball` ourselves on
  *  submit, so this is a simple filter rather than a rolling window). */
 export function currentOverDeliveries(recentDeliveries: CricketDelivery[]): CricketDelivery[] {
@@ -368,9 +366,9 @@ export function playerNameFor(
 }
 
 // `NextBallContext` (who's on strike/bowling for the next delivery) is now
-// folded server-side, incrementally, as part of the live snapshot (see
-// `CricketLiveState.next_ball_context` and the backend's
-// `apply_delivery_to_context`) — no client-side replay needed for the
-// online case. An offline-scoring client will need its own local copy of
-// that same incremental fold (applied to its not-yet-synced queue) when
-// that's built; it isn't yet, so there's nothing here today.
+// folded server-side, incrementally, as part of `CricketDetail` (see
+// `CricketDetail.next_ball_context` and the backend's `apply_delivery`) — no
+// client-side replay needed for the online case. An offline-scoring client
+// will need its own local copy of that same incremental fold (applied to its
+// not-yet-synced queue) when that's built; it isn't yet, so there's nothing
+// here today.

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -4,8 +4,9 @@ import type { CricketFormat } from './matchFormat'
 
 export type CricketDelivery = components['schemas']['CricketDelivery']
 export type CricketInnings = components['schemas']['CricketInnings']
-export type CricketLiveInnings = components['schemas']['CricketLiveInnings']
+export type CricketInningsTotals = components['schemas']['CricketInningsTotals']
 export type CricketLiveState = components['schemas']['CricketLiveState']
+export type NextBallContext = components['schemas']['NextBallContext']
 export type CricketExtraKind = components['schemas']['CricketExtraKind']
 export type CricketDismissalKind = components['schemas']['CricketDismissalKind']
 export type CricketBattingEntry = components['schemas']['CricketBattingEntry']
@@ -46,6 +47,13 @@ export function cricketDetail(
   if (!detail || detail.type !== 'Cricket') return null
   return detail.innings
 }
+
+/** A `detailed_score` innings (batting/bowling cards, totals) with its
+ *  ball-by-ball log folded back in from the live event log — what the match
+ *  detail page builds for the scorecard/run-rate graph, since
+ *  `detailed_score` itself no longer carries deliveries (see
+ *  `inningsDeliveriesFromEvents`). */
+export type CricketInningsWithDeliveries = CricketInnings & { deliveries: CricketDelivery[] }
 
 /** One innings' ball-by-ball log, recovered by segmenting the raw live event
  *  log on its `InningsStart`/`InningsEnd` markers. This is the durable
@@ -122,7 +130,7 @@ export function cricketProgressFromScore(score: CricketScore): CricketMatchProgr
 /** The innings currently being played, or `null` when the match hasn't
  *  started its first innings yet, or is between innings (see
  *  `CricketLiveState.awaiting_next_innings`). */
-export function currentInnings(state: CricketLiveState): CricketLiveInnings | null {
+export function currentInnings(state: CricketLiveState): CricketInningsTotals | null {
   if (state.awaiting_next_innings) return null
   return state.innings[state.innings.length - 1] ?? null
 }
@@ -196,12 +204,13 @@ export function runProgression(
   })
 }
 
-/** This over's deliveries — everything recorded against the innings' latest
- *  over index (we assign `over`/`ball` ourselves on submit, so this is a
- *  simple filter rather than a rolling window). */
-export function currentOverDeliveries(innings: CricketLiveInnings): CricketDelivery[] {
-  const latestOver = innings.deliveries.reduce((max, d) => Math.max(max, d.over), 0)
-  return innings.deliveries.filter((d) => d.over === latestOver)
+/** This over's deliveries out of a live snapshot's bounded recent-deliveries
+ *  window (`CricketLiveState.recent_deliveries`) — everything recorded
+ *  against the latest over index (we assign `over`/`ball` ourselves on
+ *  submit, so this is a simple filter rather than a rolling window). */
+export function currentOverDeliveries(recentDeliveries: CricketDelivery[]): CricketDelivery[] {
+  const latestOver = recentDeliveries.reduce((max, d) => Math.max(max, d.over), 0)
+  return recentDeliveries.filter((d) => d.over === latestOver)
 }
 
 /** Short chip label for a delivery in the "this over" row, e.g. "4", "W",
@@ -256,35 +265,11 @@ export function creditsBowler(kind: CricketDismissalKind): boolean {
   )
 }
 
-/** A batter's card entry, or `null` if they haven't faced a ball yet (e.g. a
- *  non-striker who's yet to be on strike) — not the same as not being on the
- *  crease at all. */
-export function battingEntryFor(
-  innings: CricketInnings,
-  playerId: string | null,
-): CricketBattingEntry | null {
-  if (!playerId) return null
-  return innings.batting.find((b) => b.player_id === playerId) ?? null
-}
-
-export function bowlingEntryFor(
-  innings: CricketInnings,
-  playerId: string | null,
-): CricketBowlingEntry | null {
-  if (!playerId) return null
-  return innings.bowling.find((b) => b.player_id === playerId) ?? null
-}
-
 /** "3.2-0-24-1" bowling figures (overs-maidens-runs-wickets), or an em dash
  *  before the bowler has sent down a delivery. */
 export function bowlingFigures(entry: CricketBowlingEntry | null): string {
   if (!entry) return '—'
   return `${formatOvers(entry.overs)}-${entry.maidens}-${entry.runs_conceded}-${entry.wickets}`
-}
-
-/** "46 (32)" — runs and balls faced, or "0 (0)" before a batter's first ball. */
-export function battingLine(entry: CricketBattingEntry | null): string {
-  return `${entry?.runs ?? 0} (${entry?.balls_faced ?? 0})`
 }
 
 /** Total runs scored by each side across every completed innings so far —
@@ -367,14 +352,6 @@ export function cricketStateDescription(
   return `${sideNameFor(match, last.bowling_side_id)} won by ${margin} run${margin === 1 ? '' : 's'}`
 }
 
-/** Batters who can't be picked as a new arrival — already dismissed for a
- *  reason other than "retired hurt" (which lets the same batter resume). */
-export function outBattersFor(innings: CricketInnings): string[] {
-  return innings.batting
-    .filter((b) => b.dismissal && b.dismissal.kind !== 'retired_hurt')
-    .map((b) => b.player_id)
-}
-
 /** Display name for a side id: its name, or a neutral fallback. */
 export function sideNameFor(match: Pick<Match, 'sides'>, sideId: string): string {
   return match.sides.find((s) => s.id === sideId)?.name?.trim() || 'This side'
@@ -390,87 +367,10 @@ export function playerNameFor(
   return player ? memberName(player.member) : '—'
 }
 
-/**
- * What's known about who's at the crease/bowling for the *next* delivery,
- * folded from the current innings' delivery log. A `null` field means the
- * scorer needs to pick someone before the next ball can be recorded — either
- * a fresh innings (nothing bowled yet), a wicket just fell (the dismissed
- * batter's slot is open), or an over just completed (a new bowler is
- * required; the same bowler can't bowl consecutive overs).
- *
- * Strike rotates automatically on an odd number of the ball's rotating runs
- * (off the bat, or byes/leg-byes — wides/no-balls don't rotate strike here)
- * and always at the end of an over — including when one slot is already
- * vacant from a wicket on that same ball (e.g. dismissed on the over's final
- * ball): the swap still applies to whichever slot the survivor occupies, so
- * the vacancy lands in the correct slot for the next ball rather than always
- * defaulting to "striker". One remaining simplification: a mid-run run-out's
- * rotation is inferred from the parity of runs completed before the
- * dismissal (as entered in the wicket dialog), not an explicit "had they
- * crossed?" flag — the two agree in the vast majority of real dismissals.
- */
-export interface NextBallContext {
-  strikerPlayerId: string | null
-  nonStrikerPlayerId: string | null
-  bowlerPlayerId: string | null
-  /** 0-based over index the next delivery belongs to. */
-  over: number
-  /** 1-based ball number within that over. */
-  ball: number
-  /** The bowler who just finished an over — excluded from the next-bowler
-   *  picker. `null` unless a bowler pick is actually needed. */
-  previousOverBowlerPlayerId: string | null
-}
-
-export function nextBallContext(
-  innings: CricketLiveInnings,
-  format: Pick<CricketFormat, 'balls_per_over' | 'wide_is_extra_ball' | 'no_ball_is_extra_ball'>,
-): NextBallContext {
-  let striker: string | null = null
-  let nonStriker: string | null = null
-  let bowler: string | null = null
-  let legalInOver = 0
-  let over = 0
-  let previousOverBowler: string | null = null
-
-  for (const d of innings.deliveries) {
-    bowler = d.bowler_player_id
-    striker = d.striker_player_id
-    nonStriker = d.non_striker_player_id
-    previousOverBowler = null
-
-    if (d.wicket) {
-      if (d.wicket.dismissed_player_id === striker) striker = null
-      else if (d.wicket.dismissed_player_id === nonStriker) nonStriker = null
-    }
-
-    if (isLegalDelivery(d, format)) {
-      legalInOver += 1
-      const rotatingRuns =
-        d.runs_off_bat + (d.extra && (d.extra.kind === 'bye' || d.extra.kind === 'leg_bye') ? d.extra.runs : 0)
-      // Not guarded on both being non-null: swapping a real id with a `null`
-      // vacancy still means something — it moves *which slot* is vacant, so
-      // a wicket that falls alongside a rotation (odd runs, or an over
-      // boundary) leaves the opening in the correct slot for the next ball.
-      if (rotatingRuns % 2 === 1) {
-        ;[striker, nonStriker] = [nonStriker, striker]
-      }
-      if (legalInOver === format.balls_per_over) {
-        ;[striker, nonStriker] = [nonStriker, striker]
-        previousOverBowler = bowler
-        bowler = null
-        over += 1
-        legalInOver = 0
-      }
-    }
-  }
-
-  return {
-    strikerPlayerId: striker,
-    nonStrikerPlayerId: nonStriker,
-    bowlerPlayerId: bowler,
-    over,
-    ball: legalInOver + 1,
-    previousOverBowlerPlayerId: previousOverBowler,
-  }
-}
+// `NextBallContext` (who's on strike/bowling for the next delivery) is now
+// folded server-side, incrementally, as part of the live snapshot (see
+// `CricketLiveState.next_ball_context` and the backend's
+// `apply_delivery_to_context`) — no client-side replay needed for the
+// online case. An offline-scoring client will need its own local copy of
+// that same incremental fold (applied to its not-yet-synced queue) when
+// that's built; it isn't yet, so there's nothing here today.

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -1,20 +1,73 @@
 import type { components } from '@/types/api'
 import { memberName } from './members'
 
-export type FootballEventKind = components['schemas']['FootballEventKind']
-export type FootballEvent = components['schemas']['FootballEvent']
 export type FootballPeriod = components['schemas']['FootballPeriod']
-export type FootballLiveState = components['schemas']['FootballLiveState']
-type LiveScoreSnapshot = components['schemas']['LiveScoreSnapshot']
+export type FootballDetail = components['schemas']['FootballDetail']
+type FootballGoalEvent = components['schemas']['FootballGoalEvent']
+type FootballCardEvent = components['schemas']['FootballCardEvent']
+type DetailedScore = components['schemas']['DetailedScore']
 type Match = components['schemas']['Match']
 
-/** Narrows a live-score snapshot to its football state, or `null` when there's
- *  no snapshot yet or it's for a different sport. */
-export function footballLiveState(
-  snapshot: LiveScoreSnapshot | null | undefined,
-): FootballLiveState | null {
-  if (!snapshot || snapshot.state.sport !== 'Football') return null
-  return snapshot.state
+/** Narrows a match's detailed score to its football detail, or `null` when
+ *  there's none yet or it's for a different sport. */
+export function footballDetailFrom(detail: DetailedScore | null | undefined): FootballDetail | null {
+  if (!detail || detail.type !== 'Football') return null
+  return detail
+}
+
+/** A client-side view of one football event, merging `FootballDetail`'s
+ *  separately-typed `goals`/`cards`/`substitutions` lists back into a single
+ *  timeline for the event log/mini-ticker (see `eventsFromDetail`) — the
+ *  backend keeps them apart so a goal's scorer/assist/own-goal/penalty
+ *  fields mean the same thing they did when recorded, not a shared field
+ *  reinterpreted per kind. */
+export type FootballEventKind = 'goal' | 'own_goal' | 'penalty' | 'yellow_card' | 'red_card' | 'substitution'
+export interface FootballEventView {
+  kind: FootballEventKind
+  side_id: string
+  minute?: number
+  player_id?: string
+  assist_player_id?: string
+  substituted_player_id?: string
+}
+
+function goalKind(g: FootballGoalEvent): FootballEventKind {
+  if (g.own_goal) return 'own_goal'
+  if (g.penalty) return 'penalty'
+  return 'goal'
+}
+
+function cardKind(c: FootballCardEvent): FootballEventKind {
+  return c.color === 'yellow' ? 'yellow_card' : 'red_card'
+}
+
+/** All of a football detail's goals/cards/substitutions merged into one
+ *  timeline, ordered by minute (undated events last — the scorer always
+ *  fills in a minute in practice, so this only matters for edge cases). */
+export function eventsFromDetail(detail: FootballDetail): FootballEventView[] {
+  const events: FootballEventView[] = [
+    ...detail.goals.map((g): FootballEventView => ({
+      kind: goalKind(g),
+      side_id: g.side_id,
+      minute: g.minute,
+      player_id: g.scorer_player_id,
+      assist_player_id: g.assist_player_id,
+    })),
+    ...detail.cards.map((c): FootballEventView => ({
+      kind: cardKind(c),
+      side_id: c.side_id,
+      minute: c.minute,
+      player_id: c.player_id,
+    })),
+    ...detail.substitutions.map((s): FootballEventView => ({
+      kind: 'substitution',
+      side_id: s.side_id,
+      minute: s.minute,
+      player_id: s.player_in_id,
+      substituted_player_id: s.player_out_id,
+    })),
+  ]
+  return events.sort((a, b) => (a.minute ?? Infinity) - (b.minute ?? Infinity))
 }
 
 /** Label + emoji for each football live-event kind, for the event log/ticker. */
@@ -64,8 +117,8 @@ export function periodLabel(period: FootballPeriod): string {
 }
 
 /** The most recent events first, capped to `limit` — for a mini-ticker. */
-export function recentEvents(state: FootballLiveState, limit: number): FootballEvent[] {
-  return [...state.events].reverse().slice(0, limit)
+export function recentEvents(detail: FootballDetail, limit: number): FootballEventView[] {
+  return eventsFromDetail(detail).reverse().slice(0, limit)
 }
 
 /** Side display name for an event, falling back to a neutral label. */
@@ -84,7 +137,7 @@ function playerNameFor(match: Pick<Match, 'players'>, playerId: string | undefin
  *  (Riverside)" or "Sub — Moreno on for Khan (Oak Park)" — used by the event
  *  log and mini-ticker. */
 export function describeEvent(
-  event: FootballEvent,
+  event: FootballEventView,
   match: Pick<Match, 'sides' | 'players'>,
 ): string {
   const side = sideNameFor(match, event.side_id)
@@ -156,10 +209,10 @@ export function saveTrackPrefs(matchId: string, prefs: TrackPrefs): void {
 }
 
 // ---------------------------------------------------------------------------
-// Match clock — derived entirely from `FootballLiveState`'s phase-boundary
+// Match clock — derived entirely from `FootballDetail`'s phase-boundary
 // timestamps (`kickoff_at`/`half_time_at`/`second_half_kickoff_at`/
 // `full_time_at`), each the `occurred_at` of the period marker that recorded
-// it server-side (see `agon_service::live_score::football::derive_state`).
+// it server-side (see `agon_service::live_score::football::derive_detail`).
 // Because it's computed from shared server data rather than a per-device
 // stopwatch, the scorer's own screen and every other viewer (feed card, match
 // detail) tick the exact same clock.
@@ -176,7 +229,7 @@ export type ClockPhase =
   | 'other'
 
 /** Which phase the match is in right now, purely from recorded timestamps. */
-export function phaseFromState(state: FootballLiveState): ClockPhase {
+export function phaseFromState(state: FootballDetail): ClockPhase {
   if (state.full_time_at) return 'full_time'
   if (state.second_half_kickoff_at) return 'second_half'
   if (state.half_time_at) return 'half_time'
@@ -197,7 +250,7 @@ function minutesBetween(from: string, to: Date | string): number {
  * minute count continues from wherever the first half actually left off,
  * rather than resetting to a fixed 45'.
  */
-export function currentMinute(state: FootballLiveState, now: Date = new Date()): number | null {
+export function currentMinute(state: FootballDetail, now: Date = new Date()): number | null {
   const phase = phaseFromState(state)
   const firstHalfMinutes =
     state.kickoff_at && state.half_time_at
@@ -245,7 +298,7 @@ export function phaseLabel(phase: ClockPhase): string {
 }
 
 /** A compact clock label for a score box, e.g. "63'", "HT", "FT", "LIVE". */
-export function liveClockLabel(state: FootballLiveState, now: Date = new Date()): string {
+export function liveClockLabel(state: FootballDetail, now: Date = new Date()): string {
   const phase = phaseFromState(state)
   if (phase === 'half_time') return 'HT'
   if (phase === 'full_time') return 'FT'

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -209,14 +209,19 @@ export function saveTrackPrefs(matchId: string, prefs: TrackPrefs): void {
 }
 
 // ---------------------------------------------------------------------------
-// Match clock — derived entirely from `FootballDetail`'s phase-boundary
-// timestamps (`kickoff_at`/`half_time_at`/`second_half_kickoff_at`/
-// `full_time_at`), each the `occurred_at` of the period marker that recorded
-// it server-side (see `agon_service::live_score::football::derive_detail`).
-// Because it's computed from shared server data rather than a per-device
-// stopwatch, the scorer's own screen and every other viewer (feed card, match
-// detail) tick the exact same clock.
+// Match clock — derived entirely from `FootballDetail.period_times`, each the
+// `occurred_at` of the period marker that recorded it server-side (see
+// `agon_service::live_score::football::derive_detail`). Because it's
+// computed from shared server data rather than a per-device stopwatch, the
+// scorer's own screen and every other viewer (feed card, match detail) tick
+// the exact same clock.
 // ---------------------------------------------------------------------------
+
+/** When a given period marker was recorded, if at all — a typed lookup into
+ *  `FootballDetail.period_times`'s string-keyed map. */
+export function periodTime(detail: FootballDetail, period: FootballPeriod): string | undefined {
+  return detail.period_times[period]
+}
 
 export type ClockPhase =
   | 'not_started'
@@ -230,10 +235,10 @@ export type ClockPhase =
 
 /** Which phase the match is in right now, purely from recorded timestamps. */
 export function phaseFromState(state: FootballDetail): ClockPhase {
-  if (state.full_time_at) return 'full_time'
-  if (state.second_half_kickoff_at) return 'second_half'
-  if (state.half_time_at) return 'half_time'
-  if (state.kickoff_at) return 'first_half'
+  if (periodTime(state, 'full_time')) return 'full_time'
+  if (periodTime(state, 'second_half_kick_off')) return 'second_half'
+  if (periodTime(state, 'half_time')) return 'half_time'
+  if (periodTime(state, 'kick_off')) return 'first_half'
   if (state.period) return 'other'
   return 'not_started'
 }
@@ -252,26 +257,27 @@ function minutesBetween(from: string, to: Date | string): number {
  */
 export function currentMinute(state: FootballDetail, now: Date = new Date()): number | null {
   const phase = phaseFromState(state)
-  const firstHalfMinutes =
-    state.kickoff_at && state.half_time_at
-      ? minutesBetween(state.kickoff_at, state.half_time_at)
-      : 0
+  const kickoffAt = periodTime(state, 'kick_off')
+  const halfTimeAt = periodTime(state, 'half_time')
+  const secondHalfKickoffAt = periodTime(state, 'second_half_kick_off')
+  const fullTimeAt = periodTime(state, 'full_time')
+  const firstHalfMinutes = kickoffAt && halfTimeAt ? minutesBetween(kickoffAt, halfTimeAt) : 0
 
   switch (phase) {
     case 'first_half':
-      return state.kickoff_at ? minutesBetween(state.kickoff_at, now) : null
+      return kickoffAt ? minutesBetween(kickoffAt, now) : null
     case 'half_time':
-      return state.kickoff_at && state.half_time_at ? firstHalfMinutes : null
+      return kickoffAt && halfTimeAt ? firstHalfMinutes : null
     case 'second_half':
-      return state.second_half_kickoff_at
-        ? firstHalfMinutes + minutesBetween(state.second_half_kickoff_at, now)
+      return secondHalfKickoffAt
+        ? firstHalfMinutes + minutesBetween(secondHalfKickoffAt, now)
         : null
     case 'full_time':
-      if (!state.full_time_at) return null
-      return state.second_half_kickoff_at
-        ? firstHalfMinutes + minutesBetween(state.second_half_kickoff_at, state.full_time_at)
-        : state.kickoff_at
-          ? minutesBetween(state.kickoff_at, state.full_time_at)
+      if (!fullTimeAt) return null
+      return secondHalfKickoffAt
+        ? firstHalfMinutes + minutesBetween(secondHalfKickoffAt, fullTimeAt)
+        : kickoffAt
+          ? minutesBetween(kickoffAt, fullTimeAt)
           : null
     case 'not_started':
     case 'other':

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -5,7 +5,8 @@ import { ChevronLeft } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
-import { useAppendCricketEvent, useLiveScore } from '@/hooks/useLiveScore'
+import { useAppendCricketEvent, useLiveSeq } from '@/hooks/useLiveScore'
+import { useMatchDetailedScore } from '@/hooks/useMatchDetailedScore'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { SidePicker, PlayerPicker, sideName } from '@/components/agon/live/Pickers'
 import { WicketDialog } from '@/components/agon/live/WicketDialog'
@@ -14,7 +15,7 @@ import { NoBallDialog } from '@/components/agon/live/NoBallDialog'
 import { playersOnSide } from '@/lib/members'
 import { cricketFormat } from '@/lib/matchFormat'
 import {
-  cricketLiveState,
+  cricketDetailFrom,
   currentInnings,
   currentOverDeliveries,
   deliveryChipLabel,
@@ -49,9 +50,10 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
-  const live = useLiveScore(match.id, { refetchInterval: 8000 })
+  const detailedScore = useMatchDetailedScore(match.id, { refetchInterval: 8000 })
+  const seq = useLiveSeq(match.id)
   const appendEvent = useAppendCricketEvent(match.id)
-  const state = cricketLiveState(live.data)
+  const state = cricketDetailFrom(detailedScore.data)
   const innings = state ? currentInnings(state) : null
   const format = cricketFormat(match.format)
   // The server folds this incrementally as events are recorded (see
@@ -79,7 +81,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   // instead (see `live_score::cricket`'s doc comment) — broader in-innings
   // correction support is a later step.
   const [editingOpeningPicks, setEditingOpeningPicks] = useState(false)
-  const openingPicksUnconfirmed = innings ? (state?.recent_deliveries.length ?? 0) === 0 : false
+  const openingPicksUnconfirmed = innings ? (state?.recent_deliveries?.length ?? 0) === 0 : false
   useEffect(() => {
     if (!openingPicksUnconfirmed) setEditingOpeningPicks(false)
   }, [openingPicksUnconfirmed])
@@ -136,7 +138,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
     },
   })
 
-  if (live.isLoading) {
+  if (detailedScore.isLoading || seq.isLoading) {
     return (
       <div className="mx-auto max-w-xl">
         <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
@@ -335,14 +337,17 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   }
 
   const crr = runRate(innings.runs, innings.overs, format.balls_per_over)
-  const overBalls = currentOverDeliveries(state!.recent_deliveries)
-  // The live summary only carries innings totals + a bounded recent-ball
-  // window, not full batting/bowling cards (see `CricketLiveState`) — so
-  // there's no reliable "who's already out" list to exclude from the batter
-  // picker beyond whoever's currently at the crease. A per-player live fold
-  // would need to live on this device itself (it's the source of the data);
-  // not built yet.
-  const outBatters: string[] = []
+  const overBalls = currentOverDeliveries(state!.recent_deliveries ?? [])
+  // Excluded from the batter picker in addition to whoever's currently at
+  // the crease — `innings.batting` carries the full card (see
+  // `CricketDetail`), so a dismissal here is as reliable as the server's own
+  // scorecard, not just a locally-replayed guess. Retired hurt is excluded
+  // from this list on purpose: unlike every other dismissal it isn't final —
+  // the same batter can simply be picked again to resume (see
+  // `CricketRetireEvent`'s doc comment on the backend).
+  const outBatters = innings.batting
+    .filter((b) => b.dismissal && b.dismissal.kind !== 'retired_hurt')
+    .map((b) => b.player_id)
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -119,7 +119,15 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
         })),
       } as unknown as UpdateMatchInput['score']
       const winner_side_id = a === b ? undefined : a > b ? aId : bId
-      const body: UpdateMatchInput = { score, status: 'completed' }
+      // The full per-innings breakdown (batting/bowling cards, ball-by-ball
+      // deliveries) — submitted alongside the totals-only `score` so the
+      // resolved scorecard (run-rate graph, player stats) survives after the
+      // match completes and the live event log stops being polled.
+      const detailed_score = {
+        type: 'Cricket',
+        innings: state.innings,
+      } as unknown as UpdateMatchInput['detailed_score']
+      const body: UpdateMatchInput = { score, detailed_score, status: 'completed' }
       if (winner_side_id) body.winner_side_id = winner_side_id
       const { error } = await fetchClient.PATCH('/matches/{match_id}', {
         params: { path: { match_id: match.id } },

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -119,13 +119,16 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
         })),
       } as unknown as UpdateMatchInput['score']
       const winner_side_id = a === b ? undefined : a > b ? aId : bId
-      // The full per-innings breakdown (batting/bowling cards, ball-by-ball
-      // deliveries) — submitted alongside the totals-only `score` so the
-      // resolved scorecard (run-rate graph, player stats) survives after the
-      // match completes and the live event log stops being polled.
+      // The per-innings batting/bowling cards — submitted alongside the
+      // totals-only `score` so the resolved scorecard survives after the
+      // match completes. `deliveries` is deliberately left empty here: the
+      // match detail page reads ball-by-ball detail from the live event log
+      // instead (already stored one item per ball, so it has no practical
+      // size ceiling), rather than duplicating it into this single record
+      // where it would risk DynamoDB's 400KB item cap on a long match.
       const detailed_score = {
         type: 'Cricket',
-        innings: state.innings,
+        innings: state.innings.map((inn) => ({ ...inn, deliveries: [] })),
       } as unknown as UpdateMatchInput['detailed_score']
       const body: UpdateMatchInput = { score, detailed_score, status: 'completed' }
       if (winner_side_id) body.winner_side_id = winner_side_id

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -14,10 +14,6 @@ import { NoBallDialog } from '@/components/agon/live/NoBallDialog'
 import { playersOnSide } from '@/lib/members'
 import { cricketFormat } from '@/lib/matchFormat'
 import {
-  battingEntryFor,
-  battingLine,
-  bowlingEntryFor,
-  bowlingFigures,
   cricketLiveState,
   currentInnings,
   currentOverDeliveries,
@@ -25,8 +21,6 @@ import {
   formatOvers,
   isChipHighlighted,
   matchTotalsBySide,
-  nextBallContext,
-  outBattersFor,
   playerNameFor,
   runRate,
 } from '@/lib/cricketScore'
@@ -60,19 +54,22 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   const state = cricketLiveState(live.data)
   const innings = state ? currentInnings(state) : null
   const format = cricketFormat(match.format)
-  const next = innings ? nextBallContext(innings, format) : null
+  // The server folds this incrementally as events are recorded (see
+  // `live_score::cricket::apply_delivery_to_context`) — no client-side
+  // replay needed for the online case.
+  const next = state?.next_ball_context ?? null
 
   // Locally-picked openers/replacement batter/next bowler — only used until
   // the server confirms them via an actual delivery, at which point
-  // `nextBallContext` takes over as the source of truth.
+  // `next_ball_context` takes over as the source of truth.
   const [pickedStriker, setPickedStriker] = useState<string | null>(null)
   const [pickedNonStriker, setPickedNonStriker] = useState<string | null>(null)
   const [pickedBowler, setPickedBowler] = useState<string | null>(null)
   useEffect(() => {
-    if (next?.strikerPlayerId) setPickedStriker(null)
-    if (next?.nonStrikerPlayerId) setPickedNonStriker(null)
-    if (next?.bowlerPlayerId) setPickedBowler(null)
-  }, [next?.strikerPlayerId, next?.nonStrikerPlayerId, next?.bowlerPlayerId])
+    if (next?.striker_player_id) setPickedStriker(null)
+    if (next?.non_striker_player_id) setPickedNonStriker(null)
+    if (next?.bowler_player_id) setPickedBowler(null)
+  }, [next?.striker_player_id, next?.non_striker_player_id, next?.bowler_player_id])
 
   // Lets the scorer step back into the opener/bowler picker after all three
   // are picked, to fix a mis-tap — only while the innings' very first ball
@@ -82,7 +79,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   // instead (see `live_score::cricket`'s doc comment) — broader in-innings
   // correction support is a later step.
   const [editingOpeningPicks, setEditingOpeningPicks] = useState(false)
-  const openingPicksUnconfirmed = innings ? innings.deliveries.length === 0 : false
+  const openingPicksUnconfirmed = innings ? (state?.recent_deliveries.length ?? 0) === 0 : false
   useEffect(() => {
     if (!openingPicksUnconfirmed) setEditingOpeningPicks(false)
   }, [openingPicksUnconfirmed])
@@ -98,6 +95,11 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   // the same way a manual "Add result" would, so it enters the normal
   // confirmation flow rather than being auto-confirmed. The winner is still
   // derived from the summed match totals (two-innings formats add up both).
+  // No `detailed_score` here: the backend derives and persists the full
+  // batting/bowling cards itself from the event log when a live-scored
+  // cricket match completes without one supplied (see `update_match`) — the
+  // authoritative source, and the only one with the full log to fold; this
+  // client only ever sees the bounded live summary.
   const finishMatch = useMutation({
     mutationFn: async () => {
       if (!state) throw new Error('No score recorded yet')
@@ -119,18 +121,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
         })),
       } as unknown as UpdateMatchInput['score']
       const winner_side_id = a === b ? undefined : a > b ? aId : bId
-      // The per-innings batting/bowling cards — submitted alongside the
-      // totals-only `score` so the resolved scorecard survives after the
-      // match completes. `deliveries` is deliberately left empty here: the
-      // match detail page reads ball-by-ball detail from the live event log
-      // instead (already stored one item per ball, so it has no practical
-      // size ceiling), rather than duplicating it into this single record
-      // where it would risk DynamoDB's 400KB item cap on a long match.
-      const detailed_score = {
-        type: 'Cricket',
-        innings: state.innings.map((inn) => ({ ...inn, deliveries: [] })),
-      } as unknown as UpdateMatchInput['detailed_score']
-      const body: UpdateMatchInput = { score, detailed_score, status: 'completed' }
+      const body: UpdateMatchInput = { score, status: 'completed' }
       if (winner_side_id) body.winner_side_id = winner_side_id
       const { error } = await fetchClient.PATCH('/matches/{match_id}', {
         params: { path: { match_id: match.id } },
@@ -260,9 +251,9 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
 
   const battingSide = match.sides.find((s) => s.id === innings.batting_side_id)
   const bowlingSide = match.sides.find((s) => s.id === innings.bowling_side_id)
-  const effectiveStriker = next!.strikerPlayerId ?? pickedStriker
-  const effectiveNonStriker = next!.nonStrikerPlayerId ?? pickedNonStriker
-  const effectiveBowler = next!.bowlerPlayerId ?? pickedBowler
+  const effectiveStriker = next!.striker_player_id ?? pickedStriker
+  const effectiveNonStriker = next!.non_striker_player_id ?? pickedNonStriker
+  const effectiveBowler = next!.bowler_player_id ?? pickedBowler
   const readyToScore = !!effectiveStriker && !!effectiveNonStriker && !!effectiveBowler
   const showPickerPanel = !readyToScore || editingOpeningPicks
 
@@ -297,7 +288,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
     innings.overs.overs >= format.overs_per_innings &&
     innings.overs.balls === 0
 
-  if (oversComplete && !next!.bowlerPlayerId) {
+  if (oversComplete && !next!.bowler_player_id) {
     return (
       <div className="mx-auto flex max-w-xl flex-col gap-4">
         {header}
@@ -344,11 +335,14 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   }
 
   const crr = runRate(innings.runs, innings.overs, format.balls_per_over)
-  const strikerEntry = battingEntryFor(innings, effectiveStriker)
-  const nonStrikerEntry = battingEntryFor(innings, effectiveNonStriker)
-  const bowlerEntry = bowlingEntryFor(innings, effectiveBowler)
-  const overBalls = currentOverDeliveries(innings)
-  const outBatters = outBattersFor(innings)
+  const overBalls = currentOverDeliveries(state!.recent_deliveries)
+  // The live summary only carries innings totals + a bounded recent-ball
+  // window, not full batting/bowling cards (see `CricketLiveState`) — so
+  // there's no reliable "who's already out" list to exclude from the batter
+  // picker beyond whoever's currently at the crease. A per-player live fold
+  // would need to live on this device itself (it's the source of the data);
+  // not built yet.
+  const outBatters: string[] = []
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">
@@ -376,13 +370,11 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
           {effectiveStriker && (
             <div className="flex items-center justify-between">
               <span className="font-medium">{playerNameFor(match, effectiveStriker)}*</span>
-              <span className="text-muted-foreground">{battingLine(strikerEntry)}</span>
             </div>
           )}
           {effectiveNonStriker && (
             <div className="flex items-center justify-between">
               <span>{playerNameFor(match, effectiveNonStriker)}</span>
-              <span className="text-muted-foreground">{battingLine(nonStrikerEntry)}</span>
             </div>
           )}
           {effectiveBowler && (
@@ -390,7 +382,6 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
               <span className="text-muted-foreground">
                 Bowling: <span className="font-medium text-foreground">{playerNameFor(match, effectiveBowler)}</span>
               </span>
-              <span className="text-muted-foreground">{bowlingFigures(bowlerEntry)}</span>
             </div>
           )}
         </div>
@@ -459,7 +450,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
               <PlayerPicker
                 players={playersOnSide(match.players, bowlingSide!)}
                 value={pickedBowler ?? undefined}
-                exclude={next!.previousOverBowlerPlayerId ?? undefined}
+                exclude={next!.previous_over_bowler_player_id ?? undefined}
                 onChange={setPickedBowler}
               />
             </div>

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -5,7 +5,8 @@ import { ChevronLeft, CircleDot, Flag, Repeat2, TimerReset } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
-import { useLiveScore, useAppendFootballEvent } from '@/hooks/useLiveScore'
+import { useAppendFootballEvent, useLiveSeq } from '@/hooks/useLiveScore'
+import { useMatchDetailedScore } from '@/hooks/useMatchDetailedScore'
 import { RecordEventDialog, type EventKind } from '@/components/agon/live/RecordEventDialog'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { CricketLiveScoringPage } from './CricketLiveScoringPage'
@@ -13,7 +14,8 @@ import {
   currentMinute,
   describeEvent,
   eventEmoji,
-  footballLiveState,
+  eventsFromDetail,
+  footballDetailFrom,
   loadTrackPrefs,
   nextPeriodForPhase,
   nextPhaseActionLabel,
@@ -87,7 +89,8 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
 
-  const live = useLiveScore(match.id, { refetchInterval: 8000 })
+  const detailedScore = useMatchDetailedScore(match.id, { refetchInterval: 8000 })
+  const seq = useLiveSeq(match.id)
   const append = useAppendFootballEvent(match.id)
 
   const [now, setNow] = useState(() => new Date())
@@ -99,7 +102,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
   const prefs = loadTrackPrefs(match.id)
   const [dialogKind, setDialogKind] = useState<EventKind | null>(null)
 
-  if (live.isLoading) {
+  if (detailedScore.isLoading || seq.isLoading) {
     return (
       <div className="mx-auto max-w-xl">
         <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
@@ -109,7 +112,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
 
   const nameA = sideName(match, 0, 'Side A')
   const nameB = sideName(match, 1, 'Side B')
-  const state = footballLiveState(live.data)
+  const state = footballDetailFrom(detailedScore.data)
   const goalsFor = (sideId: string | undefined) =>
     state?.score.find((s) => s.side_id === sideId)?.goals ?? 0
 
@@ -154,7 +157,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
     },
   ]
 
-  const events = state ? [...state.events].reverse() : []
+  const events = state ? eventsFromDetail(state).reverse() : []
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">

--- a/agon_ui/src/pages/LiveScoringSetupPage.tsx
+++ b/agon_ui/src/pages/LiveScoringSetupPage.tsx
@@ -6,8 +6,9 @@ import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
-import { useAppendFootballEvent, useLiveScore } from '@/hooks/useLiveScore'
-import { footballLiveState, loadTrackPrefs, saveTrackPrefs, type TrackPrefs } from '@/lib/liveScore'
+import { useAppendFootballEvent } from '@/hooks/useLiveScore'
+import { useMatchDetailedScore } from '@/hooks/useMatchDetailedScore'
+import { footballDetailFrom, loadTrackPrefs, saveTrackPrefs, type TrackPrefs } from '@/lib/liveScore'
 
 type Match = components['schemas']['Match']
 
@@ -86,8 +87,8 @@ export function LiveScoringSetupPage() {
   // Whether the match's live clock has already started (a KickOff period
   // marker already recorded) — determines whether "Start scoring" needs to
   // record one, and whether the button reads "Start" vs "Continue".
-  const live = useLiveScore(matchId)
-  const liveState = footballLiveState(live.data)
+  const detailedScore = useMatchDetailedScore(matchId)
+  const liveState = footballDetailFrom(detailedScore.data)
   const alreadyKickedOff = !!liveState?.kickoff_at
   const appendEvent = useAppendFootballEvent(matchId ?? '')
 

--- a/agon_ui/src/pages/LiveScoringSetupPage.tsx
+++ b/agon_ui/src/pages/LiveScoringSetupPage.tsx
@@ -8,7 +8,13 @@ import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { useAppendFootballEvent } from '@/hooks/useLiveScore'
 import { useMatchDetailedScore } from '@/hooks/useMatchDetailedScore'
-import { footballDetailFrom, loadTrackPrefs, saveTrackPrefs, type TrackPrefs } from '@/lib/liveScore'
+import {
+  footballDetailFrom,
+  loadTrackPrefs,
+  periodTime,
+  saveTrackPrefs,
+  type TrackPrefs,
+} from '@/lib/liveScore'
 
 type Match = components['schemas']['Match']
 
@@ -89,7 +95,7 @@ export function LiveScoringSetupPage() {
   // record one, and whether the button reads "Start" vs "Continue".
   const detailedScore = useMatchDetailedScore(matchId)
   const liveState = footballDetailFrom(detailedScore.data)
-  const alreadyKickedOff = !!liveState?.kickoff_at
+  const alreadyKickedOff = !!liveState && !!periodTime(liveState, 'kick_off')
   const appendEvent = useAppendFootballEvent(matchId ?? '')
 
   const start = useMutation({

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -125,16 +125,23 @@ function MatchDetail({
 
   // Live-scoring state — takes over the score block below (and the entry
   // button becomes "Continue scoring") while a match is actually in
-  // progress. Not fetched once it's over: a cricket match's confirmed score
-  // carries its own per-innings detail once it's been live-scored
-  // (`Score::Cricket`; see `finishMatch` in `CricketLiveScoringPage`), so
-  // there's no need to keep reading the live event log after the fact.
+  // progress. For football this is only relevant while in progress (its
+  // confirmed score has no further use for the event log). Cricket keeps
+  // fetching it after the match completes too — its deliveries log is the
+  // only durable source for the run-rate graph (see `cricketInnings` below);
+  // `detailed_score` deliberately doesn't duplicate it (a full ball-by-ball
+  // log embedded in one record risks DynamoDB's 400KB item cap on a long
+  // match, where the per-event live log doesn't).
   const live = useLiveScore(match.id, {
-    enabled: isLiveSport && match.status === 'in_progress',
-    refetchInterval: 15000,
+    enabled: match.match_type === 'football' ? match.status === 'in_progress' : isLiveSport,
+    refetchInterval: match.status === 'in_progress' ? 15000 : false,
   })
   const footballState = footballLiveState(live.data)
-  const cricketState = cricketLiveState(live.data)
+  // Only surfaced for an in-progress match — otherwise, now that cricket's
+  // live snapshot is fetched after completion too (for its deliveries), this
+  // would wrongly resurrect the "currently scoring" block on a finished
+  // match instead of the confirmed `CricketScoreBlock` below.
+  const cricketState = match.status === 'in_progress' ? cricketLiveState(live.data) : null
   const hasLiveState = !!footballState || !!cricketState
   const cricketScore = scoreInfo ? cricketScoreFrom(scoreInfo.score) : null
   // Football's setup screen also gates starting the clock; cricket has no
@@ -142,13 +149,20 @@ function MatchDetail({
   const liveEntryPath =
     match.match_type === 'cricket' ? `/matches/${match.id}/live` : `/matches/${match.id}/live/setup`
 
-  // Resolved per-innings scorecard (batting/bowling cards, run progression),
-  // regardless of whether the match was scored live or entered after the
-  // fact — separate from `live` above, which only covers scoring in progress.
+  // Resolved per-innings scorecard: batting/bowling cards + totals from
+  // `detailed_score` (works whether the match was scored live or entered
+  // after the fact), with each innings' deliveries — only ever present for a
+  // live-scored match — folded in from the live snapshot by matching
+  // innings order, for the run-rate graph.
   const detailedScore = useMatchDetailedScore(match.id, {
     enabled: match.match_type === 'cricket',
   })
-  const cricketInnings = cricketDetail(detailedScore.data)
+  const cricketDetailInnings = cricketDetail(detailedScore.data)
+  const liveCricketInnings = cricketLiveState(live.data)?.innings
+  const cricketInnings = cricketDetailInnings?.map((inn, i) => ({
+    ...inn,
+    deliveries: liveCricketInnings?.[i]?.deliveries ?? [],
+  }))
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -16,10 +16,15 @@ import { CricketMatchBlock } from '@/components/agon/live/CricketMatchBlock'
 import { CricketScoreBlock } from '@/components/agon/CricketScoreBlock'
 import { CricketScorecard } from '@/components/agon/CricketScorecard'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
-import { useLiveScore } from '@/hooks/useLiveScore'
+import { useLiveEvents, useLiveScore } from '@/hooks/useLiveScore'
 import { useMatchDetailedScore } from '@/hooks/useMatchDetailedScore'
 import { footballLiveState } from '@/lib/liveScore'
-import { cricketDetail, cricketLiveState, cricketScoreFrom } from '@/lib/cricketScore'
+import {
+  cricketDetail,
+  cricketLiveState,
+  cricketScoreFrom,
+  inningsDeliveriesFromEvents,
+} from '@/lib/cricketScore'
 import { useCurrentUserId } from '@/hooks/useCurrentUserId'
 import { displayScore, headlineBySide, headlineLabel, setLine } from '@/lib/score'
 import {
@@ -125,23 +130,16 @@ function MatchDetail({
 
   // Live-scoring state — takes over the score block below (and the entry
   // button becomes "Continue scoring") while a match is actually in
-  // progress. For football this is only relevant while in progress (its
-  // confirmed score has no further use for the event log). Cricket keeps
-  // fetching it after the match completes too — its deliveries log is the
-  // only durable source for the run-rate graph (see `cricketInnings` below);
-  // `detailed_score` deliberately doesn't duplicate it (a full ball-by-ball
-  // log embedded in one record risks DynamoDB's 400KB item cap on a long
-  // match, where the per-event live log doesn't).
+  // progress. Not fetched once it's over: the live snapshot only ever keeps
+  // deliveries for the currently (or most recently) open innings anyway, so
+  // it's no use to a finished match — see `cricketInnings` below for where
+  // the run-rate graph's deliveries actually come from.
   const live = useLiveScore(match.id, {
-    enabled: match.match_type === 'football' ? match.status === 'in_progress' : isLiveSport,
-    refetchInterval: match.status === 'in_progress' ? 15000 : false,
+    enabled: isLiveSport && match.status === 'in_progress',
+    refetchInterval: 15000,
   })
   const footballState = footballLiveState(live.data)
-  // Only surfaced for an in-progress match — otherwise, now that cricket's
-  // live snapshot is fetched after completion too (for its deliveries), this
-  // would wrongly resurrect the "currently scoring" block on a finished
-  // match instead of the confirmed `CricketScoreBlock` below.
-  const cricketState = match.status === 'in_progress' ? cricketLiveState(live.data) : null
+  const cricketState = cricketLiveState(live.data)
   const hasLiveState = !!footballState || !!cricketState
   const cricketScore = scoreInfo ? cricketScoreFrom(scoreInfo.score) : null
   // Football's setup screen also gates starting the clock; cricket has no
@@ -151,17 +149,20 @@ function MatchDetail({
 
   // Resolved per-innings scorecard: batting/bowling cards + totals from
   // `detailed_score` (works whether the match was scored live or entered
-  // after the fact), with each innings' deliveries — only ever present for a
-  // live-scored match — folded in from the live snapshot by matching
-  // innings order, for the run-rate graph.
+  // after the fact), with each innings' deliveries folded in from the raw
+  // live event log by matching innings order, for the run-rate graph. The
+  // event log (unlike the live snapshot above) has no size ceiling and stays
+  // fully readable regardless of match status, so it's fetched here
+  // independently of `live`.
   const detailedScore = useMatchDetailedScore(match.id, {
     enabled: match.match_type === 'cricket',
   })
+  const liveEvents = useLiveEvents(match.id, { enabled: match.match_type === 'cricket' })
   const cricketDetailInnings = cricketDetail(detailedScore.data)
-  const liveCricketInnings = cricketLiveState(live.data)?.innings
+  const liveInningsDeliveries = liveEvents.data ? inningsDeliveriesFromEvents(liveEvents.data) : undefined
   const cricketInnings = cricketDetailInnings?.map((inn, i) => ({
     ...inn,
-    deliveries: liveCricketInnings?.[i]?.deliveries ?? [],
+    deliveries: liveInningsDeliveries?.[i]?.deliveries ?? [],
   }))
 
   return (

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -16,12 +16,12 @@ import { CricketMatchBlock } from '@/components/agon/live/CricketMatchBlock'
 import { CricketScoreBlock } from '@/components/agon/CricketScoreBlock'
 import { CricketScorecard } from '@/components/agon/CricketScorecard'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
-import { useLiveEvents, useLiveScore } from '@/hooks/useLiveScore'
+import { useLiveEvents } from '@/hooks/useLiveScore'
 import { useMatchDetailedScore } from '@/hooks/useMatchDetailedScore'
-import { footballLiveState } from '@/lib/liveScore'
+import { footballDetailFrom } from '@/lib/liveScore'
 import {
   cricketDetail,
-  cricketLiveState,
+  cricketDetailFrom,
   cricketScoreFrom,
   inningsDeliveriesFromEvents,
 } from '@/lib/cricketScore'
@@ -128,18 +128,21 @@ function MatchDetail({
   const aWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideA?.id
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
 
-  // Live-scoring state — takes over the score block below (and the entry
-  // button becomes "Continue scoring") while a match is actually in
-  // progress. Not fetched once it's over: the live snapshot only ever keeps
-  // deliveries for the currently (or most recently) open innings anyway, so
-  // it's no use to a finished match — see `cricketInnings` below for where
-  // the run-rate graph's deliveries actually come from.
-  const live = useLiveScore(match.id, {
-    enabled: isLiveSport && match.status === 'in_progress',
-    refetchInterval: 15000,
+  // Resolved detailed score: batting/bowling cards + totals (works whether
+  // the match was scored live or entered after the fact) for cricket, or the
+  // score/goals/cards/subs for football. Also takes over the score block
+  // below (and the entry button becomes "Continue scoring") while a match is
+  // actually in progress — see `footballState`/`cricketState` below, which
+  // only surface it then; once finished, the confirmed/pending score block
+  // takes over instead. Fetched for `in_progress`/`completed` matches only —
+  // nothing to show before a match has started.
+  const detailedScore = useMatchDetailedScore(match.id, {
+    enabled: isLiveSport && (match.status === 'in_progress' || match.status === 'completed'),
+    refetchInterval: match.status === 'in_progress' ? 15000 : undefined,
   })
-  const footballState = footballLiveState(live.data)
-  const cricketState = cricketLiveState(live.data)
+  const isCurrentlyLive = isLiveSport && match.status === 'in_progress'
+  const footballState = isCurrentlyLive ? footballDetailFrom(detailedScore.data) : null
+  const cricketState = isCurrentlyLive ? cricketDetailFrom(detailedScore.data) : null
   const hasLiveState = !!footballState || !!cricketState
   const cricketScore = scoreInfo ? cricketScoreFrom(scoreInfo.score) : null
   // Football's setup screen also gates starting the clock; cricket has no
@@ -147,16 +150,12 @@ function MatchDetail({
   const liveEntryPath =
     match.match_type === 'cricket' ? `/matches/${match.id}/live` : `/matches/${match.id}/live/setup`
 
-  // Resolved per-innings scorecard: batting/bowling cards + totals from
-  // `detailed_score` (works whether the match was scored live or entered
-  // after the fact), with each innings' deliveries folded in from the raw
-  // live event log by matching innings order, for the run-rate graph. The
-  // event log (unlike the live snapshot above) has no size ceiling and stays
-  // fully readable regardless of match status, so it's fetched here
-  // independently of `live`.
-  const detailedScore = useMatchDetailedScore(match.id, {
-    enabled: match.match_type === 'cricket',
-  })
+  // Each cricket innings' deliveries, folded in from the raw live event log
+  // by matching innings order, for the run-rate graph — `detailedScore`'s
+  // own `recent_deliveries` is bounded to the current innings' last 18
+  // balls, not the full match, so the graph needs the raw log instead. The
+  // event log has no size ceiling and stays fully readable regardless of
+  // match status, so it's fetched here independently of `detailedScore`.
   const liveEvents = useLiveEvents(match.id, { enabled: match.match_type === 'cricket' })
   const cricketDetailInnings = cricketDetail(detailedScore.data)
   const liveInningsDeliveries = liveEvents.data ? inningsDeliveriesFromEvents(liveEvents.data) : undefined


### PR DESCRIPTION
## Summary

What started as "make the run-rate graph actually work" turned into a redesign of the live-scoring data path. In order:

1. **The bug**: `finishMatch` never submitted `detailed_score`, so a live-scored match never had the per-innings detail the run-rate graph/scorecard (#37) reads.
2. **The naive fix had a ceiling**: embedding full ball-by-ball deliveries in `detailed_score` risks DynamoDB's 400KB item cap on a long match. Fixed by dropping `deliveries` from `detailed_score::cricket::CricketInnings` entirely — that data already lives safely, one item per ball, in the live event log.
3. **The `#LIVESTATE` cache had the same problem, worse**: it was rewritten on every single delivery, so a long match could hit the cap continuously (not just once at finish), and since the cache write was best-effort, crossing it would silently freeze the live view.
4. **Removed the cache entirely**, deriving live state fresh from the event log on every read.
5. **Final design** (this push): rather than nothing, a genuinely fixed-size cache:
   - `GET /matches/:id/live/events` is now **paginated** (cursor + limit) — a long match's log can run to thousands of events.
   - `CricketLiveState` is now a **fixed-size live summary**: per-innings totals, a bounded 18-delivery window, and an **incrementally-folded `next_ball_context`** (striker/non-striker/bowler for the next ball) — computed once server-side (mirrors what the frontend used to replay client-side) and safe to cache/update on every ball since it can't grow unbounded.
   - The full batting/bowling cards `detailed_score` needs are now derived **server-side, once**, when a live-scored match completes without the client supplying one — the event log is the only place that data still lives.

**Known follow-up, not done here**: the live-scoring screen no longer shows live batting/bowling figures (just names) during scoring, since the summary doesn't carry full cards. Bringing that back needs a per-device local incremental fold — the same shape offline scoring will need anyway (a device has to derive its own state from a not-yet-synced queue, without a server round-trip). Flagged in the code as a deliberate gap, not an oversight.

Note: still only fixes this going forward — matches finished before this change won't retroactively gain detail.

## Test plan
- [x] `cargo build --workspace`, `cargo test --workspace` (new tests for the incremental fold: strike rotation, wicket/retirement vacancy, recent-deliveries capping, full-scorecard derivation)
- [x] `cargo fmt -- --check`, `cargo clippy -- -D warnings`
- [x] `npm run generate`, `tsc -b`, `eslint`, `vite build` all clean
- [ ] Manually score a cricket match live (multi-over, at least one wicket) and confirm: live view updates correctly ball-by-ball, finishing the match produces a correct scorecard, the match detail page's run-rate graph renders

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWA4x9JCTeDfbLX96nuMPg)_