### PR TITLE
Only count confirmed match scores toward player stats

### DIFF
--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -111,7 +111,9 @@ struct Api;
 pub struct UserSportStats {
     pub match_type: MatchType,
     pub matches_played: i32,
-    pub win_percentage: f32,
+    /// `None` when no confirmed matches have been played yet — display as
+    /// "-", not 0%.
+    pub win_percentage: Option<f32>,
     // TODO Elo
 }
 
@@ -4432,7 +4434,7 @@ fn mock_user_profile(id: String, name: String) -> UserProfile {
         stats: vec![UserSportStats {
             match_type: MatchType::Tennis,
             matches_played: 12,
-            win_percentage: 58.3,
+            win_percentage: Some(58.3),
         }],
         follower_count: 42,
         following_count: 17,

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -132,9 +132,9 @@ pub fn user_profile_from_record(user: &UserRecord, is_followed_by_me: bool) -> U
 /// Map a stored per-sport stats record to the API model, deriving win %.
 pub fn sport_stats_from_record(sport: &str, rec: &UserSportStatsRecord) -> UserSportStats {
     let win_percentage = if rec.matches_played == 0 {
-        0.0
+        None
     } else {
-        (rec.wins as f32 / rec.matches_played as f32) * 100.0
+        Some((rec.wins as f32 / rec.matches_played as f32) * 100.0)
     };
     UserSportStats {
         match_type: match_type_from_tag(sport),

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -1000,8 +1000,35 @@ async fn accepting_a_normal_invite_updates_feed_and_stats() {
 
     // The match is now on the accepter's feed...
     assert_match_reaches_feed(&invitee_config, &created.id, "invitee's feed").await;
-    // ...and their stats credit the completed match they played in (they were on
-    // the losing side, so one played, zero wins).
+
+    // Stats aren't credited yet: the creator's score is still an unconfirmed
+    // submission, and an unconfirmed game doesn't count as played.
+    assert_eq!(
+        my_matches_played(&invitee_config, models::MatchType::Tennis).await,
+        0,
+        "an unconfirmed score shouldn't count toward matches played"
+    );
+
+    // Now the invitee (side "b") confirms the creator's submitted score.
+    let submission_id = created
+        .pending_score
+        .as_ref()
+        .expect("pending score at create time")
+        .submission_id
+        .clone();
+    matches_match_id_score_submissions_submission_id_respond_post(
+        &invitee_config,
+        &created.id,
+        &submission_id,
+        models::RespondToScoreInput {
+            response: models::ScoreResponseKind::Confirm,
+        },
+    )
+    .await
+    .expect("confirm score");
+
+    // ...and their stats now credit the confirmed match they played in (they
+    // were on the losing side, so one played, zero wins).
     assert_matches_played_reaches(&invitee_config, models::MatchType::Tennis, 1, "invitee").await;
     let stats = users_me_get(&invitee_config)
         .await
@@ -1012,7 +1039,11 @@ async fn accepting_a_normal_invite_updates_feed_and_stats() {
         .iter()
         .find(|s| s.match_type == models::MatchType::Tennis)
         .expect("a tennis stat row");
-    assert_eq!(tennis.win_percentage, 0.0, "invitee was on the losing side");
+    assert_eq!(
+        tennis.win_percentage,
+        Some(0.0),
+        "invitee was on the losing side"
+    );
 }
 
 /// End-to-end for the *invite-link* (bearer token) acceptance flow into an
@@ -1052,8 +1083,33 @@ async fn accepting_a_link_invite_updates_feed_and_stats() {
         models::InvitationStatus::Accepted
     ));
 
-    // The match is on the accepter's feed and their stats credit the match.
+    // The match is on the accepter's feed, but their stats aren't credited
+    // yet: the creator's score is still an unconfirmed submission.
     assert_match_reaches_feed(&accepter_config, &created.id, "token-accepter's feed").await;
+    assert_eq!(
+        my_matches_played(&accepter_config, models::MatchType::Tennis).await,
+        0,
+        "an unconfirmed score shouldn't count toward matches played"
+    );
+
+    // The accepter (side "b") confirms the creator's submitted score, and only
+    // then does it credit the match.
+    let submission_id = created
+        .pending_score
+        .as_ref()
+        .expect("pending score at create time")
+        .submission_id
+        .clone();
+    matches_match_id_score_submissions_submission_id_respond_post(
+        &accepter_config,
+        &created.id,
+        &submission_id,
+        models::RespondToScoreInput {
+            response: models::ScoreResponseKind::Confirm,
+        },
+    )
+    .await
+    .expect("confirm score");
     assert_matches_played_reaches(
         &accepter_config,
         models::MatchType::Tennis,

--- a/agon_ui/src/lib/stats.ts
+++ b/agon_ui/src/lib/stats.ts
@@ -9,21 +9,25 @@ export function totalMatches(stats: UserSportStats[]): number {
 
 /**
  * Overall win rate (0–100) across all sports, weighted by matches played — the
- * per-sport `win_percentage` values can't just be averaged. Returns 0 when no
- * matches have been played.
+ * per-sport `win_percentage` values can't just be averaged. Returns `null`
+ * when no confirmed matches have been played (nothing to divide by).
  */
-export function overallWinRate(stats: UserSportStats[]): number {
+export function overallWinRate(stats: UserSportStats[]): number | null {
   const played = totalMatches(stats)
-  if (played === 0) return 0
+  if (played === 0) return null
   const wins = stats.reduce(
-    (sum, s) => sum + (s.win_percentage / 100) * s.matches_played,
+    (sum, s) => sum + ((s.win_percentage ?? 0) / 100) * s.matches_played,
     0,
   )
   return (wins / played) * 100
 }
 
-/** Format a 0–100 win percentage for display, e.g. 58.3 → "58%". */
-export function formatWinRate(pct: number): string {
+/**
+ * Format a 0–100 win percentage for display, e.g. 58.3 → "58%". `null`/
+ * `undefined` (no confirmed matches yet) renders as "-", not "0%".
+ */
+export function formatWinRate(pct: number | null | undefined): string {
+  if (pct == null) return '-'
   return `${Math.round(pct)}%`
 }
 

--- a/agon_worker/src/handlers/stats.rs
+++ b/agon_worker/src/handlers/stats.rs
@@ -2,10 +2,11 @@
 //!
 //! On any write to a match's `#META`, we recompute what the match *currently*
 //! contributes to each participant's stats and reconcile it (see
-//! [`Dao::reconcile_match_contribution`]): a completed match contributes
-//! `played` for everyone who actually played and `won` for the winning side;
-//! anything else (scheduled, cancelled, roster/score change) is reconciled to
-//! its new value, backing out stale contributions.
+//! [`Dao::reconcile_match_contribution`]): a match with a **confirmed** score
+//! contributes `played` for everyone who actually played and `won` for the
+//! winning side; anything else (scheduled, cancelled, pending/disputed score,
+//! roster change) is reconciled to its new value, backing out stale
+//! contributions.
 //!
 //! **Idempotency / correctness**: the worker sees a match-meta event on *every*
 //! write to it (status changes, but also each like/comment counter bump), and
@@ -49,21 +50,20 @@ pub async fn reconcile_match_stats(dao: &Dao, match_id: &str) -> WorkerResult<()
         return Ok(());
     };
 
-    let completed = agg.match_.status == "completed";
+    // A match only contributes to stats once its score is confirmed — a
+    // completed-but-pending (or disputed) score isn't agreed yet, and counting
+    // it would inflate `matches_played` with no corresponding win, dragging
+    // down (or zeroing) the win rate for a game nobody has actually lost.
+    let confirmed_score = agg.match_.confirmed_score.as_ref();
     let sport = agg.match_.match_type.clone();
-    // The confirmed winner's side, if a score has been agreed.
-    let winner_side_id = agg
-        .match_
-        .confirmed_score
-        .as_ref()
-        .and_then(|cs| cs.winner_side_id.clone());
+    let winner_side_id = confirmed_score.and_then(|cs| cs.winner_side_id.clone());
 
     // Desired `won` per participant who actually played, keyed by user id.
-    // "Played" = a completed match where the player is the creator/self-added
-    // (no embedded invitation) or an accepted invitee. Pending/declined invitees
-    // are on the roster but didn't play.
+    // "Played" = a match with a confirmed score where the player is the
+    // creator/self-added (no embedded invitation) or an accepted invitee.
+    // Pending/declined invitees are on the roster but didn't play.
     let mut desired: std::collections::BTreeMap<String, bool> = Default::default();
-    if completed {
+    if confirmed_score.is_some() {
         for player in &agg.players {
             let Some(user_id) = &player.user_id else {
                 continue;


### PR DESCRIPTION
## Summary
Match statistics (matches played, win percentage) are now only credited once a match score is confirmed by both players, rather than when the match is completed. This prevents unconfirmed or disputed scores from inflating match counts and distorting win rates.

## Changes

### Backend (Stats Reconciliation)
- **agon_worker/src/handlers/stats.rs**: Updated match stats reconciliation logic to check for a confirmed score (`confirmed_score.is_some()`) rather than just match completion status. A match with a pending or disputed score no longer contributes to player stats until both sides agree.

### API Model
- **agon_service/src/main.rs**: Changed `UserSportStats.win_percentage` from `f32` to `Option<f32>` to distinguish between "no confirmed matches played" (None) and "played but lost all" (Some(0.0)). Updated mock data accordingly.
- **agon_service/src/mapping.rs**: Updated `sport_stats_from_record()` to return `None` when `matches_played == 0`, otherwise `Some(win_percentage)`.

### Frontend (UI)
- **agon_ui/src/lib/stats.ts**: 
  - `overallWinRate()` now returns `number | null` instead of `number`, returning `null` when no confirmed matches exist (instead of 0).
  - `formatWinRate()` now accepts `number | null | undefined` and renders `null`/`undefined` as "-" rather than "0%", clarifying the distinction between "no data" and "0% win rate".

### Tests
- **agon_tests/tests/api.rs**: Updated two integration tests (`accepting_a_normal_invite_updates_feed_and_stats` and `accepting_a_link_invite_updates_feed_and_stats`) to:
  - Assert that stats are not credited until the score is confirmed
  - Explicitly confirm the creator's score submission before checking stats
  - Update assertions to expect `win_percentage: Some(0.0)` instead of `0.0`

## Implementation Details
The change ensures that a player's stats only reflect matches they have actually agreed to, preventing scenarios where an unconfirmed loss would count toward `matches_played` but not `wins`, artificially lowering win rates. The optional `win_percentage` type makes it clear in the API whether a player has no confirmed matches (None) versus a confirmed 0% win rate.

https://claude.ai/code/session_01Cecwa3rnvFb13fspa8JkFq