### PR TITLE
Add match completion and event side alignment to live scoring

### DIFF
--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -443,6 +443,7 @@ pub enum FootballLiveEventRecord {
     Card(FootballCardEventRecord),
     Substitution(FootballSubstitutionEventRecord),
     Period(FootballPeriodEventRecord),
+    PenaltyShootoutKick(FootballPenaltyShootoutKickRecord),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -495,9 +496,17 @@ pub enum FootballPeriodRecord {
     HalfTime,
     SecondHalfKickOff,
     FullTime,
+    ExtraTimeKickOff,
     ExtraTimeHalfTime,
+    ExtraTimeSecondHalfKickOff,
     ExtraTimeFullTime,
     PenaltiesComplete,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FootballPenaltyShootoutKickRecord {
+    pub side_id: String,
+    pub scored: bool,
 }
 
 // ---- Cricket live events ----------------------------------------------------

--- a/agon_service/src/detailed_score/football.rs
+++ b/agon_service/src/detailed_score/football.rs
@@ -27,6 +27,17 @@ pub struct FootballDetail {
     /// shape) so a new kind of marker — extra time, a drinks break — doesn't
     /// need a new field each time.
     pub period_times: HashMap<FootballPeriod, chrono::DateTime<chrono::Utc>>,
+    /// Every penalty-shootout kick recorded, in order taken. Separate from
+    /// `goals`/`score` — a shootout kick never counts as a match goal, only
+    /// towards `penalty_shootout_score` — since the scoreline it decides
+    /// (e.g. "1-1, Riverside win 4-3 on penalties") keeps the 90/120-minute
+    /// score and the shootout tally visually distinct, same as it's reported
+    /// in the real world.
+    pub penalty_shootout: Vec<FootballPenaltyShootoutKick>,
+    /// Running shootout tally (kicks scored, not kicks taken) per side,
+    /// derived from `penalty_shootout` the same way `score` is derived from
+    /// `goals`.
+    pub penalty_shootout_score: Vec<FootballShootoutTally>,
 }
 
 /// A side's running goal tally, derived from the event log (a convenience for
@@ -73,6 +84,23 @@ pub struct FootballSubstitutionEvent {
     pub minute: Option<u32>,
 }
 
+/// One kick in a penalty shootout.
+#[derive(Object, Clone)]
+pub struct FootballPenaltyShootoutKick {
+    /// The side taking this kick.
+    pub side_id: String,
+    pub scored: bool,
+}
+
+/// A side's shootout tally (kicks scored so far) — the penalty-shootout
+/// equivalent of `FootballSideGoals`, kept as its own type since "goals"
+/// would be a misnomer for a shootout kick.
+#[derive(Object, Clone)]
+pub struct FootballShootoutTally {
+    pub side_id: String,
+    pub scored: u32,
+}
+
 #[derive(Enum, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[oai(rename_all = "snake_case")]
 pub enum FootballPeriod {
@@ -88,7 +116,14 @@ pub enum FootballPeriod {
     /// left off, not from a fixed 45').
     SecondHalfKickOff,
     FullTime,
+    /// Kickoff of extra time's first half — same role as `KickOff`, one level
+    /// up. Only recorded if the match is level at `FullTime` and the format
+    /// plays extra time.
+    ExtraTimeKickOff,
     ExtraTimeHalfTime,
+    /// Kickoff of extra time's second half — same role as
+    /// `SecondHalfKickOff`.
+    ExtraTimeSecondHalfKickOff,
     ExtraTimeFullTime,
     PenaltiesComplete,
 }
@@ -104,7 +139,9 @@ impl std::fmt::Display for FootballPeriod {
             FootballPeriod::HalfTime => "half_time",
             FootballPeriod::SecondHalfKickOff => "second_half_kick_off",
             FootballPeriod::FullTime => "full_time",
+            FootballPeriod::ExtraTimeKickOff => "extra_time_kick_off",
             FootballPeriod::ExtraTimeHalfTime => "extra_time_half_time",
+            FootballPeriod::ExtraTimeSecondHalfKickOff => "extra_time_second_half_kick_off",
             FootballPeriod::ExtraTimeFullTime => "extra_time_full_time",
             FootballPeriod::PenaltiesComplete => "penalties_complete",
         })
@@ -120,7 +157,9 @@ impl std::str::FromStr for FootballPeriod {
             "half_time" => Ok(FootballPeriod::HalfTime),
             "second_half_kick_off" => Ok(FootballPeriod::SecondHalfKickOff),
             "full_time" => Ok(FootballPeriod::FullTime),
+            "extra_time_kick_off" => Ok(FootballPeriod::ExtraTimeKickOff),
             "extra_time_half_time" => Ok(FootballPeriod::ExtraTimeHalfTime),
+            "extra_time_second_half_kick_off" => Ok(FootballPeriod::ExtraTimeSecondHalfKickOff),
             "extra_time_full_time" => Ok(FootballPeriod::ExtraTimeFullTime),
             "penalties_complete" => Ok(FootballPeriod::PenaltiesComplete),
             other => Err(format!("unknown football period: {other}")),

--- a/agon_service/src/live_score/football.rs
+++ b/agon_service/src/live_score/football.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use poem_openapi::{Object, Union};
 
 use crate::detailed_score::football::{
-    FootballCardEvent, FootballDetail, FootballGoalEvent, FootballPeriod, FootballSideGoals,
-    FootballSubstitutionEvent,
+    FootballCardEvent, FootballDetail, FootballGoalEvent, FootballPenaltyShootoutKick,
+    FootballPeriod, FootballShootoutTally, FootballSideGoals, FootballSubstitutionEvent,
 };
 
 /// Football live-scoring events, nested under the outer sport union
@@ -20,6 +20,9 @@ pub enum FootballLiveEvent {
     Card(FootballCardEvent),
     Substitution(FootballSubstitutionEvent),
     Period(FootballPeriodEvent),
+    /// Reuses `detailed_score::football::FootballPenaltyShootoutKick`
+    /// verbatim, same as `Goal`.
+    PenaltyShootoutKick(FootballPenaltyShootoutKick),
 }
 
 #[derive(Object, Clone)]
@@ -42,6 +45,8 @@ impl FootballDetail {
             substitutions: Vec::new(),
             period: None,
             period_times: HashMap::new(),
+            penalty_shootout: Vec::new(),
+            penalty_shootout_score: Vec::new(),
         };
         for (occurred_at, event) in events {
             detail.apply_event(*occurred_at, event);
@@ -80,6 +85,23 @@ impl FootballDetail {
             FootballLiveEvent::Period(p) => {
                 self.period_times.insert(p.period, occurred_at);
                 self.period = Some(p.period);
+            }
+            FootballLiveEvent::PenaltyShootoutKick(k) => {
+                if k.scored {
+                    if let Some(s) = self
+                        .penalty_shootout_score
+                        .iter_mut()
+                        .find(|s| s.side_id == k.side_id)
+                    {
+                        s.scored += 1;
+                    } else {
+                        self.penalty_shootout_score.push(FootballShootoutTally {
+                            side_id: k.side_id.clone(),
+                            scored: 1,
+                        });
+                    }
+                }
+                self.penalty_shootout.push(k.clone());
             }
         }
     }
@@ -212,9 +234,21 @@ mod tests {
     fn extra_time_and_penalties_markers_get_timestamps_too() {
         let events = vec![
             (
-                ts(120),
+                ts(90),
+                FootballLiveEvent::Period(FootballPeriodEvent {
+                    period: FootballPeriod::ExtraTimeKickOff,
+                }),
+            ),
+            (
+                ts(105),
                 FootballLiveEvent::Period(FootballPeriodEvent {
                     period: FootballPeriod::ExtraTimeHalfTime,
+                }),
+            ),
+            (
+                ts(120),
+                FootballLiveEvent::Period(FootballPeriodEvent {
+                    period: FootballPeriod::ExtraTimeSecondHalfKickOff,
                 }),
             ),
             (
@@ -234,7 +268,17 @@ mod tests {
         let detail = FootballDetail::from_events(&events);
 
         assert_eq!(
+            detail.period_times.get(&FootballPeriod::ExtraTimeKickOff),
+            Some(&ts(90))
+        );
+        assert_eq!(
             detail.period_times.get(&FootballPeriod::ExtraTimeHalfTime),
+            Some(&ts(105))
+        );
+        assert_eq!(
+            detail
+                .period_times
+                .get(&FootballPeriod::ExtraTimeSecondHalfKickOff),
             Some(&ts(120))
         );
         assert_eq!(
@@ -245,6 +289,62 @@ mod tests {
             detail.period_times.get(&FootballPeriod::PenaltiesComplete),
             Some(&ts(160))
         );
+    }
+
+    #[test]
+    fn penalty_shootout_kicks_tally_scored_only() {
+        let events = vec![
+            (
+                ts(160),
+                FootballLiveEvent::PenaltyShootoutKick(FootballPenaltyShootoutKick {
+                    side_id: "riverside".into(),
+                    scored: true,
+                }),
+            ),
+            (
+                ts(161),
+                FootballLiveEvent::PenaltyShootoutKick(FootballPenaltyShootoutKick {
+                    side_id: "oak_park".into(),
+                    scored: false,
+                }),
+            ),
+            (
+                ts(162),
+                FootballLiveEvent::PenaltyShootoutKick(FootballPenaltyShootoutKick {
+                    side_id: "riverside".into(),
+                    scored: true,
+                }),
+            ),
+            (
+                ts(163),
+                FootballLiveEvent::PenaltyShootoutKick(FootballPenaltyShootoutKick {
+                    side_id: "oak_park".into(),
+                    scored: true,
+                }),
+            ),
+        ];
+
+        let detail = FootballDetail::from_events(&events);
+
+        assert_eq!(detail.penalty_shootout.len(), 4);
+        // Only sides with at least one scored kick get a tally entry — same
+        // "absence means zero" convention as `score`/`FootballSideGoals`.
+        assert_eq!(detail.penalty_shootout_score.len(), 2);
+        let riverside = detail
+            .penalty_shootout_score
+            .iter()
+            .find(|s| s.side_id == "riverside")
+            .unwrap();
+        assert_eq!(riverside.scored, 2);
+        let oak_park = detail
+            .penalty_shootout_score
+            .iter()
+            .find(|s| s.side_id == "oak_park")
+            .unwrap();
+        assert_eq!(oak_park.scored, 1);
+        // A shootout kick never counts as a match goal.
+        assert!(detail.score.is_empty());
+        assert!(detail.goals.is_empty());
     }
 
     #[test]
@@ -289,6 +389,8 @@ mod tests {
             substitutions: Vec::new(),
             period: None,
             period_times: HashMap::new(),
+            penalty_shootout: Vec::new(),
+            penalty_shootout_score: Vec::new(),
         };
         for (occurred_at, event) in &events {
             incremental.apply_event(*occurred_at, event);

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -4580,6 +4580,8 @@ fn mock_football_detailed_score() -> DetailedScore {
         substitutions: vec![],
         period: Some(FootballPeriod::FullTime),
         period_times: std::collections::HashMap::new(),
+        penalty_shootout: vec![],
+        penalty_shootout_score: vec![],
     })
 }
 

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -12,8 +12,8 @@ use crate::detailed_score::cricket::{
     CricketExtraKind, Overs,
 };
 use crate::detailed_score::football::{
-    FootballCardColor, FootballCardEvent, FootballGoalEvent, FootballPeriod,
-    FootballSubstitutionEvent,
+    FootballCardColor, FootballCardEvent, FootballGoalEvent, FootballPenaltyShootoutKick,
+    FootballPeriod, FootballSubstitutionEvent,
 };
 use crate::live_score::{
     LiveEvent, LiveEventInput, NewLiveEventInput,
@@ -49,13 +49,14 @@ use agon_core::dao::records::{
     CricketLiveEventRecord, CricketRetireEventRecord, CricketScoreInningsRecord,
     EmbeddedInvitationRecord, FootballCardColorRecord, FootballCardEventRecord,
     FootballFormatRecord, FootballGoalEventRecord, FootballLiveEventRecord,
-    FootballPeriodEventRecord, FootballPeriodRecord, FootballSubstitutionEventRecord,
-    InningsEndReasonRecord, InvitationContextRecord, InvitationKindRecord, InvitationRecord,
-    LiveEventPayloadRecord, LiveEventRecord, MatchDetailedScoreRecord, MatchFormatRecord,
-    MatchLikeRecord, MatchPlayerRecord, MatchRecord, MatchSideRecord, NotificationKindRecord,
-    NotificationRecord, OversRecord, PendingScoreRecord, ScoreConfirmationRecord, ScoreRecord,
-    ScoreResponseRecord, ScoreSubmissionRecord, SetsScoreEntryRecord, SimpleScoreEntryRecord,
-    TeamMemberRecord, TeamRecord, UserRecord, UserSportStatsRecord,
+    FootballPenaltyShootoutKickRecord, FootballPeriodEventRecord, FootballPeriodRecord,
+    FootballSubstitutionEventRecord, InningsEndReasonRecord, InvitationContextRecord,
+    InvitationKindRecord, InvitationRecord, LiveEventPayloadRecord, LiveEventRecord,
+    MatchDetailedScoreRecord, MatchFormatRecord, MatchLikeRecord, MatchPlayerRecord, MatchRecord,
+    MatchSideRecord, NotificationKindRecord, NotificationRecord, OversRecord, PendingScoreRecord,
+    ScoreConfirmationRecord, ScoreRecord, ScoreResponseRecord, ScoreSubmissionRecord,
+    SetsScoreEntryRecord, SimpleScoreEntryRecord, TeamMemberRecord, TeamRecord, UserRecord,
+    UserSportStatsRecord,
 };
 use poem_openapi::types::{ParseFromJSON, ToJSON};
 
@@ -783,10 +784,20 @@ fn football_live_event_to_record(event: &FootballLiveEvent) -> FootballLiveEvent
                     FootballPeriod::HalfTime => FootballPeriodRecord::HalfTime,
                     FootballPeriod::SecondHalfKickOff => FootballPeriodRecord::SecondHalfKickOff,
                     FootballPeriod::FullTime => FootballPeriodRecord::FullTime,
+                    FootballPeriod::ExtraTimeKickOff => FootballPeriodRecord::ExtraTimeKickOff,
                     FootballPeriod::ExtraTimeHalfTime => FootballPeriodRecord::ExtraTimeHalfTime,
+                    FootballPeriod::ExtraTimeSecondHalfKickOff => {
+                        FootballPeriodRecord::ExtraTimeSecondHalfKickOff
+                    }
                     FootballPeriod::ExtraTimeFullTime => FootballPeriodRecord::ExtraTimeFullTime,
                     FootballPeriod::PenaltiesComplete => FootballPeriodRecord::PenaltiesComplete,
                 },
+            })
+        }
+        FootballLiveEvent::PenaltyShootoutKick(k) => {
+            FootballLiveEventRecord::PenaltyShootoutKick(FootballPenaltyShootoutKickRecord {
+                side_id: k.side_id.clone(),
+                scored: k.scored,
             })
         }
     }
@@ -825,11 +836,21 @@ fn football_live_event_from_record(rec: &FootballLiveEventRecord) -> FootballLiv
                 FootballPeriodRecord::HalfTime => FootballPeriod::HalfTime,
                 FootballPeriodRecord::SecondHalfKickOff => FootballPeriod::SecondHalfKickOff,
                 FootballPeriodRecord::FullTime => FootballPeriod::FullTime,
+                FootballPeriodRecord::ExtraTimeKickOff => FootballPeriod::ExtraTimeKickOff,
                 FootballPeriodRecord::ExtraTimeHalfTime => FootballPeriod::ExtraTimeHalfTime,
+                FootballPeriodRecord::ExtraTimeSecondHalfKickOff => {
+                    FootballPeriod::ExtraTimeSecondHalfKickOff
+                }
                 FootballPeriodRecord::ExtraTimeFullTime => FootballPeriod::ExtraTimeFullTime,
                 FootballPeriodRecord::PenaltiesComplete => FootballPeriod::PenaltiesComplete,
             },
         }),
+        FootballLiveEventRecord::PenaltyShootoutKick(k) => {
+            FootballLiveEvent::PenaltyShootoutKick(FootballPenaltyShootoutKick {
+                side_id: k.side_id.clone(),
+                scored: k.scored,
+            })
+        }
     }
 }
 
@@ -1260,7 +1281,17 @@ mod tests {
                 minute: Some(70),
             }),
             FootballLiveEvent::Period(FootballPeriodEvent {
+                period: FootballPeriod::ExtraTimeKickOff,
+            }),
+            FootballLiveEvent::Period(FootballPeriodEvent {
+                period: FootballPeriod::ExtraTimeSecondHalfKickOff,
+            }),
+            FootballLiveEvent::Period(FootballPeriodEvent {
                 period: FootballPeriod::ExtraTimeFullTime,
+            }),
+            FootballLiveEvent::PenaltyShootoutKick(FootballPenaltyShootoutKick {
+                side_id: "riverside".into(),
+                scored: true,
             }),
         ];
 

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -203,12 +203,20 @@ export function MatchCard({
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
 
   const isLiveSport = match.match_type === 'football' || match.match_type === 'cricket'
+  const isCurrentlyLive = isLiveSport && match.status === 'in_progress'
   const detailedScore = useMatchDetailedScore(match.id, {
-    enabled: isLiveSport && match.status === 'in_progress',
+    enabled: isCurrentlyLive,
     refetchInterval: 20000,
   })
-  const footballState = footballDetailFrom(detailedScore.data)
-  const cricketState = cricketDetailFrom(detailedScore.data)
+  // Gate on `isCurrentlyLive`, not just "did the fetch return something" —
+  // `detailedScore` is a react-query cache keyed only by match id, shared
+  // with `MatchDetailPage`, which fetches it for a *completed* match too (to
+  // show the finished scorecard). `enabled: false` only stops a new fetch
+  // here; it doesn't hide data another component already populated that
+  // cache entry with, so without this guard a card could keep rendering the
+  // live block/badge for a match that finished after the card last mounted.
+  const footballState = isCurrentlyLive ? footballDetailFrom(detailedScore.data) : null
+  const cricketState = isCurrentlyLive ? cricketDetailFrom(detailedScore.data) : null
   const hasLiveState = !!footballState || !!cricketState
   // A cricket match's confirmed score carries its own per-innings detail once
   // it's been live-scored (`Score::Cricket`; see `finishMatch` in

--- a/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
@@ -83,15 +83,21 @@ export function LiveMatchBlock({
 
       {events.length > 0 && (
         <div className="mt-2.5 space-y-1 border-t pt-2">
-          {events.map((event, i) => (
-            <p key={i} className="truncate text-xs text-muted-foreground">
-              <span aria-hidden>{eventEmoji(event.kind)}</span>{' '}
-              {event.minute !== undefined && (
-                <span className="font-medium text-foreground">{event.minute}' </span>
-              )}
-              {describeEvent(event, match)}
-            </p>
-          ))}
+          {events.map((event, i) => {
+            const isSideB = event.side_id === sideB?.id
+            return (
+              <p
+                key={i}
+                className={`flex items-baseline gap-1.5 truncate text-xs text-muted-foreground ${isSideB ? 'flex-row-reverse text-right' : ''}`}
+              >
+                <span aria-hidden>{eventEmoji(event.kind)}</span>
+                {event.minute !== undefined && (
+                  <span className="font-medium text-foreground">{event.minute}'</span>
+                )}
+                <span className="truncate">{describeEvent(event, match)}</span>
+              </p>
+            )
+          })}
         </div>
       )}
     </div>

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -107,6 +107,7 @@ interface CricketInningsTotal {
   bowling_side_id: string
   runs: number
   wickets: number
+  overs: Overs
 }
 
 /** Ditto, for the match-level progress shape: a detail's own state, or a
@@ -297,11 +298,18 @@ export function matchTotalsBySide(state: CricketMatchProgress): Record<string, n
  * own roster size (players registered on that side, minus one — the last
  * batter has no partner left to bat with), falling back to the standard 10
  * if the roster looks too small to make sense of (e.g. not fully set up).
+ *
+ * A win is only reported by wickets when the chasing side's innings ended
+ * *before* using its full over allocation — i.e. they got there with
+ * balls to spare. If both sides batted out their complete overs quota, the
+ * "wickets in hand" framing doesn't mean anything (nobody was chasing down
+ * a target mid-over); that's reported as a runs margin instead, same as the
+ * side batting first finishing ahead.
  */
 export function cricketStateDescription(
   match: Pick<Match, 'sides' | 'players'>,
   state: CricketMatchProgress,
-  format: Pick<CricketFormat, 'innings_per_side'>,
+  format: Pick<CricketFormat, 'innings_per_side' | 'overs_per_innings'>,
 ): string | null {
   if (state.innings.length === 0) return null
   const quota = match.sides.length * format.innings_per_side
@@ -340,14 +348,21 @@ export function cricketStateDescription(
   const battingTotal = totals[last.batting_side_id] ?? 0
   const bowlingTotal = totals[last.bowling_side_id] ?? 0
   if (battingTotal === bowlingTotal) return 'Match tied'
-  if (battingTotal > bowlingTotal) {
+
+  const oversAllUsed =
+    format.overs_per_innings != null &&
+    last.overs.overs >= format.overs_per_innings &&
+    last.overs.balls === 0
+
+  if (battingTotal > bowlingTotal && !oversAllUsed) {
     const rosterSize = match.players.filter((p) => p.side_id === last.batting_side_id).length
     const maxWickets = rosterSize > 1 ? rosterSize - 1 : 10
     const remaining = Math.max(maxWickets - last.wickets, 0)
     return `${sideNameFor(match, last.batting_side_id)} won by ${remaining} wicket${remaining === 1 ? '' : 's'}`
   }
-  const margin = bowlingTotal - battingTotal
-  return `${sideNameFor(match, last.bowling_side_id)} won by ${margin} run${margin === 1 ? '' : 's'}`
+  const winnerSideId = battingTotal > bowlingTotal ? last.batting_side_id : last.bowling_side_id
+  const margin = Math.abs(battingTotal - bowlingTotal)
+  return `${sideNameFor(match, winnerSideId)} won by ${margin} run${margin === 1 ? '' : 's'}`
 }
 
 /** Display name for a side id: its name, or a neutral fallback. */

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -107,7 +107,9 @@ const PERIOD_LABEL: Record<FootballPeriod, string> = {
   half_time: 'Half-time',
   second_half_kick_off: 'Second-half kick-off',
   full_time: 'Full-time',
+  extra_time_kick_off: 'Extra time: kick-off',
   extra_time_half_time: 'Extra time: half-time',
+  extra_time_second_half_kick_off: 'Extra time: second-half kick-off',
   extra_time_full_time: 'Extra time: full-time',
   penalties_complete: 'Penalties complete',
 }
@@ -225,18 +227,49 @@ export type ClockPhase =
   | 'half_time'
   | 'second_half'
   | 'full_time'
-  /** An extra-time/penalties marker was recorded — those phases aren't
-   *  clocked yet (see `FootballPeriod`), so just the marker itself is shown. */
+  | 'extra_time_first_half'
+  | 'extra_time_half_time'
+  | 'extra_time_second_half'
+  | 'extra_time_full_time'
+  /** Shootout under way or finished (`penalties_complete` recorded) — see
+   *  `penaltiesComplete`. Not individually clocked; kicks are just recorded
+   *  in order taken. */
+  | 'penalties'
+  /** An unrecognized marker was recorded (forward-compat only — every
+   *  `FootballPeriod` variant maps to a phase above today). */
   | 'other'
 
-/** Which phase the match is in right now, purely from recorded timestamps. */
+/** Which phase the match is in right now, purely from recorded timestamps
+ *  (plus, for `penalties`, whether any shootout kicks exist yet — there's no
+ *  dedicated "shootout started" marker, the first kick doubles as one). */
 export function phaseFromState(state: FootballDetail): ClockPhase {
+  if (periodTime(state, 'penalties_complete') || state.penalty_shootout.length > 0) {
+    return 'penalties'
+  }
+  if (periodTime(state, 'extra_time_full_time')) return 'extra_time_full_time'
+  if (periodTime(state, 'extra_time_second_half_kick_off')) return 'extra_time_second_half'
+  if (periodTime(state, 'extra_time_half_time')) return 'extra_time_half_time'
+  if (periodTime(state, 'extra_time_kick_off')) return 'extra_time_first_half'
   if (periodTime(state, 'full_time')) return 'full_time'
   if (periodTime(state, 'second_half_kick_off')) return 'second_half'
   if (periodTime(state, 'half_time')) return 'half_time'
   if (periodTime(state, 'kick_off')) return 'first_half'
   if (state.period) return 'other'
   return 'not_started'
+}
+
+/** Whether the penalty shootout has been marked done. `phaseFromState`
+ *  returns `'penalties'` for both an in-progress and a finished shootout —
+ *  callers that need to tell them apart (e.g. to show "Finish match" instead
+ *  of the kick-recording panel) check this too. */
+export function penaltiesComplete(state: FootballDetail): boolean {
+  return !!periodTime(state, 'penalties_complete')
+}
+
+/** A side's penalty-shootout tally (kicks scored, not taken) — the shootout
+ *  equivalent of reading `FootballDetail.score` for goals. */
+export function shootoutScoreFor(state: FootballDetail, sideId: string | undefined): number {
+  return state.penalty_shootout_score.find((s) => s.side_id === sideId)?.scored ?? 0
 }
 
 function minutesBetween(from: string, to: Date | string): number {
@@ -246,10 +279,11 @@ function minutesBetween(from: string, to: Date | string): number {
 /**
  * The current match minute, e.g. for the live clock display or to prefill an
  * event's minute field (still overridable — see `RecordEventDialog`). `null`
- * before kickoff or during an unclocked phase (extra time/penalties).
- * Added time in the first half carries over automatically: the second half's
- * minute count continues from wherever the first half actually left off,
- * rather than resetting to a fixed 45'.
+ * before kickoff or during an unclocked phase (penalties). Added time in a
+ * half carries over automatically into the next one — first half into
+ * second half, and normal time into extra time — so the clock counts up
+ * continuously (e.g. 94', then 106' once extra time starts) rather than
+ * resetting to a fixed 45'/90' each time.
  */
 export function currentMinute(state: FootballDetail, now: Date = new Date()): number | null {
   const phase = phaseFromState(state)
@@ -257,7 +291,20 @@ export function currentMinute(state: FootballDetail, now: Date = new Date()): nu
   const halfTimeAt = periodTime(state, 'half_time')
   const secondHalfKickoffAt = periodTime(state, 'second_half_kick_off')
   const fullTimeAt = periodTime(state, 'full_time')
+  const etKickoffAt = periodTime(state, 'extra_time_kick_off')
+  const etHalfTimeAt = periodTime(state, 'extra_time_half_time')
+  const etSecondHalfKickoffAt = periodTime(state, 'extra_time_second_half_kick_off')
+  const etFullTimeAt = periodTime(state, 'extra_time_full_time')
+
   const firstHalfMinutes = kickoffAt && halfTimeAt ? minutesBetween(kickoffAt, halfTimeAt) : 0
+  const normalTimeMinutes = fullTimeAt
+    ? secondHalfKickoffAt
+      ? firstHalfMinutes + minutesBetween(secondHalfKickoffAt, fullTimeAt)
+      : kickoffAt
+        ? minutesBetween(kickoffAt, fullTimeAt)
+        : 0
+    : 0
+  const etFirstHalfMinutes = etKickoffAt && etHalfTimeAt ? minutesBetween(etKickoffAt, etHalfTimeAt) : 0
 
   switch (phase) {
     case 'first_half':
@@ -270,12 +317,24 @@ export function currentMinute(state: FootballDetail, now: Date = new Date()): nu
         : null
     case 'full_time':
       if (!fullTimeAt) return null
-      return secondHalfKickoffAt
-        ? firstHalfMinutes + minutesBetween(secondHalfKickoffAt, fullTimeAt)
-        : kickoffAt
-          ? minutesBetween(kickoffAt, fullTimeAt)
+      return normalTimeMinutes
+    case 'extra_time_first_half':
+      return etKickoffAt ? normalTimeMinutes + minutesBetween(etKickoffAt, now) : null
+    case 'extra_time_half_time':
+      return etKickoffAt && etHalfTimeAt ? normalTimeMinutes + etFirstHalfMinutes : null
+    case 'extra_time_second_half':
+      return etSecondHalfKickoffAt
+        ? normalTimeMinutes + etFirstHalfMinutes + minutesBetween(etSecondHalfKickoffAt, now)
+        : null
+    case 'extra_time_full_time':
+      if (!etFullTimeAt) return null
+      return etSecondHalfKickoffAt
+        ? normalTimeMinutes + etFirstHalfMinutes + minutesBetween(etSecondHalfKickoffAt, etFullTimeAt)
+        : etKickoffAt
+          ? normalTimeMinutes + minutesBetween(etKickoffAt, etFullTimeAt)
           : null
     case 'not_started':
+    case 'penalties':
     case 'other':
       return null
   }
@@ -294,26 +353,56 @@ export function phaseLabel(phase: ClockPhase): string {
       return '2nd half'
     case 'full_time':
       return 'Full-time'
+    case 'extra_time_first_half':
+      return 'Extra time: 1st half'
+    case 'extra_time_half_time':
+      return 'Extra time: half-time'
+    case 'extra_time_second_half':
+      return 'Extra time: 2nd half'
+    case 'extra_time_full_time':
+      return 'Extra time: full-time'
+    case 'penalties':
+      return 'Penalties'
     case 'other':
       return 'Live'
   }
 }
 
-/** A compact clock label for a score box, e.g. "63'", "HT", "FT", "LIVE". */
+/** A compact clock label for a score box, e.g. "63'", "HT", "FT", "AET", "PENS". */
 export function liveClockLabel(state: FootballDetail, now: Date = new Date()): string {
   const phase = phaseFromState(state)
   if (phase === 'half_time') return 'HT'
   if (phase === 'full_time') return 'FT'
+  if (phase === 'extra_time_half_time') return 'ET HT'
+  if (phase === 'extra_time_full_time') return 'AET'
+  if (phase === 'penalties') return 'PENS'
   if (phase === 'other') return state.period ? periodLabel(state.period) : 'LIVE'
   const minute = currentMinute(state, now)
   return minute === null ? 'LIVE' : `${minute}'`
 }
 
+/** Whether extra time/penalties can extend the match beyond normal time, and
+ *  whether it's currently needed (level on goals) — what `nextPeriodForPhase`
+ *  /`nextPhaseActionLabel` need to decide whether `full_time`/
+ *  `extra_time_full_time` lead further or the match is simply done. Entering
+ *  the penalty shootout isn't a period marker (see `phaseFromState`), so it's
+ *  not represented here — callers offer it separately once
+ *  `extra_time_full_time` is reached still level with `penalties` enabled. */
+export interface FootballProgressionContext {
+  isDraw: boolean
+  extraTime: boolean
+}
+
 /** The `FootballPeriod` marker to record for "the next thing that happens"
- *  from the current phase (kickoff, end of a half, full time) — what the
- *  live scoring screen's Half/FT-style quick action should send. `null` once
- *  the match is done, or during an unclocked phase. */
-export function nextPeriodForPhase(phase: ClockPhase): FootballPeriod | null {
+ *  from the current phase (kickoff, end of a half, full/extra time) — what
+ *  the live scoring screen's Half/FT-style quick action should send. `null`
+ *  once the match is done (or waiting on a non-period-marker decision like
+ *  starting penalties — see `FootballProgressionContext`), or during an
+ *  unclocked phase. */
+export function nextPeriodForPhase(
+  phase: ClockPhase,
+  ctx: FootballProgressionContext,
+): FootballPeriod | null {
   switch (phase) {
     case 'not_started':
       return 'kick_off'
@@ -324,13 +413,25 @@ export function nextPeriodForPhase(phase: ClockPhase): FootballPeriod | null {
     case 'second_half':
       return 'full_time'
     case 'full_time':
+      return ctx.isDraw && ctx.extraTime ? 'extra_time_kick_off' : null
+    case 'extra_time_first_half':
+      return 'extra_time_half_time'
+    case 'extra_time_half_time':
+      return 'extra_time_second_half_kick_off'
+    case 'extra_time_second_half':
+      return 'extra_time_full_time'
+    case 'extra_time_full_time':
+    case 'penalties':
     case 'other':
       return null
   }
 }
 
 /** Label for the clock's quick-action button, contextual to the current phase. */
-export function nextPhaseActionLabel(phase: ClockPhase): string {
+export function nextPhaseActionLabel(
+  phase: ClockPhase,
+  ctx: FootballProgressionContext,
+): string {
   switch (phase) {
     case 'not_started':
       return 'Kick off'
@@ -341,6 +442,15 @@ export function nextPhaseActionLabel(phase: ClockPhase): string {
     case 'second_half':
       return 'End match'
     case 'full_time':
+      return ctx.isDraw && ctx.extraTime ? 'Start extra time' : 'Full-time'
+    case 'extra_time_first_half':
+      return 'End ET 1st half'
+    case 'extra_time_half_time':
+      return 'Start ET 2nd half'
+    case 'extra_time_second_half':
+      return 'End extra time'
+    case 'extra_time_full_time':
+    case 'penalties':
     case 'other':
       return 'Full-time'
   }

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -121,11 +121,6 @@ export function recentEvents(detail: FootballDetail, limit: number): FootballEve
   return eventsFromDetail(detail).reverse().slice(0, limit)
 }
 
-/** Side display name for an event, falling back to a neutral label. */
-function sideNameFor(match: Pick<Match, 'sides'>, sideId: string): string {
-  return match.sides.find((s) => s.id === sideId)?.name?.trim() || 'This side'
-}
-
 /** Player display name for a member id, if it's on the roster. */
 function playerNameFor(match: Pick<Match, 'players'>, playerId: string | undefined): string | null {
   if (!playerId) return null
@@ -134,30 +129,31 @@ function playerNameFor(match: Pick<Match, 'players'>, playerId: string | undefin
 }
 
 /** One-line human description of a football event, e.g. "Goal — J. Alvarez
- *  (Riverside)" or "Sub — Moreno on for Khan (Oak Park)" — used by the event
- *  log and mini-ticker. */
+ *  (A. Silva)" or "Sub — Moreno on for Khan" — used by the event log and
+ *  mini-ticker. Which side it belongs to isn't repeated in the text; callers
+ *  convey that by aligning/positioning the row using `event.side_id`
+ *  instead (see `LiveScoringPage`/`LiveMatchBlock`). */
 export function describeEvent(
   event: FootballEventView,
-  match: Pick<Match, 'sides' | 'players'>,
+  match: Pick<Match, 'players'>,
 ): string {
-  const side = sideNameFor(match, event.side_id)
   const scorer = playerNameFor(match, event.player_id)
 
   switch (event.kind) {
     case 'goal':
-    case 'penalty':
-      return scorer ? `${eventLabel(event.kind)} — ${scorer} (${side})` : `${eventLabel(event.kind)} (${side})`
+    case 'penalty': {
+      const assist = playerNameFor(match, event.assist_player_id)
+      const base = scorer ? `${eventLabel(event.kind)} — ${scorer}` : eventLabel(event.kind)
+      return assist ? `${base} (${assist})` : base
+    }
     case 'own_goal':
-      return `Own goal — ${side}`
+      return eventLabel(event.kind)
     case 'yellow_card':
     case 'red_card':
-      return scorer
-        ? `${eventLabel(event.kind)} — ${scorer} (${side})`
-        : `${eventLabel(event.kind)} — ${side}`
+      return scorer ? `${eventLabel(event.kind)} — ${scorer}` : eventLabel(event.kind)
     case 'substitution': {
       const out = playerNameFor(match, event.substituted_player_id)
-      if (scorer && out) return `Sub — ${scorer} on for ${out} (${side})`
-      return `Substitution (${side})`
+      return scorer && out ? `Sub — ${scorer} on for ${out}` : 'Substitution'
     }
   }
 }

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { ChevronLeft } from 'lucide-react'
@@ -61,6 +61,19 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   // replay needed for the online case.
   const next = state?.next_ball_context ?? null
 
+  // The over quota's been fully bowled but nothing on the backend blocks
+  // further deliveries (see `match_format`'s doc comment — enforcement is
+  // intentionally out of scope there), so the picker flow would otherwise
+  // just keep asking for a new bowler forever. The reason is unambiguous
+  // here — the overs ran out, nobody needs to be asked — so this ends the
+  // innings itself instead of prompting (see the auto-end effect below).
+  const oversComplete =
+    !!innings &&
+    format.overs_per_innings != null &&
+    innings.overs.overs >= format.overs_per_innings &&
+    innings.overs.balls === 0
+  const oversCompleteAwaitingEnd = oversComplete && !next?.bowler_player_id
+
   // Locally-picked openers/replacement batter/next bowler — only used until
   // the server confirms them via an actual delivery, at which point
   // `next_ball_context` takes over as the source of truth.
@@ -90,6 +103,25 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   const [extraDialog, setExtraDialog] = useState<'no_ball' | 'bye' | null>(null)
   const [endInningsOpen, setEndInningsOpen] = useState(false)
   const [startBattingSide, setStartBattingSide] = useState<string | undefined>(undefined)
+
+  // Fires the `overs_complete` end-of-innings event itself the moment the
+  // quota's used up, rather than asking the scorer to pick a reason they
+  // didn't choose. Guarded by a ref (not `appendEvent.isPending`) so it
+  // fires exactly once per innings — `isPending` flips mid-flight and isn't
+  // a dependency here, so it can't retrigger the effect — and resets once
+  // the innings actually ends (`oversComplete` goes false) so the next
+  // innings' overs-complete moment can auto-end too.
+  const autoEndedOversRef = useRef(false)
+  useEffect(() => {
+    if (!oversCompleteAwaitingEnd) {
+      autoEndedOversRef.current = false
+      return
+    }
+    if (autoEndedOversRef.current) return
+    autoEndedOversRef.current = true
+    appendEvent.mutate({ kind: 'InningsEnd', reason: 'overs_complete' })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [oversCompleteAwaitingEnd])
 
   // Concludes the match: submits the per-innings totals as a `Cricket` score
   // (so the completed tile can show overs/wickets and the result line
@@ -280,17 +312,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
     )
   }
 
-  // The over quota's been fully bowled but nothing on the backend blocks
-  // further deliveries (see `match_format`'s doc comment — enforcement is
-  // intentionally out of scope there), so the picker flow would otherwise
-  // just keep asking for a new bowler forever. Steer the scorer to end the
-  // innings instead once every configured over is used up.
-  const oversComplete =
-    format.overs_per_innings != null &&
-    innings.overs.overs >= format.overs_per_innings &&
-    innings.overs.balls === 0
-
-  if (oversComplete && !next!.bowler_player_id) {
+  if (oversCompleteAwaitingEnd) {
     return (
       <div className="mx-auto flex max-w-xl flex-col gap-4">
         {header}
@@ -310,25 +332,23 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
           </p>
         </div>
         <div className="rounded-xl border border-primary/30 bg-primary/5 p-4">
-          <p className="mb-3 text-sm font-medium">
-            All {format.overs_per_innings} overs bowled — end this innings to continue.
-          </p>
-          <div className="grid grid-cols-2 gap-2">
-            {END_REASONS.map((r) => (
+          {appendEvent.isError ? (
+            <>
+              <p className="mb-3 text-sm font-medium">
+                All {format.overs_per_innings} overs bowled, but ending the innings failed.
+              </p>
               <Button
-                key={r.value}
                 variant="outline"
                 size="sm"
                 disabled={appendEvent.isPending}
-                onClick={() => endInnings(r.value)}
+                onClick={() => endInnings('overs_complete')}
               >
-                {r.label}
+                Try again
               </Button>
-            ))}
-          </div>
-          {appendEvent.isError && (
-            <p className="mt-2 text-xs text-destructive">
-              Failed to end the innings — try again.
+            </>
+          ) : (
+            <p className="text-sm font-medium text-muted-foreground">
+              All {format.overs_per_innings} overs bowled — ending the innings…
             </p>
           )}
         </div>

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -10,6 +10,7 @@ import { useMatchDetailedScore } from '@/hooks/useMatchDetailedScore'
 import { RecordEventDialog, type EventKind } from '@/components/agon/live/RecordEventDialog'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { CricketLiveScoringPage } from './CricketLiveScoringPage'
+import { footballFormat } from '@/lib/matchFormat'
 import {
   currentMinute,
   describeEvent,
@@ -19,8 +20,11 @@ import {
   loadTrackPrefs,
   nextPeriodForPhase,
   nextPhaseActionLabel,
+  penaltiesComplete,
   phaseFromState,
   phaseLabel,
+  shootoutScoreFor,
+  type ClockPhase,
 } from '@/lib/liveScore'
 
 type Match = components['schemas']['Match']
@@ -103,12 +107,15 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
   const prefs = loadTrackPrefs(match.id)
   const [dialogKind, setDialogKind] = useState<EventKind | null>(null)
 
-  // Concludes the match once full-time is recorded: submits the goal tally
-  // as a `Simple` score (the same shape `MatchResultEditor` writes) and
-  // marks the match `completed`, the way a manual "Add result" would — so it
-  // enters the normal confirmation flow rather than being auto-confirmed.
-  // No `detailed_score` here: the goals/cards/subs/period markers recorded
-  // live are already persisted against the match as they happened. Reads
+  // Concludes the match once it's decided (full-time, extra-time full-time,
+  // or the penalty shootout is done): submits the goal tally — normal time
+  // plus extra time, never shootout kicks — as a `Simple` score (the same
+  // shape `MatchResultEditor` writes) and marks the match `completed`, the
+  // way a manual "Add result" would — so it enters the normal confirmation
+  // flow rather than being auto-confirmed. Still level on goals falls back to
+  // the penalty shootout tally to pick a winner. No `detailed_score` here:
+  // the goals/cards/subs/period markers/shootout kicks recorded live are
+  // already persisted against the match as they happened. Reads
   // `detailedScore.data` directly (rather than closing over the `state`
   // computed below) so this hook can be declared before the loading early
   // return, same as every other hook in this component.
@@ -129,7 +136,13 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
         ],
       } as unknown as UpdateMatchInput['score']
       const body: UpdateMatchInput = { score, status: 'completed' }
-      if (a !== b) body.winner_side_id = a > b ? aId : bId
+      if (a !== b) {
+        body.winner_side_id = a > b ? aId : bId
+      } else if (detail) {
+        const penA = shootoutScoreFor(detail, aId)
+        const penB = shootoutScoreFor(detail, bId)
+        if (penA !== penB) body.winner_side_id = penA > penB ? aId : bId
+      }
       const { error } = await fetchClient.PATCH('/matches/{match_id}', {
         params: { path: { match_id: match.id } },
         body,
@@ -156,17 +169,39 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
   const state = footballDetailFrom(detailedScore.data)
   const goalsFor = (sideId: string | undefined) =>
     state?.score.find((s) => s.side_id === sideId)?.goals ?? 0
+  const format = footballFormat(match.format)
+  const aId = match.sides[0]?.id
+  const bId = match.sides[1]?.id
 
   // Before the first event, there's no snapshot yet at all — treat that the
   // same as an explicit "not started" phase (kickoff just hasn't happened).
   const phase = state ? phaseFromState(state) : 'not_started'
   const minute = state ? currentMinute(state, now) : null
+  const isDraw = !!state && goalsFor(aId) === goalsFor(bId)
+  const progressionCtx = { isDraw, extraTime: format.extra_time }
 
   const handleHalfFt = () => {
-    const period = nextPeriodForPhase(phase)
+    const period = nextPeriodForPhase(phase, progressionCtx)
     if (!period) return
     append.mutate({ kind: 'Period', period })
   }
+
+  // These phases are where the match is up for grabs on a period-marker
+  // "advance the clock" tap (kickoff/half-time/full-time and their extra-time
+  // equivalents). `full_time`/`extra_time_full_time` are deliberately
+  // excluded — they're decision points (finish, or continue into extra
+  // time/penalties) handled by the dedicated panel below instead of this
+  // grid tile, and `penalties` isn't clocked at all (see `ClockPhase`).
+  const advanceClockPhases: ClockPhase[] = [
+    'not_started',
+    'first_half',
+    'half_time',
+    'second_half',
+    'extra_time_first_half',
+    'extra_time_half_time',
+    'extra_time_second_half',
+  ]
+  const showAdvanceClockTile = advanceClockPhases.includes(phase)
 
   const actions: {
     key: EventKind | 'half_ft'
@@ -174,29 +209,48 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
     icon: React.ReactNode
     onClick: () => void
     disabled?: boolean
-  }[] = [
-    { key: 'goal', label: 'Goal', icon: <CircleDot className="size-5" />, onClick: () => setDialogKind('goal') },
-    ...(prefs.cards
-      ? [{ key: 'card' as const, label: 'Card', icon: <Flag className="size-5" />, onClick: () => setDialogKind('card') }]
-      : []),
-    ...(prefs.substitutions
-      ? [
-          {
-            key: 'substitution' as const,
-            label: 'Sub',
-            icon: <Repeat2 className="size-5" />,
-            onClick: () => setDialogKind('substitution'),
-          },
+  }[] =
+    phase === 'penalties'
+      ? []
+      : [
+          { key: 'goal', label: 'Goal', icon: <CircleDot className="size-5" />, onClick: () => setDialogKind('goal') },
+          ...(prefs.cards
+            ? [{ key: 'card' as const, label: 'Card', icon: <Flag className="size-5" />, onClick: () => setDialogKind('card') }]
+            : []),
+          ...(prefs.substitutions
+            ? [
+                {
+                  key: 'substitution' as const,
+                  label: 'Sub',
+                  icon: <Repeat2 className="size-5" />,
+                  onClick: () => setDialogKind('substitution'),
+                },
+              ]
+            : []),
+          ...(showAdvanceClockTile
+            ? [
+                {
+                  key: 'half_ft' as const,
+                  label: nextPhaseActionLabel(phase, progressionCtx),
+                  icon: <TimerReset className="size-5" />,
+                  onClick: handleHalfFt,
+                  disabled: nextPeriodForPhase(phase, progressionCtx) === null,
+                },
+              ]
+            : []),
         ]
-      : []),
-    {
-      key: 'half_ft',
-      label: nextPhaseActionLabel(phase),
-      icon: <TimerReset className="size-5" />,
-      onClick: handleHalfFt,
-      disabled: nextPeriodForPhase(phase) === null,
-    },
-  ]
+
+  // At full-time/extra-time-full-time still level, the format may call for
+  // more play — offer it, with an explicit override to finish as a draw
+  // anyway (the format is a plan, not a rule the organiser is locked into).
+  // Otherwise (decided on goals, or level with no more play configured) the
+  // match is ready to finish. The penalty shootout has its own completion
+  // signal (`penaltiesComplete`) instead of a phase-advance action.
+  const decidingPhase = phase === 'full_time' || phase === 'extra_time_full_time'
+  const continuationAvailable =
+    decidingPhase && isDraw && (phase === 'full_time' ? format.extra_time : format.penalties)
+  const readyToFinish =
+    (decidingPhase && !continuationAvailable) || (phase === 'penalties' && !!state && penaltiesComplete(state))
 
   const events = state ? eventsFromDetail(state).reverse() : []
 
@@ -221,45 +275,124 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
           <p className="flex-1 truncate text-sm font-medium">{nameA}</p>
           <div className="px-3 text-center">
             <div className="text-3xl font-medium tracking-tight">
-              {goalsFor(match.sides[0]?.id)}
+              {goalsFor(aId)}
               <span className="text-muted-foreground">–</span>
-              {goalsFor(match.sides[1]?.id)}
+              {goalsFor(bId)}
             </div>
             <div className="mt-0.5 text-xs text-primary">
               {minute !== null && `${minute}' · `}
               {phaseLabel(phase)}
             </div>
+            {phase === 'penalties' && (
+              <div className="mt-1 text-lg font-medium tracking-tight text-muted-foreground">
+                {state && shootoutScoreFor(state, aId)}
+                <span className="mx-1 text-xs">pens</span>
+                {state && shootoutScoreFor(state, bId)}
+              </div>
+            )}
           </div>
           <p className="flex-1 truncate text-right text-sm font-medium">{nameB}</p>
         </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        {actions.map((a) => (
-          <button
-            key={a.key}
-            type="button"
-            disabled={a.disabled}
-            onClick={a.onClick}
-            className="flex flex-col items-center gap-1.5 rounded-xl border bg-card p-5 text-sm font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {a.icon}
-            {a.label}
-          </button>
-        ))}
-      </div>
+      {actions.length > 0 && (
+        <div className="grid grid-cols-2 gap-3">
+          {actions.map((a) => (
+            <button
+              key={a.key}
+              type="button"
+              disabled={a.disabled}
+              onClick={a.onClick}
+              className="flex flex-col items-center gap-1.5 rounded-xl border bg-card p-5 text-sm font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {a.icon}
+              {a.label}
+            </button>
+          ))}
+        </div>
+      )}
 
-      {phase === 'full_time' && (
-        <>
-          <Button size="lg" disabled={finishMatch.isPending} onClick={() => finishMatch.mutate()}>
-            {finishMatch.isPending ? 'Finishing…' : 'Finish match'}
+      {phase === 'penalties' && state && !penaltiesComplete(state) && (
+        <div className="grid grid-cols-2 gap-3">
+          {([
+            [aId, nameA],
+            [bId, nameB],
+          ] as const).map(([sideId, name]) => (
+            <div key={sideId} className="flex flex-col gap-2 rounded-xl border bg-card p-4">
+              <p className="truncate text-center text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                {name}
+              </p>
+              <Button
+                variant="outline"
+                disabled={append.isPending || !sideId}
+                onClick={() => sideId && append.mutate({ kind: 'PenaltyShootoutKick', side_id: sideId, scored: true })}
+              >
+                Scored
+              </Button>
+              <Button
+                variant="ghost"
+                disabled={append.isPending || !sideId}
+                onClick={() => sideId && append.mutate({ kind: 'PenaltyShootoutKick', side_id: sideId, scored: false })}
+              >
+                Missed
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {phase === 'penalties' && state && state.penalty_shootout.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {state.penalty_shootout.map((kick, i) => (
+            <span
+              key={i}
+              className={`flex size-7 items-center justify-center rounded-full text-xs font-semibold ${
+                kick.scored ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'
+              }`}
+              title={kick.side_id === aId ? nameA : nameB}
+            >
+              {kick.scored ? '✓' : '✗'}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {phase === 'penalties' && state && !penaltiesComplete(state) && (
+        <Button
+          variant="outline"
+          disabled={append.isPending}
+          onClick={() => append.mutate({ kind: 'Period', period: 'penalties_complete' })}
+        >
+          End penalties
+        </Button>
+      )}
+
+      {continuationAvailable && (
+        <div className="flex flex-col gap-2">
+          <Button size="lg" disabled={append.isPending} onClick={handleHalfFt}>
+            {nextPhaseActionLabel(phase, progressionCtx)}
           </Button>
-          {finishMatch.isError && (
-            <p className="text-center text-xs text-destructive">
-              {(finishMatch.error as Error).message}
-            </p>
-          )}
-        </>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={finishMatch.isPending}
+            onClick={() => finishMatch.mutate()}
+          >
+            Or finish as a draw
+          </Button>
+        </div>
+      )}
+
+      {readyToFinish && (
+        <Button size="lg" disabled={finishMatch.isPending} onClick={() => finishMatch.mutate()}>
+          {finishMatch.isPending ? 'Finishing…' : 'Finish match'}
+        </Button>
+      )}
+
+      {finishMatch.isError && (
+        <p className="text-center text-xs text-destructive">
+          {(finishMatch.error as Error).message}
+        </p>
       )}
 
       <Link

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useNavigate, useParams, Link } from 'react-router-dom'
 import { ChevronLeft, CircleDot, Flag, Repeat2, TimerReset } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
@@ -24,6 +24,7 @@ import {
 } from '@/lib/liveScore'
 
 type Match = components['schemas']['Match']
+type UpdateMatchInput = components['schemas']['UpdateMatchInput']
 
 function sideName(match: Match, index: number, fallback: string): string {
   return match.sides[index]?.name?.trim() || fallback
@@ -101,6 +102,46 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
 
   const prefs = loadTrackPrefs(match.id)
   const [dialogKind, setDialogKind] = useState<EventKind | null>(null)
+
+  // Concludes the match once full-time is recorded: submits the goal tally
+  // as a `Simple` score (the same shape `MatchResultEditor` writes) and
+  // marks the match `completed`, the way a manual "Add result" would — so it
+  // enters the normal confirmation flow rather than being auto-confirmed.
+  // No `detailed_score` here: the goals/cards/subs/period markers recorded
+  // live are already persisted against the match as they happened. Reads
+  // `detailedScore.data` directly (rather than closing over the `state`
+  // computed below) so this hook can be declared before the loading early
+  // return, same as every other hook in this component.
+  const finishMatch = useMutation({
+    mutationFn: async () => {
+      const detail = footballDetailFrom(detailedScore.data)
+      const goalsFor = (sideId: string | undefined) =>
+        detail?.score.find((s) => s.side_id === sideId)?.goals ?? 0
+      const aId = match.sides[0]?.id ?? ''
+      const bId = match.sides[1]?.id ?? ''
+      const a = goalsFor(aId)
+      const b = goalsFor(bId)
+      const score = {
+        type: 'Simple',
+        entries: [
+          { side_id: aId, points: a },
+          { side_id: bId, points: b },
+        ],
+      } as unknown as UpdateMatchInput['score']
+      const body: UpdateMatchInput = { score, status: 'completed' }
+      if (a !== b) body.winner_side_id = a > b ? aId : bId
+      const { error } = await fetchClient.PATCH('/matches/{match_id}', {
+        params: { path: { match_id: match.id } },
+        body,
+      })
+      if (error) throw new Error('Failed to finish the match')
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['match', match.id] })
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
+      navigate(`/matches/${match.id}`)
+    },
+  })
 
   if (detailedScore.isLoading || seq.isLoading) {
     return (
@@ -208,6 +249,19 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
         ))}
       </div>
 
+      {phase === 'full_time' && (
+        <>
+          <Button size="lg" disabled={finishMatch.isPending} onClick={() => finishMatch.mutate()}>
+            {finishMatch.isPending ? 'Finishing…' : 'Finish match'}
+          </Button>
+          {finishMatch.isError && (
+            <p className="text-center text-xs text-destructive">
+              {(finishMatch.error as Error).message}
+            </p>
+          )}
+        </>
+      )}
+
       <Link
         to={`/matches/${match.id}/live/setup`}
         className="text-center text-sm text-primary hover:underline"
@@ -223,15 +277,21 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
           <p className="text-sm text-muted-foreground">No events recorded yet.</p>
         ) : (
           <div className="flex flex-col gap-2">
-            {events.map((event, i) => (
-              <div key={i} className="flex items-baseline gap-2 text-sm">
-                <span className="w-8 shrink-0 text-xs text-muted-foreground">
-                  {event.minute !== undefined ? `${event.minute}'` : ''}
-                </span>
-                <span aria-hidden>{eventEmoji(event.kind)}</span>
-                <span className="min-w-0 truncate">{describeEvent(event, match)}</span>
-              </div>
-            ))}
+            {events.map((event, i) => {
+              const isSideB = event.side_id === match.sides[1]?.id
+              return (
+                <div
+                  key={i}
+                  className={`flex items-baseline gap-2 text-sm ${isSideB ? 'flex-row-reverse text-right' : ''}`}
+                >
+                  <span className="w-8 shrink-0 text-xs text-muted-foreground">
+                    {event.minute !== undefined ? `${event.minute}'` : ''}
+                  </span>
+                  <span aria-hidden>{eventEmoji(event.kind)}</span>
+                  <span className="min-w-0 truncate">{describeEvent(event, match)}</span>
+                </div>
+              )
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
Enhances live scoring pages for both football and cricket with match completion workflows and improved event display. Football now supports finishing matches once full-time is recorded, while cricket auto-ends innings when overs are exhausted. Event logs now visually align with their respective sides.

## Key Changes

**Football Live Scoring (`LiveScoringPage.tsx`)**
- Added `finishMatch` mutation to conclude matches: submits goal tally as a `Simple` score and marks match `completed`, entering the normal confirmation flow
- Displays "Finish match" button when `phase === 'full_time'`, with pending/error states
- Event log entries now align left/right based on which side recorded them (`flex-row-reverse` for side B)

**Cricket Live Scoring (`CricketLiveScoringPage.tsx`)**
- Implemented auto-end innings when over quota is exhausted: fires `overs_complete` end-of-innings event automatically via `useRef` guard to ensure it fires exactly once per innings
- Replaced manual end-reason picker UI with auto-ending flow; shows "ending the innings…" message or retry button on error
- Moved `oversComplete` calculation earlier to support the auto-end effect

**Event Description (`liveScore.ts`)**
- Removed side name from event descriptions (e.g., "Goal — J. Alvarez" instead of "Goal — J. Alvarez (Riverside)")
- Added assist player display for goals/penalties (e.g., "Goal — Alvarez (Silva)")
- Callers now convey side context via event alignment/positioning rather than text, reducing redundancy
- Updated `describeEvent` signature to remove `sides` parameter

**Event Display Components**
- `LiveScoringPage.tsx` and `LiveMatchBlock.tsx` now render events with side-aware alignment
- Events from side B display with `flex-row-reverse text-right` for visual side correspondence
- Minute marker and emoji remain positioned consistently relative to event text

**Cricket Score Description (`cricketScore.ts`)**
- Enhanced `cricketStateDescription` to distinguish between wins by wickets vs. runs
- Win by wickets only reported when chasing side's innings ended before using full over allocation
- If both sides bat out complete overs, result reported as runs margin instead
- Updated function signature to include `overs_per_innings` format parameter
- Added `overs` field to `CricketInningsTotal` interface for tracking over usage

## Implementation Details
- Football match completion reads `detailedScore.data` directly (not via closure) so the hook can be declared before loading early return, consistent with other hooks
- Cricket auto-end uses `useRef` guard rather than `isPending` dependency to avoid mid-flight retriggers
- Event alignment uses conditional `flex-row-reverse` class for clean side-based positioning

https://claude.ai/code/session_01Qa442GGpkuZLYojwJQu9Ey