### PR TITLE
Add item key and type context to deserialization errors

### DIFF
--- a/agon_core/src/dao/error.rs
+++ b/agon_core/src/dao/error.rs
@@ -23,9 +23,26 @@ pub enum DaoError {
     #[error(transparent)]
     Key(#[from] KeyError),
 
-    /// (De)serialization between items and structs failed.
+    /// (De)serialization not tied to a specific stored item (e.g. a pagination
+    /// cursor's key map) failed. Reads of an actual item go through
+    /// [`SerdeItem`](DaoError::SerdeItem) instead, which carries enough to
+    /// find the offending row without a table scan.
     #[error("serialization error: {0}")]
     Serde(#[from] serde_dynamo::Error),
+
+    /// A stored item failed to deserialize into its expected record type.
+    /// Carries the item's key and target type alongside the underlying
+    /// serde error, so the log line alone is enough to go find and fix the
+    /// offending item — no separate diagnostic scan needed. See
+    /// `dao::item::from_item`, the sole place this is constructed.
+    #[error("serialization error deserializing {type_name} from {pk}/{sk}: {source}")]
+    SerdeItem {
+        type_name: &'static str,
+        pk: String,
+        sk: String,
+        #[source]
+        source: serde_dynamo::Error,
+    },
 
     /// Any underlying DynamoDB error not otherwise classified.
     #[error("dynamodb error: {0}")]

--- a/agon_core/src/dao/item.rs
+++ b/agon_core/src/dao/item.rs
@@ -42,8 +42,38 @@ pub fn to_item<T: Serialize>(pk: &Pk, sk: &Sk, type_tag: &str, data: &T) -> DaoR
 
 /// Deserialize a stored item map back into a data struct. The `PK`/`SK`/`type`
 /// and GSI attributes are ignored (the struct doesn't declare them).
+///
+/// On failure, the error carries the item's `PK`/`SK` and the target type
+/// name (peeked before `item` is consumed below) — e.g. a stray legacy value
+/// somewhere in a match's stored score shows up in the logs as exactly which
+/// match failed and which type it failed deserializing into, not just a bare
+/// "invalid type" message with no way to find the row it came from.
 pub fn from_item<T: DeserializeOwned>(item: Item) -> DaoResult<T> {
-    Ok(serde_dynamo::from_item(item)?)
+    let pk = attr_s(&item, ATTR_PK);
+    let sk = attr_s(&item, ATTR_SK);
+    serde_dynamo::from_item(item).map_err(|source| DaoError::SerdeItem {
+        type_name: short_type_name::<T>(),
+        pk,
+        sk,
+        source,
+    })
+}
+
+/// Best-effort string peek at an attribute, for error context only — `"?"`
+/// if absent or not a string (never itself a reason to fail the read).
+fn attr_s(item: &Item, attr: &str) -> String {
+    match item.get(attr) {
+        Some(AttributeValue::S(v)) => v.clone(),
+        _ => "?".to_string(),
+    }
+}
+
+/// `T`'s type name with the module path stripped (`agon_core::dao::records::
+/// MatchRecord` -> `MatchRecord`) — plenty to identify the record shape in a
+/// log line without the noise.
+fn short_type_name<T>() -> &'static str {
+    let full = std::any::type_name::<T>();
+    full.rsplit("::").next().unwrap_or(full)
 }
 
 /// Fluent helper to add GSI projection keys onto an item after [`to_item`].
@@ -104,4 +134,70 @@ pub fn item_sk(item: &Item) -> DaoResult<Sk> {
 /// Convenience: a string AttributeValue.
 pub fn s(v: impl Into<String>) -> AttributeValue {
     AttributeValue::S(v.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+    use crate::dao::error::DaoError;
+
+    /// A deserialize failure names the offending item's `PK`/`SK` and the
+    /// target type in the error, not just the bare serde message — this is
+    /// what makes an unlocatable "invalid type"-style error actually
+    /// actionable from the logs alone.
+    #[test]
+    fn from_item_error_carries_key_and_type_context() {
+        #[derive(Debug, Deserialize)]
+        struct Widget {
+            #[allow(dead_code)]
+            count: u32,
+        }
+
+        let mut item: Item = HashMap::new();
+        item.insert(ATTR_PK.into(), s("MATCH#abc123"));
+        item.insert(ATTR_SK.into(), s("#META"));
+        // `count` needs a number; a string here forces a deserialize failure.
+        item.insert("count".into(), s("not-a-number"));
+
+        let err = from_item::<Widget>(item).unwrap_err();
+        match err {
+            DaoError::SerdeItem {
+                type_name,
+                pk,
+                sk,
+                source: _,
+            } => {
+                assert_eq!(type_name, "Widget");
+                assert_eq!(pk, "MATCH#abc123");
+                assert_eq!(sk, "#META");
+            }
+            other => panic!("expected SerdeItem, got {other:?}"),
+        }
+    }
+
+    /// Missing PK/SK (shouldn't happen for a real stored item, but the error
+    /// path must not panic on it) falls back to "?" rather than failing to
+    /// construct the error itself.
+    #[test]
+    fn from_item_error_context_defaults_when_keys_absent() {
+        #[derive(Debug, Deserialize)]
+        struct Widget {
+            #[allow(dead_code)]
+            count: u32,
+        }
+
+        let mut item: Item = HashMap::new();
+        item.insert("count".into(), s("not-a-number"));
+
+        let err = from_item::<Widget>(item).unwrap_err();
+        match err {
+            DaoError::SerdeItem { pk, sk, .. } => {
+                assert_eq!(pk, "?");
+                assert_eq!(sk, "?");
+            }
+            other => panic!("expected SerdeItem, got {other:?}"),
+        }
+    }
 }

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -35,19 +35,11 @@ pub struct HeaderPhotoRecord {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ScoreRecord {
     Simple {
-        /// Points per side, keyed by side id. Accepts the pre-migration
-        /// `Vec<{side_id, points}>` shape on read (see
-        /// `deserialize_simple_entries`) so a match doesn't 500 just because
-        /// it hasn't been through `migrate_score_entries.py` yet.
-        #[serde(deserialize_with = "deserialize_simple_entries")]
+        /// Points per side, keyed by side id.
         entries: HashMap<String, u32>,
     },
     Sets {
-        /// Games won per set per side, keyed by side id. Accepts the
-        /// pre-migration `Vec<{side_id, sets}>` shape on read (see
-        /// `deserialize_sets_entries`) so a match doesn't 500 just because it
-        /// hasn't been through `migrate_score_entries.py` yet.
-        #[serde(deserialize_with = "deserialize_sets_entries")]
+        /// Games won per set per side, keyed by side id.
         entries: HashMap<String, Vec<u32>>,
     },
     Cricket {
@@ -90,64 +82,6 @@ pub enum ScoreRecord {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         penalty_shootout_score: Option<HashMap<String, u32>>,
     },
-}
-
-/// Legacy pre-migration shape for one `Simple` score entry: `{"side_id":
-/// ..., "points": ...}`. Only ever seen on read, from items written before
-/// `entries` became a side_id-keyed map.
-#[derive(Deserialize)]
-struct LegacySimpleEntry {
-    side_id: String,
-    points: u32,
-}
-
-/// Accepts `entries` as either the current side_id-keyed map or the
-/// pre-migration `Vec<{side_id, points}>` list, so a `Simple` score
-/// deserializes regardless of whether the item has been through
-/// `migrate_score_entries.py` yet. `#[serde(untagged)]` buffers the value and
-/// tries each shape in turn — cheap here since scores are small.
-fn deserialize_simple_entries<'de, D>(deserializer: D) -> Result<HashMap<String, u32>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Shape {
-        Map(HashMap<String, u32>),
-        List(Vec<LegacySimpleEntry>),
-    }
-    Ok(match Shape::deserialize(deserializer)? {
-        Shape::Map(map) => map,
-        Shape::List(list) => list.into_iter().map(|e| (e.side_id, e.points)).collect(),
-    })
-}
-
-/// Legacy pre-migration shape for one `Sets` score entry: `{"side_id": ...,
-/// "sets": [...]}`. Only ever seen on read, from items written before
-/// `entries` became a side_id-keyed map.
-#[derive(Deserialize)]
-struct LegacySetsEntry {
-    side_id: String,
-    sets: Vec<u32>,
-}
-
-/// Accepts `entries` as either the current side_id-keyed map or the
-/// pre-migration `Vec<{side_id, sets}>` list — see
-/// `deserialize_simple_entries`, the `Simple`-score counterpart.
-fn deserialize_sets_entries<'de, D>(deserializer: D) -> Result<HashMap<String, Vec<u32>>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum Shape {
-        Map(HashMap<String, Vec<u32>>),
-        List(Vec<LegacySetsEntry>),
-    }
-    Ok(match Shape::deserialize(deserializer)? {
-        Shape::Map(map) => map,
-        Shape::List(list) => list.into_iter().map(|e| (e.side_id, e.sets)).collect(),
-    })
 }
 
 /// One innings' final totals, as stored on a match's confirmed/pending
@@ -1030,7 +964,10 @@ mod tests {
     use aws_sdk_dynamodb::types::AttributeValue;
 
     /// `Simple`/`Sets` `entries` round-trip through the side_id-keyed map
-    /// shape — the shape every write produces today.
+    /// shape. (Data written before this shape landed no longer needs
+    /// handling here — see `migrate_score_entries.py`, the one-off script
+    /// that backfilled every match's `confirmed_score`/`pending_score`/
+    /// score-submission history to this shape.)
     #[test]
     fn simple_map_shape_deserializes() {
         let map_shape = AttributeValue::M(HashMap::from([
@@ -1040,37 +977,6 @@ mod tests {
         let score_av = AttributeValue::M(HashMap::from([
             ("type".to_string(), AttributeValue::S("simple".into())),
             ("entries".to_string(), map_shape),
-        ]));
-        let rec: ScoreRecord = serde_dynamo::from_attribute_value(score_av).unwrap();
-        match rec {
-            ScoreRecord::Simple { entries } => {
-                assert_eq!(entries.get("sideA"), Some(&6));
-                assert_eq!(entries.get("sideB"), Some(&3));
-            }
-            _ => panic!("expected simple"),
-        }
-    }
-
-    /// `Simple` `entries` also deserializes from the pre-migration
-    /// `Vec<{side_id, points}>` list shape, so a match written before the
-    /// side_id-keyed map landed still reads (e.g. from the API's feed/match
-    /// endpoints) even if `migrate_score_entries.py` hasn't reached it yet —
-    /// see `deserialize_simple_entries`.
-    #[test]
-    fn simple_legacy_list_shape_deserializes() {
-        let list_shape = AttributeValue::L(vec![
-            AttributeValue::M(HashMap::from([
-                ("side_id".to_string(), AttributeValue::S("sideA".into())),
-                ("points".to_string(), AttributeValue::N("6".into())),
-            ])),
-            AttributeValue::M(HashMap::from([
-                ("side_id".to_string(), AttributeValue::S("sideB".into())),
-                ("points".to_string(), AttributeValue::N("3".into())),
-            ])),
-        ]);
-        let score_av = AttributeValue::M(HashMap::from([
-            ("type".to_string(), AttributeValue::S("simple".into())),
-            ("entries".to_string(), list_shape),
         ]));
         let rec: ScoreRecord = serde_dynamo::from_attribute_value(score_av).unwrap();
         match rec {
@@ -1094,35 +1000,6 @@ mod tests {
         let score_av = AttributeValue::M(HashMap::from([
             ("type".to_string(), AttributeValue::S("sets".into())),
             ("entries".to_string(), map_shape),
-        ]));
-        let rec: ScoreRecord = serde_dynamo::from_attribute_value(score_av).unwrap();
-        match rec {
-            ScoreRecord::Sets { entries } => {
-                assert_eq!(entries.get("sideA"), Some(&vec![6, 4]));
-            }
-            _ => panic!("expected sets"),
-        }
-    }
-
-    /// `Sets` `entries` also deserializes from the pre-migration
-    /// `Vec<{side_id, sets}>` list shape — see
-    /// `simple_legacy_list_shape_deserializes`, the `Simple`-score
-    /// counterpart.
-    #[test]
-    fn sets_legacy_list_shape_deserializes() {
-        let list_shape = AttributeValue::L(vec![AttributeValue::M(HashMap::from([
-            ("side_id".to_string(), AttributeValue::S("sideA".into())),
-            (
-                "sets".to_string(),
-                AttributeValue::L(vec![
-                    AttributeValue::N("6".into()),
-                    AttributeValue::N("4".into()),
-                ]),
-            ),
-        ]))]);
-        let score_av = AttributeValue::M(HashMap::from([
-            ("type".to_string(), AttributeValue::S("sets".into())),
-            ("entries".to_string(), list_shape),
         ]));
         let rec: ScoreRecord = serde_dynamo::from_attribute_value(score_av).unwrap();
         match rec {

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -35,11 +35,19 @@ pub struct HeaderPhotoRecord {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ScoreRecord {
     Simple {
-        /// Points per side, keyed by side id.
+        /// Points per side, keyed by side id. Accepts the pre-migration
+        /// `Vec<{side_id, points}>` shape on read (see
+        /// `deserialize_simple_entries`) so a match doesn't 500 just because
+        /// it hasn't been through `migrate_score_entries.py` yet.
+        #[serde(deserialize_with = "deserialize_simple_entries")]
         entries: HashMap<String, u32>,
     },
     Sets {
-        /// Games won per set per side, keyed by side id.
+        /// Games won per set per side, keyed by side id. Accepts the
+        /// pre-migration `Vec<{side_id, sets}>` shape on read (see
+        /// `deserialize_sets_entries`) so a match doesn't 500 just because it
+        /// hasn't been through `migrate_score_entries.py` yet.
+        #[serde(deserialize_with = "deserialize_sets_entries")]
         entries: HashMap<String, Vec<u32>>,
     },
     Cricket {
@@ -82,6 +90,64 @@ pub enum ScoreRecord {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         penalty_shootout_score: Option<HashMap<String, u32>>,
     },
+}
+
+/// Legacy pre-migration shape for one `Simple` score entry: `{"side_id":
+/// ..., "points": ...}`. Only ever seen on read, from items written before
+/// `entries` became a side_id-keyed map.
+#[derive(Deserialize)]
+struct LegacySimpleEntry {
+    side_id: String,
+    points: u32,
+}
+
+/// Accepts `entries` as either the current side_id-keyed map or the
+/// pre-migration `Vec<{side_id, points}>` list, so a `Simple` score
+/// deserializes regardless of whether the item has been through
+/// `migrate_score_entries.py` yet. `#[serde(untagged)]` buffers the value and
+/// tries each shape in turn — cheap here since scores are small.
+fn deserialize_simple_entries<'de, D>(deserializer: D) -> Result<HashMap<String, u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Shape {
+        Map(HashMap<String, u32>),
+        List(Vec<LegacySimpleEntry>),
+    }
+    Ok(match Shape::deserialize(deserializer)? {
+        Shape::Map(map) => map,
+        Shape::List(list) => list.into_iter().map(|e| (e.side_id, e.points)).collect(),
+    })
+}
+
+/// Legacy pre-migration shape for one `Sets` score entry: `{"side_id": ...,
+/// "sets": [...]}`. Only ever seen on read, from items written before
+/// `entries` became a side_id-keyed map.
+#[derive(Deserialize)]
+struct LegacySetsEntry {
+    side_id: String,
+    sets: Vec<u32>,
+}
+
+/// Accepts `entries` as either the current side_id-keyed map or the
+/// pre-migration `Vec<{side_id, sets}>` list — see
+/// `deserialize_simple_entries`, the `Simple`-score counterpart.
+fn deserialize_sets_entries<'de, D>(deserializer: D) -> Result<HashMap<String, Vec<u32>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Shape {
+        Map(HashMap<String, Vec<u32>>),
+        List(Vec<LegacySetsEntry>),
+    }
+    Ok(match Shape::deserialize(deserializer)? {
+        Shape::Map(map) => map,
+        Shape::List(list) => list.into_iter().map(|e| (e.side_id, e.sets)).collect(),
+    })
 }
 
 /// One innings' final totals, as stored on a match's confirmed/pending
@@ -964,10 +1030,7 @@ mod tests {
     use aws_sdk_dynamodb::types::AttributeValue;
 
     /// `Simple`/`Sets` `entries` round-trip through the side_id-keyed map
-    /// shape. (Data written before this shape landed no longer needs
-    /// handling here — see `migrate_score_entries.py`, the one-off script
-    /// that backfilled every match's `confirmed_score`/`pending_score`/
-    /// score-submission history to this shape.)
+    /// shape — the shape every write produces today.
     #[test]
     fn simple_map_shape_deserializes() {
         let map_shape = AttributeValue::M(HashMap::from([
@@ -977,6 +1040,37 @@ mod tests {
         let score_av = AttributeValue::M(HashMap::from([
             ("type".to_string(), AttributeValue::S("simple".into())),
             ("entries".to_string(), map_shape),
+        ]));
+        let rec: ScoreRecord = serde_dynamo::from_attribute_value(score_av).unwrap();
+        match rec {
+            ScoreRecord::Simple { entries } => {
+                assert_eq!(entries.get("sideA"), Some(&6));
+                assert_eq!(entries.get("sideB"), Some(&3));
+            }
+            _ => panic!("expected simple"),
+        }
+    }
+
+    /// `Simple` `entries` also deserializes from the pre-migration
+    /// `Vec<{side_id, points}>` list shape, so a match written before the
+    /// side_id-keyed map landed still reads (e.g. from the API's feed/match
+    /// endpoints) even if `migrate_score_entries.py` hasn't reached it yet —
+    /// see `deserialize_simple_entries`.
+    #[test]
+    fn simple_legacy_list_shape_deserializes() {
+        let list_shape = AttributeValue::L(vec![
+            AttributeValue::M(HashMap::from([
+                ("side_id".to_string(), AttributeValue::S("sideA".into())),
+                ("points".to_string(), AttributeValue::N("6".into())),
+            ])),
+            AttributeValue::M(HashMap::from([
+                ("side_id".to_string(), AttributeValue::S("sideB".into())),
+                ("points".to_string(), AttributeValue::N("3".into())),
+            ])),
+        ]);
+        let score_av = AttributeValue::M(HashMap::from([
+            ("type".to_string(), AttributeValue::S("simple".into())),
+            ("entries".to_string(), list_shape),
         ]));
         let rec: ScoreRecord = serde_dynamo::from_attribute_value(score_av).unwrap();
         match rec {
@@ -1000,6 +1094,35 @@ mod tests {
         let score_av = AttributeValue::M(HashMap::from([
             ("type".to_string(), AttributeValue::S("sets".into())),
             ("entries".to_string(), map_shape),
+        ]));
+        let rec: ScoreRecord = serde_dynamo::from_attribute_value(score_av).unwrap();
+        match rec {
+            ScoreRecord::Sets { entries } => {
+                assert_eq!(entries.get("sideA"), Some(&vec![6, 4]));
+            }
+            _ => panic!("expected sets"),
+        }
+    }
+
+    /// `Sets` `entries` also deserializes from the pre-migration
+    /// `Vec<{side_id, sets}>` list shape — see
+    /// `simple_legacy_list_shape_deserializes`, the `Simple`-score
+    /// counterpart.
+    #[test]
+    fn sets_legacy_list_shape_deserializes() {
+        let list_shape = AttributeValue::L(vec![AttributeValue::M(HashMap::from([
+            ("side_id".to_string(), AttributeValue::S("sideA".into())),
+            (
+                "sets".to_string(),
+                AttributeValue::L(vec![
+                    AttributeValue::N("6".into()),
+                    AttributeValue::N("4".into()),
+                ]),
+            ),
+        ]))]);
+        let score_av = AttributeValue::M(HashMap::from([
+            ("type".to_string(), AttributeValue::S("sets".into())),
+            ("entries".to_string(), list_shape),
         ]));
         let rec: ScoreRecord = serde_dynamo::from_attribute_value(score_av).unwrap();
         match rec {


### PR DESCRIPTION
## Summary
Improve error diagnostics when DynamoDB item deserialization fails by capturing and including the item's `PK`/`SK` and target type name in the error. This makes it possible to locate and fix corrupted or stale items from log output alone, without requiring a separate table scan.

## Changes
- **New `DaoError::SerdeItem` variant** in `error.rs`: Carries the item's partition key, sort key, target type name, and underlying serde error. Replaces bare `Serde` errors for stored item reads.
- **Enhanced `from_item()` function** in `item.rs`: Now extracts `PK`/`SK` from the item before deserialization and wraps any serde failure with full context.
- **Helper functions** in `item.rs`:
  - `attr_s()`: Best-effort string extraction of an attribute for error context; falls back to `"?"` if absent or not a string (never fails the read itself).
  - `short_type_name()`: Strips module paths from type names (e.g. `agon_core::dao::records::MatchRecord` → `MatchRecord`) to keep error messages concise.
- **Comprehensive test coverage** in `item.rs`:
  - `from_item_error_carries_key_and_type_context()`: Verifies that a deserialization failure includes the item's key and target type.
  - `from_item_error_context_defaults_when_keys_absent()`: Ensures the error path gracefully handles missing `PK`/`SK` without panicking.

## Implementation Details
- The `SerdeItem` error is constructed only in `from_item()`, the sole place where stored items are deserialized. Generic serde errors (e.g. pagination cursor keys) continue to use the `Serde` variant.
- Error messages now follow the pattern: `"serialization error deserializing {type_name} from {pk}/{sk}: {source}"`, making it immediately clear which record failed and why.
- The `#[source]` attribute on the `source` field preserves the error chain for debugging.

https://claude.ai/code/session_017yxhuQWWMyWidGXpR218jG