### PR TITLE
Log the underlying DaoError before mapping it to a 500

### DIFF
--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -5,6 +5,7 @@
 //! thin and the coupling lives in one file.
 
 use poem::error::InternalServerError;
+use tracing::error;
 
 use crate::detailed_score::cricket::{
     CricketBattingEntry, CricketBowlingEntry, CricketDelivery, CricketDeliveryExtra,
@@ -74,7 +75,11 @@ pub fn parse_ts_opt(raw: &Option<String>) -> Option<chrono::DateTime<chrono::Utc
 
 /// Map an unexpected `DaoError` to a 500. Handlers deal with the *expected*
 /// variants (Conflict/NotFound) explicitly by matching before calling this.
+/// Logs the underlying error first — `InternalServerError` on its own gives
+/// the client (and, until now, our own logs) nothing but a bare 500, which
+/// makes anything unexpected here unreproducible after the fact.
 pub fn dao_internal(err: DaoError) -> poem::Error {
+    error!("DAO error: {err}");
     InternalServerError(err)
 }
 


### PR DESCRIPTION
## What

`dao_internal` (the function every unexpected `DaoError` in the service gets funneled through before becoming a 500) silently discarded the error instead of logging it. `InternalServerError(err)` on its own gave the client — and, until now, our own logs — nothing but a bare 500, with no way to reproduce or diagnose it after the fact.

This came up debugging a live `/feed` 500 on staging after the [Score/DetailedScore merge](https://github.com/JElgar/agon/pull/46) went out: the logs showed only `"Request complete", "path":"/feed", "status":500` with nothing else nearby, because there was genuinely nothing else being logged.

## Change

Log the `DaoError` immediately before wrapping it:

```rust
pub fn dao_internal(err: DaoError) -> poem::Error {
    error!("DAO error: {err}");
    InternalServerError(err)
}
```

## Verification

- `cargo build -p agon_core -p agon_service`
- `cargo test -p agon_core -p agon_service`
- `cargo clippy -p agon_core -p agon_service --all-targets`
- `cargo fmt --check -p agon_core -p agon_service`

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwKvm6exbmejxPmsxBz657)_