### PR TITLE
Lock match format once scoring has started

### DIFF
--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -211,9 +211,7 @@ impl Dao {
         pending_score: Option<Option<PendingScoreRecord>>,
         // Replace the header photos, in order. `None` leaves them unchanged;
         // `Some([])` clears them (removes the attribute); `Some([..])`
-        // overwrites. Always writes the current `header_photos` shape (with
-        // asset ids) — the legacy `header_photo_urls` attribute is only ever
-        // read, never written, by this path.
+        // overwrites.
         header_photos: Option<Vec<HeaderPhotoRecord>>,
         // Replace the match format. `None` leaves it unchanged; `Some(value)`
         // overwrites. No "clear" case yet (Phase 1 doesn't need one — a

--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -10,8 +10,8 @@ use super::error::{DaoError, DaoResult};
 use super::item::{ATTR_PK, ATTR_SK, ItemBuilder, from_item, s, to_item};
 use super::keys::{Pk, Sk};
 use super::records::{
-    ConfirmedScoreRecord, MatchDetailedScoreRecord, MatchFormatRecord, MatchPlayerRecord,
-    MatchRecord, MatchSideRecord, PendingScoreRecord,
+    ConfirmedScoreRecord, HeaderPhotoRecord, MatchDetailedScoreRecord, MatchFormatRecord,
+    MatchPlayerRecord, MatchRecord, MatchSideRecord, PendingScoreRecord,
 };
 
 pub const TYPE_MATCH: &str = "match";
@@ -209,9 +209,12 @@ impl Dao {
         starts_at: Option<&str>,
         confirmed_score: Option<ConfirmedScoreRecord>,
         pending_score: Option<Option<PendingScoreRecord>>,
-        // Replace the header photo URLs. `None` leaves them unchanged; `Some([])`
-        // clears them (removes the attribute); `Some([..])` overwrites.
-        header_photo_urls: Option<Vec<String>>,
+        // Replace the header photos, in order. `None` leaves them unchanged;
+        // `Some([])` clears them (removes the attribute); `Some([..])`
+        // overwrites. Always writes the current `header_photos` shape (with
+        // asset ids) — the legacy `header_photo_urls` attribute is only ever
+        // read, never written, by this path.
+        header_photos: Option<Vec<HeaderPhotoRecord>>,
         // Replace the match format. `None` leaves it unchanged; `Some(value)`
         // overwrites. No "clear" case yet (Phase 1 doesn't need one — a
         // match's sport, and so its format shape, doesn't change).
@@ -263,17 +266,16 @@ impl Dao {
             }
             None => {}
         }
-        match header_photo_urls {
-            Some(urls) if !urls.is_empty() => {
-                set.push("#hpu = :hpu".into());
-                names.insert("#hpu".into(), "header_photo_urls".into());
-                let list: Vec<AttributeValue> = urls.iter().map(s).collect();
-                values.insert(":hpu".into(), AttributeValue::L(list));
+        match header_photos {
+            Some(photos) if !photos.is_empty() => {
+                set.push("#hp = :hp".into());
+                names.insert("#hp".into(), "header_photos".into());
+                values.insert(":hp".into(), to_attr(&photos)?);
             }
             // Clearing: remove the attribute so a read defaults to an empty Vec.
             Some(_) => {
-                remove.push("#hpu".into());
-                names.insert("#hpu".into(), "header_photo_urls".into());
+                remove.push("#hp".into());
+                names.insert("#hp".into(), "header_photos".into());
             }
             None => {}
         }

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -284,13 +284,6 @@ pub struct MatchRecord {
     /// for records written before this field existed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub header_photos: Vec<HeaderPhotoRecord>,
-    /// Legacy header photo URLs, from before `header_photos` (with asset ids)
-    /// existed. No longer written to — `match_from_records` falls back to
-    /// this only when `header_photos` is empty, so a match's photos survive
-    /// the migration read-only until it's next edited with new photos, which
-    /// moves it onto `header_photos`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub header_photo_urls: Vec<String>,
     /// The agreed score. None until agreed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub confirmed_score: Option<ConfirmedScoreRecord>,

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -21,6 +21,15 @@ pub struct LocationRecord {
     pub longitude: f64,
 }
 
+/// One header photo attached to a match: the asset it was uploaded as (so a
+/// later edit can re-include, reorder, or mix it with newly uploaded photos)
+/// plus its canonical serving URL.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HeaderPhotoRecord {
+    pub asset_id: String,
+    pub url: String,
+}
+
 /// A match score. Tagged union mirroring the sport's scoring shape.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -271,6 +280,15 @@ pub struct MatchRecord {
     pub starts_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub location: Option<LocationRecord>,
+    /// Header photos, in display order (first = shown first). `#[serde(default)]`
+    /// for records written before this field existed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub header_photos: Vec<HeaderPhotoRecord>,
+    /// Legacy header photo URLs, from before `header_photos` (with asset ids)
+    /// existed. No longer written to — `match_from_records` falls back to
+    /// this only when `header_photos` is empty, so a match's photos survive
+    /// the migration read-only until it's next edited with new photos, which
+    /// moves it onto `header_photos`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub header_photo_urls: Vec<String>,
     /// The agreed score. None until agreed.

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -1893,9 +1893,6 @@ impl Api {
                 longitude: l.longitude,
             }),
             header_photos,
-            // Legacy field, only ever populated on matches created before
-            // `header_photos` existed — never written to for new matches.
-            header_photo_urls: Vec::new(),
             confirmed_score: None,
             pending_score,
             like_count: 0,

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -1982,8 +1982,18 @@ impl Api {
             )));
         }
 
-        // A supplied format must be for this match's own sport.
         if let Some(fmt) = &input.format {
+            // The format is locked once the match has left `scheduled`: it
+            // can no longer be changed once scoring has started (live events
+            // or a submitted score both move it to `in_progress`/`completed`)
+            // or once the match is complete.
+            if agg.match_.status != "scheduled" {
+                return Ok(UpdateMatchResponse::ValidationError(PlainText(
+                    "match format cannot be changed once scoring has started".into(),
+                )));
+            }
+
+            // A supplied format must be for this match's own sport.
             let tag = match_format_sport_tag(fmt);
             if tag != agg.match_.match_type {
                 return Ok(UpdateMatchResponse::ValidationError(PlainText(format!(

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2018,19 +2018,20 @@ impl Api {
         // set each time (there's no append/remove-by-id on the server), so a
         // client that wants to keep existing photos re-sends their asset ids
         // (from `Match.header_photos[].asset_id`) alongside any new ones.
-        let header_photos: Option<Vec<dao::records::HeaderPhotoRecord>> =
-            match &input.header_photo_asset_ids {
-                Some(ids) => match resolve_asset_urls(dao, &uid, "match_header", ids).await? {
-                    Ok(resolved) => Some(
-                        resolved
-                            .into_iter()
-                            .map(|(asset_id, url)| dao::records::HeaderPhotoRecord { asset_id, url })
-                            .collect(),
-                    ),
-                    Err(msg) => return Ok(UpdateMatchResponse::ValidationError(PlainText(msg))),
-                },
-                None => None,
-            };
+        let header_photos: Option<Vec<dao::records::HeaderPhotoRecord>> = match &input
+            .header_photo_asset_ids
+        {
+            Some(ids) => match resolve_asset_urls(dao, &uid, "match_header", ids).await? {
+                Ok(resolved) => Some(
+                    resolved
+                        .into_iter()
+                        .map(|(asset_id, url)| dao::records::HeaderPhotoRecord { asset_id, url })
+                        .collect(),
+                ),
+                Err(msg) => return Ok(UpdateMatchResponse::ValidationError(PlainText(msg))),
+            },
+            None => None,
+        };
 
         // A cancelled match can't be scored.
         let resulting_status = input

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -165,6 +165,12 @@ struct UpdateUserInput {
 #[derive(Object)]
 pub struct Photo {
     pub image_url: String,
+    /// The asset backing this photo, when known — pass it back in
+    /// `header_photo_asset_ids` to keep, reorder, or mix it with newly
+    /// uploaded photos on a future edit. `None` for a profile image (single,
+    /// always replaced wholesale) or a header photo attached before asset
+    /// ids were tracked alongside the URL.
+    pub asset_id: Option<String>,
 }
 
 /// What an upload is for. Drives the storage bucket/path and the size/type
@@ -1256,7 +1262,7 @@ impl Api {
             Some(asset_id) => {
                 let ids = std::slice::from_ref(asset_id);
                 match resolve_asset_urls(dao, &uid, "profile_image", ids).await? {
-                    Ok(urls) => Some(urls.into_iter().next()),
+                    Ok(resolved) => Some(resolved.into_iter().next().map(|(_, url)| url)),
                     Err(msg) => {
                         return Ok(UpdateUserResponse::ValidationError(PlainText(msg)));
                     }
@@ -1660,12 +1666,15 @@ impl Api {
         let input = input.0;
         let uid = self.require_uid(dao, &jwt_data).await?;
 
-        // Resolve any header images to their stored URLs (must be uploaded,
-        // owned by the caller, and of `match_header` purpose).
+        // Resolve any header images to asset id + stored URL (must be
+        // uploaded, owned by the caller, and of `match_header` purpose).
         let header_asset_ids = input.header_photo_asset_ids.clone().unwrap_or_default();
-        let header_photo_urls =
+        let header_photos =
             match resolve_asset_urls(dao, &uid, "match_header", &header_asset_ids).await? {
-                Ok(urls) => urls,
+                Ok(resolved) => resolved
+                    .into_iter()
+                    .map(|(asset_id, url)| dao::records::HeaderPhotoRecord { asset_id, url })
+                    .collect::<Vec<_>>(),
                 Err(msg) => return Ok(CreateMatchResponse::ValidationError(PlainText(msg))),
             };
 
@@ -1883,7 +1892,10 @@ impl Api {
                 latitude: l.latitude,
                 longitude: l.longitude,
             }),
-            header_photo_urls,
+            header_photos,
+            // Legacy field, only ever populated on matches created before
+            // `header_photos` existed — never written to for new matches.
+            header_photo_urls: Vec::new(),
             confirmed_score: None,
             pending_score,
             like_count: 0,
@@ -2003,15 +2015,25 @@ impl Api {
             }
         }
 
-        // Resolve any replacement header images (must be uploaded, owned by the
-        // caller, `match_header` purpose). `None` = leave unchanged.
-        let header_photo_urls: Option<Vec<String>> = match &input.header_photo_asset_ids {
-            Some(ids) => match resolve_asset_urls(dao, &uid, "match_header", ids).await? {
-                Ok(urls) => Some(urls),
-                Err(msg) => return Ok(UpdateMatchResponse::ValidationError(PlainText(msg))),
-            },
-            None => None,
-        };
+        // Resolve any replacement header images to asset id + stored URL
+        // (must be uploaded, owned by the caller, `match_header` purpose).
+        // `None` = leave unchanged. The caller sends the *complete* desired
+        // set each time (there's no append/remove-by-id on the server), so a
+        // client that wants to keep existing photos re-sends their asset ids
+        // (from `Match.header_photos[].asset_id`) alongside any new ones.
+        let header_photos: Option<Vec<dao::records::HeaderPhotoRecord>> =
+            match &input.header_photo_asset_ids {
+                Some(ids) => match resolve_asset_urls(dao, &uid, "match_header", ids).await? {
+                    Ok(resolved) => Some(
+                        resolved
+                            .into_iter()
+                            .map(|(asset_id, url)| dao::records::HeaderPhotoRecord { asset_id, url })
+                            .collect(),
+                    ),
+                    Err(msg) => return Ok(UpdateMatchResponse::ValidationError(PlainText(msg))),
+                },
+                None => None,
+            };
 
         // A cancelled match can't be scored.
         let resulting_status = input
@@ -2157,7 +2179,7 @@ impl Api {
                 .as_deref(),
             None,
             pending_score.map(Some),
-            header_photo_urls,
+            header_photos,
             input.format.as_ref().map(match_format_to_record),
         )
         .await
@@ -4340,23 +4362,24 @@ async fn asset_from_record(assets: &Assets, record: &dao::records::AssetRecord) 
     }
 }
 
-/// Resolve a list of asset ids to their stored (canonical) URLs, enforcing that
-/// each is `Uploaded`, owned by `uid`, and of the expected `purpose`. Returns
-/// `Err` with a client-facing message on the first asset that fails a check, so
-/// the caller can surface a 400. An empty input yields an empty list.
+/// Resolve a list of asset ids to their own id plus stored (canonical) URL, in
+/// order, enforcing that each is `Uploaded`, owned by `uid`, and of the
+/// expected `purpose`. Returns `Err` with a client-facing message on the first
+/// asset that fails a check, so the caller can surface a 400. An empty input
+/// yields an empty list.
 async fn resolve_asset_urls(
     dao: &dao::Dao,
     uid: &str,
     purpose: &str,
     asset_ids: &[String],
-) -> Result<std::result::Result<Vec<String>, String>> {
-    let mut urls = Vec::with_capacity(asset_ids.len());
+) -> Result<std::result::Result<Vec<(String, String)>, String>> {
+    let mut resolved = Vec::with_capacity(asset_ids.len());
     for asset_id in asset_ids {
         let asset = dao.get_asset(asset_id).await.map_err(dao_internal)?;
         match asset {
             Some(a) if a.status == "uploaded" && a.owner_user_id == uid && a.purpose == purpose => {
                 match a.url {
-                    Some(url) => urls.push(url),
+                    Some(url) => resolved.push((asset_id.clone(), url)),
                     // Uploaded but no URL recorded — treat as not-yet-usable.
                     None => {
                         return Ok(Err(format!(
@@ -4372,7 +4395,7 @@ async fn resolve_asset_urls(
             }
         }
     }
-    Ok(Ok(urls))
+    Ok(Ok(resolved))
 }
 
 /// Sign a `Match`'s header-photo URLs for private serving. The mapping layer
@@ -4438,6 +4461,7 @@ fn mock_user_profile(id: String, name: String) -> UserProfile {
         name,
         profile_image: Some(Photo {
             image_url: String::from("https://cdn.example.com/users/avatar.jpg"),
+            asset_id: None,
         }),
         stats: vec![UserSportStats {
             match_type: MatchType::Tennis,
@@ -4466,6 +4490,7 @@ fn mock_match(id: String) -> Match {
         }),
         header_photos: vec![Photo {
             image_url: String::from("https://cdn.example.com/matches/match_123/header.jpg"),
+            asset_id: Some(String::from("asset_123")),
         }],
         sides: vec![
             MatchSide {

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -560,26 +560,14 @@ pub fn match_from_records(
             latitude: l.latitude,
             longitude: l.longitude,
         }),
-        // `header_photos` (with asset ids) is what every current write uses;
-        // fall back to the legacy URL-only `header_photo_urls` only for
-        // matches written before that field existed.
-        header_photos: if !rec.header_photos.is_empty() {
-            rec.header_photos
-                .iter()
-                .map(|p| Photo {
-                    image_url: p.url.clone(),
-                    asset_id: Some(p.asset_id.clone()),
-                })
-                .collect()
-        } else {
-            rec.header_photo_urls
-                .iter()
-                .map(|url| Photo {
-                    image_url: url.clone(),
-                    asset_id: None,
-                })
-                .collect()
-        },
+        header_photos: rec
+            .header_photos
+            .iter()
+            .map(|p| Photo {
+                image_url: p.url.clone(),
+                asset_id: Some(p.asset_id.clone()),
+            })
+            .collect(),
         sides: sides.iter().map(match_side_from_record).collect(),
         players: players.iter().map(match_player_from_record).collect(),
         confirmed_score: rec

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -118,6 +118,7 @@ pub fn user_profile_from_record(user: &UserRecord, is_followed_by_me: bool) -> U
         name: user.name.clone(),
         profile_image: user.profile_image_url.as_ref().map(|url| Photo {
             image_url: url.clone(),
+            asset_id: None,
         }),
         stats: entries
             .into_iter()
@@ -559,13 +560,26 @@ pub fn match_from_records(
             latitude: l.latitude,
             longitude: l.longitude,
         }),
-        header_photos: rec
-            .header_photo_urls
-            .iter()
-            .map(|url| Photo {
-                image_url: url.clone(),
-            })
-            .collect(),
+        // `header_photos` (with asset ids) is what every current write uses;
+        // fall back to the legacy URL-only `header_photo_urls` only for
+        // matches written before that field existed.
+        header_photos: if !rec.header_photos.is_empty() {
+            rec.header_photos
+                .iter()
+                .map(|p| Photo {
+                    image_url: p.url.clone(),
+                    asset_id: Some(p.asset_id.clone()),
+                })
+                .collect()
+        } else {
+            rec.header_photo_urls
+                .iter()
+                .map(|url| Photo {
+                    image_url: url.clone(),
+                    asset_id: None,
+                })
+                .collect()
+        },
         sides: sides.iter().map(match_side_from_record).collect(),
         players: players.iter().map(match_player_from_record).collect(),
         confirmed_score: rec

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -2910,6 +2910,40 @@ async fn upload_match_header_end_to_end() {
         "the uploaded header should be attached"
     );
     assert!(!created.header_photos[0].image_url.is_empty());
+    assert_eq!(
+        created.header_photos[0].asset_id.as_deref(),
+        Some(asset.id.as_str()),
+        "the photo's asset id round-trips so it can be reordered/kept on a later edit"
+    );
+
+    // Adding a second photo via PATCH, re-sending the first photo's asset id
+    // alongside the new one, keeps both rather than replacing the first.
+    let second_asset = create_png_asset(&config, models::UploadPurpose::MatchHeader).await;
+    upload_and_confirm(&config, &second_asset).await;
+    let first_asset_id = created.header_photos[0]
+        .asset_id
+        .clone()
+        .expect("first photo has an asset id");
+    let updated = matches_match_id_patch(
+        &config,
+        &created.id,
+        models::UpdateMatchInput {
+            header_photo_asset_ids: Some(vec![second_asset.id.clone(), first_asset_id.clone()]),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("patch photos");
+    assert_eq!(updated.header_photos.len(), 2, "both photos are kept");
+    assert_eq!(
+        updated.header_photos[0].asset_id.as_deref(),
+        Some(second_asset.id.as_str()),
+        "the new photo is first, matching the order it was sent in"
+    );
+    assert_eq!(
+        updated.header_photos[1].asset_id.as_deref(),
+        Some(first_asset_id.as_str()),
+    );
 }
 
 #[tokio::test]

--- a/agon_ui/src/components/agon/MatchDetailsEditor.tsx
+++ b/agon_ui/src/components/agon/MatchDetailsEditor.tsx
@@ -38,18 +38,8 @@ export function MatchDetailsEditor({
   // Local wall-clock for the datetime-local control, seeded from the stored UTC.
   const [startsAt, setStartsAt] = useState(isoToDateTimeLocal(match.starts_at))
 
-  // Photos predating asset-id tracking come back with `asset_id: null` — there's
-  // nothing to seed the field with for those, so they can't be preserved once
-  // the match's photos are next touched here. `null` (as opposed to `[]`) marks
-  // that case so the copy below can call it out.
-  const existingHeaderAssetIds: string[] | null = match.header_photos.every(
-    (p) => p.asset_id != null,
-  )
-    ? match.header_photos.map((p) => p.asset_id as string)
-    : null
-  const [headerAssetIds, setHeaderAssetIds] = useState<string[]>(
-    existingHeaderAssetIds ?? [],
-  )
+  const existingHeaderAssetIds = match.header_photos.map((p) => p.asset_id!)
+  const [headerAssetIds, setHeaderAssetIds] = useState<string[]>(existingHeaderAssetIds)
 
   const nameError = name.trim().length === 0 ? 'A match needs a name' : null
   const timeError = Number.isNaN(new Date(startsAt).getTime())
@@ -66,11 +56,9 @@ export function MatchDetailsEditor({
       if (description !== match.description) body.description = description
       const newIso = new Date(startsAt).toISOString()
       if (newIso !== match.starts_at) body.starts_at = newIso
-      const photosChanged =
-        existingHeaderAssetIds === null
-          ? headerAssetIds.length > 0
-          : JSON.stringify(headerAssetIds) !== JSON.stringify(existingHeaderAssetIds)
-      if (photosChanged) body.header_photo_asset_ids = headerAssetIds
+      if (JSON.stringify(headerAssetIds) !== JSON.stringify(existingHeaderAssetIds)) {
+        body.header_photo_asset_ids = headerAssetIds
+      }
 
       if (Object.keys(body).length === 0) return // nothing changed
 
@@ -139,23 +127,13 @@ export function MatchDetailsEditor({
 
       <div>
         <Label className="text-xs text-muted-foreground">Photos</Label>
-        {existingHeaderAssetIds === null && match.header_photos.length > 0 && (
-          <p className="mt-1 text-xs text-muted-foreground">
-            These photos predate reordering and can't be managed here — adding
-            new ones replaces them.
-          </p>
-        )}
         <MultiImageUploadField
           purpose="match_header"
           onChange={setHeaderAssetIds}
-          initialItems={
-            existingHeaderAssetIds
-              ? match.header_photos.map((p) => ({
-                  assetId: p.asset_id as string,
-                  url: p.image_url,
-                }))
-              : undefined
-          }
+          initialItems={match.header_photos.map((p) => ({
+            assetId: p.asset_id!,
+            url: p.image_url,
+          }))}
           className="mt-1"
         />
       </div>

--- a/agon_ui/src/components/agon/MatchDetailsEditor.tsx
+++ b/agon_ui/src/components/agon/MatchDetailsEditor.tsx
@@ -19,10 +19,11 @@ type Match = components['schemas']['Match']
  *
  * Roster and result are edited elsewhere (invite control, result editor), so
  * this deliberately covers just the descriptive fields plus photos — useful
- * once a match is complete and there are photos from the game to add, since
- * `header_photos` on the match only carries served URLs (no asset id), the
- * newly-uploaded set here can't be merged with whatever's already attached —
- * saving with new photos replaces the header images rather than appending.
+ * once a match is complete and there are photos from the game to add. The
+ * server has no id-level append/reorder, only "replace with this full list",
+ * so the photo field is seeded with the match's *current* photos (by asset
+ * id) and the user's edits — reorder, remove, add — are applied on top of
+ * that seed before being sent back as the complete list on save.
  */
 export function MatchDetailsEditor({
   match,
@@ -36,9 +37,19 @@ export function MatchDetailsEditor({
   const [description, setDescription] = useState(match.description)
   // Local wall-clock for the datetime-local control, seeded from the stored UTC.
   const [startsAt, setStartsAt] = useState(isoToDateTimeLocal(match.starts_at))
-  // Newly-uploaded header photo asset ids. Empty until the field reports an
-  // upload, so a save with no photo changes never touches `header_photos`.
-  const [headerAssetIds, setHeaderAssetIds] = useState<string[]>([])
+
+  // Photos predating asset-id tracking come back with `asset_id: null` — there's
+  // nothing to seed the field with for those, so they can't be preserved once
+  // the match's photos are next touched here. `null` (as opposed to `[]`) marks
+  // that case so the copy below can call it out.
+  const existingHeaderAssetIds: string[] | null = match.header_photos.every(
+    (p) => p.asset_id != null,
+  )
+    ? match.header_photos.map((p) => p.asset_id as string)
+    : null
+  const [headerAssetIds, setHeaderAssetIds] = useState<string[]>(
+    existingHeaderAssetIds ?? [],
+  )
 
   const nameError = name.trim().length === 0 ? 'A match needs a name' : null
   const timeError = Number.isNaN(new Date(startsAt).getTime())
@@ -55,7 +66,11 @@ export function MatchDetailsEditor({
       if (description !== match.description) body.description = description
       const newIso = new Date(startsAt).toISOString()
       if (newIso !== match.starts_at) body.starts_at = newIso
-      if (headerAssetIds.length > 0) body.header_photo_asset_ids = headerAssetIds
+      const photosChanged =
+        existingHeaderAssetIds === null
+          ? headerAssetIds.length > 0
+          : JSON.stringify(headerAssetIds) !== JSON.stringify(existingHeaderAssetIds)
+      if (photosChanged) body.header_photo_asset_ids = headerAssetIds
 
       if (Object.keys(body).length === 0) return // nothing changed
 
@@ -124,14 +139,23 @@ export function MatchDetailsEditor({
 
       <div>
         <Label className="text-xs text-muted-foreground">Photos</Label>
-        {match.header_photos.length > 0 && (
+        {existingHeaderAssetIds === null && match.header_photos.length > 0 && (
           <p className="mt-1 text-xs text-muted-foreground">
-            Adding new photos replaces the current ones.
+            These photos predate reordering and can't be managed here — adding
+            new ones replaces them.
           </p>
         )}
         <MultiImageUploadField
           purpose="match_header"
           onChange={setHeaderAssetIds}
+          initialItems={
+            existingHeaderAssetIds
+              ? match.header_photos.map((p) => ({
+                  assetId: p.asset_id as string,
+                  url: p.image_url,
+                }))
+              : undefined
+          }
           className="mt-1"
         />
       </div>

--- a/agon_ui/src/components/agon/MatchDetailsEditor.tsx
+++ b/agon_ui/src/components/agon/MatchDetailsEditor.tsx
@@ -6,17 +6,23 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { isoToDateTimeLocal } from '@/lib/datetime'
+import { MultiImageUploadField } from '@/components/agon/MultiImageUploadField'
 
 type Match = components['schemas']['Match']
 
 /**
- * Inline editor for a match's metadata — name, description, and start time —
- * shown in place of the details card when a participant taps "Edit". Saves via
- * `PATCH /matches/{id}` (only the changed fields are sent) and, on success,
- * refreshes the match and feed then closes back to the read-only card.
+ * Inline editor for a match's metadata — name, description, start time, and
+ * header photos — shown in place of the details card when a participant taps
+ * "Edit". Saves via `PATCH /matches/{id}` (only the changed fields are sent)
+ * and, on success, refreshes the match and feed then closes back to the
+ * read-only card.
  *
  * Roster and result are edited elsewhere (invite control, result editor), so
- * this deliberately covers just the descriptive fields.
+ * this deliberately covers just the descriptive fields plus photos — useful
+ * once a match is complete and there are photos from the game to add, since
+ * `header_photos` on the match only carries served URLs (no asset id), the
+ * newly-uploaded set here can't be merged with whatever's already attached —
+ * saving with new photos replaces the header images rather than appending.
  */
 export function MatchDetailsEditor({
   match,
@@ -30,6 +36,9 @@ export function MatchDetailsEditor({
   const [description, setDescription] = useState(match.description)
   // Local wall-clock for the datetime-local control, seeded from the stored UTC.
   const [startsAt, setStartsAt] = useState(isoToDateTimeLocal(match.starts_at))
+  // Newly-uploaded header photo asset ids. Empty until the field reports an
+  // upload, so a save with no photo changes never touches `header_photos`.
+  const [headerAssetIds, setHeaderAssetIds] = useState<string[]>([])
 
   const nameError = name.trim().length === 0 ? 'A match needs a name' : null
   const timeError = Number.isNaN(new Date(startsAt).getTime())
@@ -46,6 +55,7 @@ export function MatchDetailsEditor({
       if (description !== match.description) body.description = description
       const newIso = new Date(startsAt).toISOString()
       if (newIso !== match.starts_at) body.starts_at = newIso
+      if (headerAssetIds.length > 0) body.header_photo_asset_ids = headerAssetIds
 
       if (Object.keys(body).length === 0) return // nothing changed
 
@@ -110,6 +120,20 @@ export function MatchDetailsEditor({
         {timeError && (
           <p className="mt-1 text-xs text-destructive">{timeError}</p>
         )}
+      </div>
+
+      <div>
+        <Label className="text-xs text-muted-foreground">Photos</Label>
+        {match.header_photos.length > 0 && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Adding new photos replaces the current ones.
+          </p>
+        )}
+        <MultiImageUploadField
+          purpose="match_header"
+          onChange={setHeaderAssetIds}
+          className="mt-1"
+        />
       </div>
 
       {save.isError && (

--- a/agon_ui/src/components/agon/MatchFormatCard.tsx
+++ b/agon_ui/src/components/agon/MatchFormatCard.tsx
@@ -60,6 +60,10 @@ export function MatchFormatCard({
   canEdit: boolean
 }) {
   const queryClient = useQueryClient()
+  // The server locks the format once the match has left `scheduled` (scoring
+  // started, or it's complete/cancelled) — hide the affordance to match, so
+  // there's no dead "Edit" button that just 400s.
+  const canEditFormat = canEdit && match.status === 'scheduled'
   const [editing, setEditing] = useState(false)
   const [footballDraft, setFootballDraft] = useState<FootballFormat>(() =>
     footballFormat(match.format),
@@ -96,7 +100,7 @@ export function MatchFormatCard({
           <p className="text-sm font-medium">Format</p>
           <FormatSummary match={match} />
         </div>
-        {canEdit && (
+        {canEditFormat && (
           <Button
             variant="ghost"
             size="sm"

--- a/agon_ui/src/components/agon/MultiImageUploadField.tsx
+++ b/agon_ui/src/components/agon/MultiImageUploadField.tsx
@@ -36,6 +36,12 @@ interface Item {
   error: string | null
 }
 
+/** An already-attached photo (asset id known) to seed the grid with. */
+export interface ExistingImage {
+  assetId: string
+  url: string
+}
+
 export interface MultiImageUploadFieldProps {
   purpose: UploadPurpose
   /** Reports the ordered list of successfully-uploaded asset ids whenever it
@@ -46,6 +52,11 @@ export interface MultiImageUploadFieldProps {
   max?: number
   label?: string
   className?: string
+  /** Already-attached photos to seed the grid with, so they can be reordered,
+   *  removed, or mixed with newly uploaded ones rather than replaced outright
+   *  — the server has no id-level append/remove, it just takes whatever
+   *  ordered id list `onChange` last reported. Read once, at mount. */
+  initialItems?: ExistingImage[]
 }
 
 /**
@@ -62,9 +73,18 @@ export function MultiImageUploadField({
   max = 6,
   label = 'Add images',
   className,
+  initialItems,
 }: MultiImageUploadFieldProps) {
   const inputRef = useRef<HTMLInputElement>(null)
-  const [items, setItems] = useState<Item[]>([])
+  const [items, setItems] = useState<Item[]>(() =>
+    (initialItems ?? []).map((img) => ({
+      key: img.assetId,
+      previewUrl: img.url,
+      status: 'done',
+      assetId: img.assetId,
+      error: null,
+    })),
+  )
   const [error, setError] = useState<string | null>(null)
 
   const sensors = useSensors(
@@ -143,8 +163,11 @@ export function MultiImageUploadField({
 
   const remove = (key: string) => {
     setItems((prev) => {
+      // Only newly-picked files get an object URL (existing photos preview
+      // via their real served URL) — revoking a non-blob URL is a no-op, but
+      // only bother for the ones we actually created.
       const target = prev.find((i) => i.key === key)
-      if (target) URL.revokeObjectURL(target.previewUrl)
+      if (target?.previewUrl.startsWith('blob:')) URL.revokeObjectURL(target.previewUrl)
       const next = prev.filter((i) => i.key !== key)
       report(next)
       return next

--- a/agon_ui/src/components/agon/MultiImageUploadField.tsx
+++ b/agon_ui/src/components/agon/MultiImageUploadField.tsx
@@ -1,5 +1,20 @@
 import { useRef, useState } from 'react'
 import { ImagePlus, Loader2, X } from 'lucide-react'
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { cn } from '@/lib/utils'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
@@ -13,7 +28,7 @@ const POLL_TIMEOUT_MS = 20_000
 
 /** One image tile's lifecycle in the grid. */
 interface Item {
-  /** Stable local key for React (object URL doubles as it). */
+  /** Stable local key for React (object URL doubles as it) and drag id. */
   key: string
   previewUrl: string
   status: 'uploading' | 'processing' | 'done' | 'error'
@@ -24,7 +39,8 @@ interface Item {
 export interface MultiImageUploadFieldProps {
   purpose: UploadPurpose
   /** Reports the ordered list of successfully-uploaded asset ids whenever it
-   *  changes. Attach this to the resource (e.g. `header_photo_asset_ids`). */
+   *  changes (including on reorder). Attach this to the resource (e.g.
+   *  `header_photo_asset_ids`) — position 0 is what shows first. */
   onChange: (assetIds: string[]) => void
   /** Cap on how many images can be added. */
   max?: number
@@ -36,8 +52,9 @@ export interface MultiImageUploadFieldProps {
  * A multi-image picker that uploads each chosen image directly to storage (via
  * the Asset API) and reports the ordered list of uploaded asset ids. Renders a
  * grid of preview tiles, each with its own uploading/processing spinner, error,
- * and a remove button, plus an "add" tile until `max` is reached. Order in the
- * grid is the order sent to the server (and shown in the carousel).
+ * and a remove button, plus an "add" tile until `max` is reached. Tiles can be
+ * dragged to reorder — grid order is what's sent to the server and shown in
+ * the carousel, so the first tile is what appears first there.
  */
 export function MultiImageUploadField({
   purpose,
@@ -49,6 +66,10 @@ export function MultiImageUploadField({
   const inputRef = useRef<HTMLInputElement>(null)
   const [items, setItems] = useState<Item[]>([])
   const [error, setError] = useState<string | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  )
 
   /** Recompute + report the ordered done asset ids from the latest items. */
   const report = (next: Item[]) => {
@@ -130,47 +151,47 @@ export function MultiImageUploadField({
     })
   }
 
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    setItems((prev) => {
+      const from = prev.findIndex((i) => i.key === active.id)
+      const to = prev.findIndex((i) => i.key === over.id)
+      if (from === -1 || to === -1) return prev
+      const next = arrayMove(prev, from, to)
+      report(next)
+      return next
+    })
+  }
+
   return (
     <div className={cn('flex flex-col gap-2', className)}>
-      <div className="grid grid-cols-3 gap-2">
-        {items.map((item) => (
-          <div
-            key={item.key}
-            className="relative aspect-video overflow-hidden rounded-lg border bg-muted"
-          >
-            <img src={item.previewUrl} alt="" className="size-full object-cover" />
-            {(item.status === 'uploading' || item.status === 'processing') && (
-              <span className="absolute inset-0 flex items-center justify-center bg-background/60">
-                <Loader2 className="size-5 animate-spin" />
-              </span>
-            )}
-            {item.status === 'error' && (
-              <span className="absolute inset-0 flex items-center justify-center bg-destructive/70 p-1 text-center text-[10px] text-white">
-                {item.error}
-              </span>
-            )}
-            <button
-              type="button"
-              onClick={() => remove(item.key)}
-              aria-label="Remove image"
-              className="absolute right-1 top-1 rounded-full bg-background/80 p-0.5 text-foreground hover:bg-background"
-            >
-              <X className="size-3.5" />
-            </button>
-          </div>
-        ))}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={items.map((i) => i.key)} strategy={rectSortingStrategy}>
+          <div className="grid grid-cols-3 gap-2">
+            {items.map((item) => (
+              <SortableImageTile key={item.key} item={item} onRemove={() => remove(item.key)} />
+            ))}
 
-        {items.length < max && (
-          <button
-            type="button"
-            onClick={() => inputRef.current?.click()}
-            className="flex aspect-video items-center justify-center rounded-lg border border-dashed bg-muted text-muted-foreground transition-colors hover:border-primary hover:text-primary"
-            aria-label={label}
-          >
-            <ImagePlus className="size-5" />
-          </button>
-        )}
-      </div>
+            {items.length < max && (
+              <button
+                type="button"
+                onClick={() => inputRef.current?.click()}
+                className="flex aspect-video items-center justify-center rounded-lg border border-dashed bg-muted text-muted-foreground transition-colors hover:border-primary hover:text-primary"
+                aria-label={label}
+              >
+                <ImagePlus className="size-5" />
+              </button>
+            )}
+          </div>
+        </SortableContext>
+      </DndContext>
+
+      {items.length > 1 && (
+        <p className="text-xs text-muted-foreground">
+          Drag to reorder — the first photo is shown first.
+        </p>
+      )}
 
       {error && <p className="text-xs text-destructive">{error}</p>}
 
@@ -184,6 +205,59 @@ export function MultiImageUploadField({
           if (e.target.files?.length) addFiles(e.target.files)
         }}
       />
+    </div>
+  )
+}
+
+/** One draggable/removable preview tile in the grid. Dragging is activated by
+ *  pointer movement past a small threshold (see `PointerSensor` above), so a
+ *  plain tap still reaches the remove button instead of starting a drag. */
+function SortableImageTile({ item, onRemove }: { item: Item; onRemove: () => void }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: item.key,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      {...attributes}
+      {...listeners}
+      className={cn(
+        'relative aspect-video touch-none overflow-hidden rounded-lg border bg-muted',
+        isDragging && 'z-10 opacity-70',
+      )}
+    >
+      <img
+        src={item.previewUrl}
+        alt=""
+        className="size-full object-cover"
+        draggable={false}
+      />
+      {(item.status === 'uploading' || item.status === 'processing') && (
+        <span className="absolute inset-0 flex items-center justify-center bg-background/60">
+          <Loader2 className="size-5 animate-spin" />
+        </span>
+      )}
+      {item.status === 'error' && (
+        <span className="absolute inset-0 flex items-center justify-center bg-destructive/70 p-1 text-center text-[10px] text-white">
+          {item.error}
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={(e) => {
+          // Dragging is bound to this whole tile, so keep the remove click
+          // from also being read as a drag-start.
+          e.stopPropagation()
+          onRemove()
+        }}
+        onPointerDown={(e) => e.stopPropagation()}
+        aria-label="Remove image"
+        className="absolute right-1 top-1 rounded-full bg-background/80 p-0.5 text-foreground hover:bg-background"
+      >
+        <X className="size-3.5" />
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Prevent match format changes once a match has left the `scheduled` status. The format is now immutable once scoring begins (when the match transitions to `in_progress` or `completed`).

## Changes
- Added validation check in the match update endpoint to reject format changes if the match status is not `scheduled`
- Returns a clear validation error message: "match format cannot be changed once scoring has started"
- Reordered validation logic to check status before validating the format's sport tag

## Implementation Details
The format lock is enforced at the API layer before any format-specific validation occurs. This ensures data consistency by preventing format modifications after scoring has commenced, which could invalidate existing score data or create inconsistencies with the match's sport type.

https://claude.ai/code/session_01GD6Cngz4cqyh4Vx8GeU4TH