### PR TITLE
Expand bowling figures table to separate columns

### DIFF
--- a/agon_ui/src/components/agon/CricketScorecard.tsx
+++ b/agon_ui/src/components/agon/CricketScorecard.tsx
@@ -1,6 +1,5 @@
 import type { components } from '@/types/api'
 import {
-  bowlingFigures,
   dismissalLabel,
   formatOvers,
   playerNameFor,
@@ -110,14 +109,20 @@ function InningsCard({ match, innings }: { match: Match; innings: CricketInnings
           <TableHeader>
             <TableRow>
               <TableHead>Bowler</TableHead>
-              <TableHead className="text-right">O-M-R-W</TableHead>
+              <TableHead className="text-right">O</TableHead>
+              <TableHead className="text-right">M</TableHead>
+              <TableHead className="text-right">R</TableHead>
+              <TableHead className="text-right">W</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {bowling.map((bw: CricketBowlingEntry) => (
               <TableRow key={bw.player_id}>
                 <TableCell className="font-medium">{playerNameFor(match, bw.player_id)}</TableCell>
-                <TableCell className="text-right tabular-nums">{bowlingFigures(bw)}</TableCell>
+                <TableCell className="text-right tabular-nums">{formatOvers(bw.overs)}</TableCell>
+                <TableCell className="text-right tabular-nums">{bw.maidens}</TableCell>
+                <TableCell className="text-right tabular-nums">{bw.runs_conceded}</TableCell>
+                <TableCell className="text-right tabular-nums">{bw.wickets}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -256,13 +256,6 @@ export function creditsBowler(kind: CricketDismissalKind): boolean {
   )
 }
 
-/** "3.2-0-24-1" bowling figures (overs-maidens-runs-wickets), or an em dash
- *  before the bowler has sent down a delivery. */
-export function bowlingFigures(entry: CricketBowlingEntry | null): string {
-  if (!entry) return '—'
-  return `${formatOvers(entry.overs)}-${entry.maidens}-${entry.runs_conceded}-${entry.wickets}`
-}
-
 /** Total runs scored by each side across every completed innings so far —
  *  the input to a final result once the match is done (sums across both
  *  innings for a two-innings-per-side format, not just the latest one). */


### PR DESCRIPTION
## Summary
Refactored the cricket scorecard bowling figures display from a single concatenated column to four separate columns (Overs, Maidens, Runs, Wickets), improving readability and data presentation.

## Changes
- **CricketScorecard.tsx**: Split the bowling figures table header from a single "O-M-R-W" column into four distinct columns, one for each statistic
- **CricketScorecard.tsx**: Updated the bowling entry row rendering to display each figure in its own cell instead of using the `bowlingFigures()` helper
- **cricketScore.ts**: Removed the `bowlingFigures()` utility function, which is no longer needed with the expanded column layout

## Implementation Details
- Each bowling statistic now has its own `TableCell` with consistent right-alignment and tabular number formatting
- The `formatOvers()` helper is still used for the overs column to maintain consistent formatting
- Other bowling entry properties (`maidens`, `runs_conceded`, `wickets`) are displayed directly as numeric values

https://claude.ai/code/session_01UDA8DUdyTuFiQAmTgwYXwp