### PR TITLE
Exclude /api/* routes from service worker navigation fallback

### DIFF
--- a/agon_ui/vite.config.ts
+++ b/agon_ui/vite.config.ts
@@ -60,7 +60,13 @@ export default defineConfig({
         // which is exactly how an old Supabase project URL survived a redeploy.
         // Exclude it from the precache and never let the SW serve a cached copy.
         globIgnores: ['**/runtime-env*.js'],
-        navigateFallbackDenylist: [/runtime-env/],
+        // Also exclude /api/* from the SPA navigation fallback: without this,
+        // a direct browser navigation to e.g. /api/docs (not in the precache)
+        // is intercepted by the service worker and served the app shell
+        // instead of hitting the backend, and the app's catch-all route then
+        // bounces it to /feed. Only affects navigations (address bar/links),
+        // not fetch() calls the already-loaded UI makes to the API.
+        navigateFallbackDenylist: [/runtime-env/, /^\/api\//],
         runtimeCaching: [
           {
             urlPattern: /\/assets\/runtime-env.*\.js$/,


### PR DESCRIPTION
## Summary
Prevents the service worker from intercepting direct browser navigations to API routes (e.g., `/api/docs`) and serving the app shell instead. This ensures backend API endpoints are properly reached rather than being caught by the SPA's catch-all route.

## Changes
- Updated `navigateFallbackDenylist` in `vite.config.ts` to exclude `/api/*` routes from service worker interception
- Added detailed comment explaining the rationale: without this exclusion, direct navigations to API routes would be served the app shell and bounced to `/feed` by the app's catch-all route
- Clarified that this only affects navigations (address bar/links), not fetch() calls from the already-loaded UI

## Implementation Details
The service worker's navigation fallback is now configured to deny both:
- `/runtime-env/` (existing, for runtime environment configuration)
- `/^\/api\//` (new, for all API routes)

This allows the backend to handle API requests directly while still providing the app shell for SPA navigation to UI routes.

https://claude.ai/code/session_01UkRXB3vew28if11vW9Yyh3