### PR TITLE
CI fix + resolved player names on cricket/football scores

### DIFF
--- a/.github/workflows/docker-ui.yml
+++ b/.github/workflows/docker-ui.yml
@@ -56,5 +56,11 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # ignore-error: the GHA cache backend occasionally 504s with an
+          # HTML error page instead of JSON ("invalid character '<' looking
+          # for beginning of value") — a flaky GitHub-side cache API issue,
+          # not a build problem. Without this the whole push fails even
+          # though the image itself built fine; with it, a failed cache
+          # export just means the next build warms the cache from scratch.
+          cache-to: type=gha,mode=max,ignore-error=true
           platforms: linux/amd64

--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -257,6 +257,44 @@ impl Dao {
         Ok(out)
     }
 
+    /// Fetch specific players from one match by id, in one round-trip. Each
+    /// player's key (`PK = MATCH#<matchId>`, `SK = PLAYER#<playerId>`) is
+    /// already known to the caller (e.g. a live-scoring `next_ball_context`'s
+    /// striker/non-striker ids), so this is a `BatchGetItem` of exact keys —
+    /// not the `begins_with(SK, "PLAYER#")` `Query` `get_match` uses for the
+    /// *whole* roster. Resolving a couple of names this way stays flat-cost
+    /// regardless of squad size, unlike a full roster query. Missing ids are
+    /// simply absent from the map.
+    #[tracing::instrument(skip(self))]
+    pub async fn batch_get_match_players(
+        &self,
+        match_id: &str,
+        player_ids: &[String],
+    ) -> DaoResult<HashMap<String, MatchPlayerRecord>> {
+        let mut seen = std::collections::HashSet::new();
+        let keys: Vec<_> = player_ids
+            .iter()
+            .filter(|id| seen.insert((*id).clone()))
+            .map(|id| {
+                HashMap::from([
+                    (
+                        ATTR_PK.to_string(),
+                        s(Pk::Match(match_id.into()).to_string()),
+                    ),
+                    (ATTR_SK.to_string(), s(Sk::Player(id.clone()).to_string())),
+                ])
+            })
+            .collect();
+
+        let items = self.batch_get_all(keys, None).await?;
+        let mut out = HashMap::with_capacity(items.len());
+        for item in items {
+            let record: MatchPlayerRecord = from_item(item)?;
+            out.insert(record.player_id.clone(), record);
+        }
+        Ok(out)
+    }
+
     /// Fetch match summaries (meta + sides, *no* players) for many matches at
     /// once — the feed's and search's hydration path, neither of which
     /// renders a full roster (see [`MatchSummary`]). Missing ids are simply

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -289,6 +289,8 @@ impl CricketScore {
             recent_deliveries: None,
             next_ball_context: None,
             awaiting_next_innings: Some(true),
+            current_striker: None,
+            current_non_striker: None,
         };
         for event in events {
             score.apply_event(
@@ -771,6 +773,8 @@ mod tests {
             recent_deliveries: None,
             next_ball_context: None,
             awaiting_next_innings: Some(true),
+            current_striker: None,
+            current_non_striker: None,
         };
         for event in &events {
             incremental.apply_event(event, 6, true, true);

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use poem_openapi::{Enum, Object, Union};
 
 use crate::detailed_score::cricket::{
@@ -289,8 +291,7 @@ impl CricketScore {
             recent_deliveries: None,
             next_ball_context: None,
             awaiting_next_innings: Some(true),
-            current_striker: None,
-            current_non_striker: None,
+            players: HashMap::new(),
         };
         for event in events {
             score.apply_event(
@@ -773,8 +774,7 @@ mod tests {
             recent_deliveries: None,
             next_ball_context: None,
             awaiting_next_innings: Some(true),
-            current_striker: None,
-            current_non_striker: None,
+            players: HashMap::new(),
         };
         for event in &events {
             incremental.apply_event(event, 6, true, true);

--- a/agon_service/src/live_score/football.rs
+++ b/agon_service/src/live_score/football.rs
@@ -48,6 +48,7 @@ impl FootballScore {
             period_times: Some(HashMap::new()),
             penalty_shootout: Some(Vec::new()),
             penalty_shootout_score: Some(HashMap::new()),
+            players: HashMap::new(),
         };
         for (occurred_at, event) in events {
             score.apply_event(*occurred_at, event);
@@ -378,6 +379,7 @@ mod tests {
             period_times: Some(HashMap::new()),
             penalty_shootout: Some(Vec::new()),
             penalty_shootout_score: Some(HashMap::new()),
+            players: HashMap::new(),
         };
         for (occurred_at, event) in &events {
             incremental.apply_event(*occurred_at, event);

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -44,8 +44,9 @@ use mapping::{
     invitation_status_str, live_event_from_record, match_format_sport_tag, match_format_to_record,
     match_from_records, match_score_from_record, match_score_to_record, match_status_str,
     match_type_tag, new_live_event_to_dao, notification_actor_id, notification_from_record,
-    score_submission_from_record, score_to_record, search_match_from_records, team_from_records,
-    team_list_item_from_record, user_profile_from_record,
+    roster_preview_player, score_submission_from_record, score_to_record,
+    search_match_from_records, team_from_records, team_list_item_from_record,
+    user_profile_from_record,
 };
 
 // Object-storage integration: S3 presigned uploads + CloudFront serving URLs.
@@ -387,6 +388,19 @@ struct CricketScore {
     /// started yet (i.e. between innings, or nothing's been recorded).
     /// `None` for a result with no live log behind it.
     awaiting_next_innings: Option<bool>,
+    /// Live name/avatar for `next_ball_context`'s striker — whoever's
+    /// currently facing. Resolved separately from everything else on this
+    /// type: `score_from_record`/`CricketScore::from_events` (the DAO-only
+    /// paths) always leave this `None`, since neither has access to player
+    /// records; `Api::get_match_score` hydrates it afterward with a targeted
+    /// `Dao::batch_get_match_players` lookup, just for this one id, rather
+    /// than a full roster query. Exists so a feed/search card — whose
+    /// trimmed match type never carries the full player roster the match
+    /// detail view resolves names from locally — can still show who's
+    /// batting. Not persisted (no counterpart on `ScoreRecord`).
+    current_striker: Option<RosterPreviewPlayer>,
+    /// Same as `current_striker`, for `next_ball_context`'s non-striker.
+    current_non_striker: Option<RosterPreviewPlayer>,
 }
 
 /// One innings' totals, plus optional per-player detail. The totals
@@ -2723,34 +2737,88 @@ impl Api {
             .get_match_score(&match_id, sport)
             .await
             .map_err(dao_internal)?;
-        if let Some(record) = record {
-            return Ok(GetMatchScoreResponse::Score(Json(match_score_from_record(
-                &record,
-            ))));
+        let mut score = match record {
+            Some(record) => match_score_from_record(&record),
+            None => {
+                // No persisted record — recover by folding the event log, if
+                // there is one (e.g. a live-scored match whose record was
+                // somehow missing). Persist the result so subsequent reads,
+                // and the next incremental append, have a fresh checkpoint
+                // to build on.
+                let records = dao
+                    .list_live_events(&match_id)
+                    .await
+                    .map_err(dao_internal)?;
+                if records.is_empty() {
+                    return Ok(GetMatchScoreResponse::NotFound(PlainText(
+                        "match has no score".into(),
+                    )));
+                }
+                let last_seq = records.iter().map(|r| r.seq).max().unwrap_or(0);
+                let Some(score) = derive_live_score(sport, &records, agg.match_.format.as_ref())
+                else {
+                    return Ok(GetMatchScoreResponse::NotFound(PlainText(
+                        "match has no score".into(),
+                    )));
+                };
+                self.persist_score(dao, &match_id, &score, Some(last_seq))
+                    .await;
+                score
+            }
+        };
+
+        self.hydrate_current_batters(dao, &match_id, &mut score)
+            .await?;
+        Ok(GetMatchScoreResponse::Score(Json(score)))
+    }
+
+    /// Resolve live name/avatar for a cricket score's current striker/non-
+    /// striker (`CricketScore.current_striker`/`current_non_striker`), from
+    /// `next_ball_context`'s player ids. A targeted `BatchGetItem` for just
+    /// those 1-2 players (`Dao::batch_get_match_players`) — not the full
+    /// roster `Query` `Match.players` needs — plus `batch_get_users` for
+    /// whichever of them are linked accounts, same "live name/avatar over
+    /// stored" rule `feed_roster_preview` uses. No-op for any sport but
+    /// cricket, or once there's no current innings (`next_ball_context` is
+    /// `None`) — nothing to resolve either way.
+    async fn hydrate_current_batters(
+        &self,
+        dao: &dao::Dao,
+        match_id: &str,
+        score: &mut Score,
+    ) -> Result<()> {
+        let Score::Cricket(cricket) = score else {
+            return Ok(());
+        };
+        let Some(ctx) = &cricket.next_ball_context else {
+            return Ok(());
+        };
+        let mut player_ids = Vec::with_capacity(2);
+        if let Some(id) = &ctx.striker_player_id {
+            player_ids.push(id.clone());
+        }
+        if let Some(id) = &ctx.non_striker_player_id {
+            player_ids.push(id.clone());
+        }
+        if player_ids.is_empty() {
+            return Ok(());
         }
 
-        // No persisted record — recover by folding the event log, if there
-        // is one (e.g. a live-scored match whose record was somehow
-        // missing). Persist the result so subsequent reads, and the next
-        // incremental append, have a fresh checkpoint to build on.
-        let records = dao
-            .list_live_events(&match_id)
+        let players = dao
+            .batch_get_match_players(match_id, &player_ids)
             .await
             .map_err(dao_internal)?;
-        if records.is_empty() {
-            return Ok(GetMatchScoreResponse::NotFound(PlainText(
-                "match has no score".into(),
-            )));
-        }
-        let last_seq = records.iter().map(|r| r.seq).max().unwrap_or(0);
-        let Some(score) = derive_live_score(sport, &records, agg.match_.format.as_ref()) else {
-            return Ok(GetMatchScoreResponse::NotFound(PlainText(
-                "match has no score".into(),
-            )));
+        let user_ids: Vec<String> = players.values().filter_map(|p| p.user_id.clone()).collect();
+        let users = dao.batch_get_users(&user_ids).await.map_err(dao_internal)?;
+
+        let resolve = |player_id: &Option<String>| {
+            players.get(player_id.as_ref()?).map(|p| {
+                roster_preview_player(p.user_id.as_deref(), p.display_name.as_deref(), &users)
+            })
         };
-        self.persist_score(dao, &match_id, &score, Some(last_seq))
-            .await;
-        Ok(GetMatchScoreResponse::Score(Json(score)))
+        cricket.current_striker = resolve(&ctx.striker_player_id);
+        cricket.current_non_striker = resolve(&ctx.non_striker_player_id);
+        Ok(())
     }
 
     /// Append a batch of live-scoring events (1 to
@@ -4969,6 +5037,8 @@ fn resolve_score_ids(
                 recent_deliveries,
                 next_ball_context,
                 awaiting_next_innings: s.awaiting_next_innings,
+                current_striker: None,
+                current_non_striker: None,
             }))
         }
         Score::Football(s) => {

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -388,19 +388,20 @@ struct CricketScore {
     /// started yet (i.e. between innings, or nothing's been recorded).
     /// `None` for a result with no live log behind it.
     awaiting_next_innings: Option<bool>,
-    /// Live name/avatar for `next_ball_context`'s striker — whoever's
-    /// currently facing. Resolved separately from everything else on this
-    /// type: `score_from_record`/`CricketScore::from_events` (the DAO-only
-    /// paths) always leave this `None`, since neither has access to player
-    /// records; `Api::get_match_score` hydrates it afterward with a targeted
-    /// `Dao::batch_get_match_players` lookup, just for this one id, rather
-    /// than a full roster query. Exists so a feed/search card — whose
-    /// trimmed match type never carries the full player roster the match
-    /// detail view resolves names from locally — can still show who's
-    /// batting. Not persisted (no counterpart on `ScoreRecord`).
-    current_striker: Option<RosterPreviewPlayer>,
-    /// Same as `current_striker`, for `next_ball_context`'s non-striker.
-    current_non_striker: Option<RosterPreviewPlayer>,
+    /// Live name/avatar for every player id referenced anywhere else in this
+    /// score — `next_ball_context`'s striker/non-striker/bowler, each
+    /// innings' batting/bowling/fall-of-wicket entries, `recent_deliveries` —
+    /// keyed by that same (match-scoped) player id. Look a player up here
+    /// instead of scanning `Match.players`, which a feed/search card's
+    /// trimmed match type doesn't carry at all. Resolved separately from
+    /// everything else on this type: `score_from_record`/
+    /// `CricketScore::from_events` (the DAO-only paths) always leave this
+    /// empty, since neither has access to player records;
+    /// `Api::hydrate_score_players` fills it afterward with one targeted
+    /// `Dao::batch_get_match_players` lookup for exactly the ids this score
+    /// references, not a full roster query. Not persisted (no counterpart on
+    /// `ScoreRecord`).
+    players: HashMap<String, RosterPreviewPlayer>,
 }
 
 /// One innings' totals, plus optional per-player detail. The totals
@@ -487,6 +488,11 @@ struct FootballScore {
     /// derived from `penalty_shootout` the same way `score` is derived from
     /// `goals`. Keyed by side id, same reasoning as `score`.
     penalty_shootout_score: Option<HashMap<String, u32>>,
+    /// Live name/avatar for every player id referenced anywhere else in this
+    /// score — `goals`' scorer/assist, `cards`' player, `substitutions`' in/
+    /// out — keyed by that same (match-scoped) player id. Same mechanism and
+    /// rationale as `CricketScore.players`.
+    players: HashMap<String, RosterPreviewPlayer>,
 }
 
 /// The sport a match was played in. Determines the expected `Score` shape
@@ -2767,57 +2773,57 @@ impl Api {
             }
         };
 
-        self.hydrate_current_batters(dao, &match_id, &mut score)
+        self.hydrate_score_players(dao, &match_id, &mut score)
             .await?;
         Ok(GetMatchScoreResponse::Score(Json(score)))
     }
 
-    /// Resolve live name/avatar for a cricket score's current striker/non-
-    /// striker (`CricketScore.current_striker`/`current_non_striker`), from
-    /// `next_ball_context`'s player ids. A targeted `BatchGetItem` for just
-    /// those 1-2 players (`Dao::batch_get_match_players`) — not the full
-    /// roster `Query` `Match.players` needs — plus `batch_get_users` for
-    /// whichever of them are linked accounts, same "live name/avatar over
-    /// stored" rule `feed_roster_preview` uses. No-op for any sport but
-    /// cricket, or once there's no current innings (`next_ball_context` is
-    /// `None`) — nothing to resolve either way.
-    async fn hydrate_current_batters(
+    /// Resolve live name/avatar for every player id referenced anywhere in a
+    /// cricket or football score (`CricketScore.players`/
+    /// `FootballScore.players`) — striker/non-striker/bowler, batting/
+    /// bowling cards, goal scorers/assists, cards, substitutions, and so on
+    /// (see [`score_player_ids`]). One targeted `BatchGetItem` for exactly
+    /// those ids (`Dao::batch_get_match_players`) — not the full roster
+    /// `Query` `Match.players` needs — plus `batch_get_users` for whichever
+    /// are linked accounts, same "live name/avatar over stored" rule
+    /// `feed_roster_preview` uses. No-op for `Score::Simple`/`Score::Sets`
+    /// (neither references players by id) or once a score references no
+    /// players at all.
+    async fn hydrate_score_players(
         &self,
         dao: &dao::Dao,
         match_id: &str,
         score: &mut Score,
     ) -> Result<()> {
-        let Score::Cricket(cricket) = score else {
-            return Ok(());
-        };
-        let Some(ctx) = &cricket.next_ball_context else {
-            return Ok(());
-        };
-        let mut player_ids = Vec::with_capacity(2);
-        if let Some(id) = &ctx.striker_player_id {
-            player_ids.push(id.clone());
-        }
-        if let Some(id) = &ctx.non_striker_player_id {
-            player_ids.push(id.clone());
-        }
+        let player_ids = score_player_ids(score);
         if player_ids.is_empty() {
             return Ok(());
         }
 
-        let players = dao
+        let match_players = dao
             .batch_get_match_players(match_id, &player_ids)
             .await
             .map_err(dao_internal)?;
-        let user_ids: Vec<String> = players.values().filter_map(|p| p.user_id.clone()).collect();
+        let user_ids: Vec<String> = match_players
+            .values()
+            .filter_map(|p| p.user_id.clone())
+            .collect();
         let users = dao.batch_get_users(&user_ids).await.map_err(dao_internal)?;
 
-        let resolve = |player_id: &Option<String>| {
-            players.get(player_id.as_ref()?).map(|p| {
-                roster_preview_player(p.user_id.as_deref(), p.display_name.as_deref(), &users)
+        let resolved: HashMap<String, RosterPreviewPlayer> = match_players
+            .iter()
+            .map(|(id, p)| {
+                (
+                    id.clone(),
+                    roster_preview_player(p.user_id.as_deref(), p.display_name.as_deref(), &users),
+                )
             })
-        };
-        cricket.current_striker = resolve(&ctx.striker_player_id);
-        cricket.current_non_striker = resolve(&ctx.non_striker_player_id);
+            .collect();
+        match score {
+            Score::Cricket(s) => s.players = resolved,
+            Score::Football(s) => s.players = resolved,
+            Score::Simple(_) | Score::Sets(_) => {}
+        }
         Ok(())
     }
 
@@ -5037,8 +5043,7 @@ fn resolve_score_ids(
                 recent_deliveries,
                 next_ball_context,
                 awaiting_next_innings: s.awaiting_next_innings,
-                current_striker: None,
-                current_non_striker: None,
+                players: HashMap::new(),
             }))
         }
         Score::Football(s) => {
@@ -5125,9 +5130,83 @@ fn resolve_score_ids(
                 period_times: s.period_times.clone(),
                 penalty_shootout,
                 penalty_shootout_score,
+                players: HashMap::new(),
             }))
         }
     }
+}
+
+/// Every player id referenced anywhere in a score — the set
+/// `Api::hydrate_score_players` resolves names for. Empty (nothing to
+/// resolve) for `Score::Simple`/`Score::Sets`, which don't reference
+/// players by id at all.
+fn score_player_ids(score: &Score) -> Vec<String> {
+    match score {
+        Score::Cricket(s) => cricket_score_player_ids(s),
+        Score::Football(s) => football_score_player_ids(s),
+        Score::Simple(_) | Score::Sets(_) => Vec::new(),
+    }
+}
+
+/// Every player id referenced in a `CricketScore`: `next_ball_context`'s
+/// striker/non-striker/bowler/previous-over-bowler, each innings' batting/
+/// bowling/fall-of-wicket entries (plus a batting entry's dismissal bowler/
+/// fielder), and `recent_deliveries` (plus each delivery's wicket). May
+/// repeat the same id many times over (e.g. a bowler across several
+/// deliveries) — `Dao::batch_get_match_players` dedupes before querying.
+fn cricket_score_player_ids(score: &CricketScore) -> Vec<String> {
+    let mut ids = Vec::new();
+    if let Some(ctx) = &score.next_ball_context {
+        ids.extend(ctx.striker_player_id.clone());
+        ids.extend(ctx.non_striker_player_id.clone());
+        ids.extend(ctx.bowler_player_id.clone());
+        ids.extend(ctx.previous_over_bowler_player_id.clone());
+    }
+    for innings in &score.innings {
+        for entry in innings.batting.iter().flatten() {
+            ids.push(entry.player_id.clone());
+            if let Some(d) = &entry.dismissal {
+                ids.extend(d.bowler_player_id.clone());
+                ids.extend(d.fielder_player_id.clone());
+            }
+        }
+        for entry in innings.bowling.iter().flatten() {
+            ids.push(entry.player_id.clone());
+        }
+        for fow in innings.fall_of_wickets.iter().flatten() {
+            ids.push(fow.player_id.clone());
+        }
+    }
+    for delivery in score.recent_deliveries.iter().flatten() {
+        ids.push(delivery.bowler_player_id.clone());
+        ids.push(delivery.striker_player_id.clone());
+        ids.push(delivery.non_striker_player_id.clone());
+        if let Some(w) = &delivery.wicket {
+            ids.push(w.dismissed_player_id.clone());
+            ids.extend(w.bowler_player_id.clone());
+            ids.extend(w.fielder_player_id.clone());
+        }
+    }
+    ids
+}
+
+/// Every player id referenced in a `FootballScore`: each goal's scorer/
+/// assist, each card's player, each substitution's player in/out. Same
+/// "may repeat, deduped downstream" contract as [`cricket_score_player_ids`].
+fn football_score_player_ids(score: &FootballScore) -> Vec<String> {
+    let mut ids = Vec::new();
+    for goal in score.goals.iter().flatten() {
+        ids.extend(goal.scorer_player_id.clone());
+        ids.extend(goal.assist_player_id.clone());
+    }
+    for card in score.cards.iter().flatten() {
+        ids.push(card.player_id.clone());
+    }
+    for sub in score.substitutions.iter().flatten() {
+        ids.push(sub.player_in_id.clone());
+        ids.push(sub.player_out_id.clone());
+    }
+    ids
 }
 
 /// Derives the winner (when decidable) from a live-scored match's persisted

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -202,10 +202,9 @@ pub fn score_from_record(rec: &ScoreRecord) -> Score {
                 .as_ref()
                 .map(next_ball_context_from_record),
             awaiting_next_innings: *awaiting_next_innings,
-            // Not stored — `Api::get_match_score` hydrates these afterward
-            // (see `CricketScore::current_striker`'s doc comment).
-            current_striker: None,
-            current_non_striker: None,
+            // Not stored — `Api::hydrate_score_players` fills this afterward
+            // (see `CricketScore::players`' doc comment).
+            players: std::collections::HashMap::new(),
         }),
         ScoreRecord::Football {
             score,
@@ -244,6 +243,8 @@ pub fn score_from_record(rec: &ScoreRecord) -> Score {
                     .collect()
             }),
             penalty_shootout_score: penalty_shootout_score.clone(),
+            // Not stored — `Api::hydrate_score_players` fills this afterward.
+            players: std::collections::HashMap::new(),
         }),
     }
 }
@@ -1892,8 +1893,7 @@ mod tests {
                 recent_deliveries: None,
                 next_ball_context: None,
                 awaiting_next_innings: None,
-                current_striker: None,
-                current_non_striker: None,
+                players: HashMap::new(),
             }),
             // A live-scored cricket result: full per-player detail.
             Score::Cricket(CricketScore {
@@ -1960,8 +1960,7 @@ mod tests {
                     runs_conceded_this_over: 1,
                 }),
                 awaiting_next_innings: Some(false),
-                current_striker: None,
-                current_non_striker: None,
+                players: HashMap::new(),
             }),
             // A manually-entered football result: totals only, no detail.
             Score::Football(FootballScore {
@@ -1973,6 +1972,7 @@ mod tests {
                 period_times: None,
                 penalty_shootout: None,
                 penalty_shootout_score: None,
+                players: HashMap::new(),
             }),
             // A live-scored football result: full goal/card/sub detail.
             Score::Football(FootballScore {
@@ -2023,6 +2023,7 @@ mod tests {
                     scored: true,
                 }]),
                 penalty_shootout_score: Some(HashMap::from([("side_red".to_string(), 1)])),
+                players: HashMap::new(),
             }),
         ];
 

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -202,6 +202,10 @@ pub fn score_from_record(rec: &ScoreRecord) -> Score {
                 .as_ref()
                 .map(next_ball_context_from_record),
             awaiting_next_innings: *awaiting_next_innings,
+            // Not stored — `Api::get_match_score` hydrates these afterward
+            // (see `CricketScore::current_striker`'s doc comment).
+            current_striker: None,
+            current_non_striker: None,
         }),
         ScoreRecord::Football {
             score,
@@ -774,23 +778,37 @@ pub fn feed_roster_preview(
     Some(
         side.roster_preview
             .iter()
-            .map(|p| match &p.user_id {
-                Some(uid) => {
-                    let record = users.get(uid);
-                    RosterPreviewPlayer {
-                        user_id: Some(uid.clone()),
-                        name: record.map(|u| u.name.clone()).unwrap_or_default(),
-                        avatar_url: record.and_then(|u| u.profile_image_url.clone()),
-                    }
-                }
-                None => RosterPreviewPlayer {
-                    user_id: None,
-                    name: p.display_name.clone().unwrap_or_default(),
-                    avatar_url: None,
-                },
-            })
+            .map(|p| roster_preview_player(p.user_id.as_deref(), p.display_name.as_deref(), users))
             .collect(),
     )
+}
+
+/// Build one `RosterPreviewPlayer` for a player identified either by a
+/// linked account (`user_id`, live name/avatar looked up in `users`) or an
+/// external display name. Shared by [`feed_roster_preview`] (a side's cached
+/// roster preview) and `Api`'s live-scoring current-batter resolution
+/// (`batch_get_match_players`) — same "prefer a live user record over
+/// whatever's stored on the player" rule either way.
+pub fn roster_preview_player(
+    user_id: Option<&str>,
+    display_name: Option<&str>,
+    users: &std::collections::HashMap<String, UserRecord>,
+) -> RosterPreviewPlayer {
+    match user_id {
+        Some(uid) => {
+            let record = users.get(uid);
+            RosterPreviewPlayer {
+                user_id: Some(uid.to_string()),
+                name: record.map(|u| u.name.clone()).unwrap_or_default(),
+                avatar_url: record.and_then(|u| u.profile_image_url.clone()),
+            }
+        }
+        None => RosterPreviewPlayer {
+            user_id: None,
+            name: display_name.unwrap_or_default().to_string(),
+            avatar_url: None,
+        },
+    }
 }
 
 // ===========================================================================
@@ -1874,6 +1892,8 @@ mod tests {
                 recent_deliveries: None,
                 next_ball_context: None,
                 awaiting_next_innings: None,
+                current_striker: None,
+                current_non_striker: None,
             }),
             // A live-scored cricket result: full per-player detail.
             Score::Cricket(CricketScore {
@@ -1940,6 +1960,8 @@ mod tests {
                     runs_conceded_this_over: 1,
                 }),
                 awaiting_next_innings: Some(false),
+                current_striker: None,
+                current_non_striker: None,
             }),
             // A manually-entered football result: totals only, no detail.
             Score::Football(FootballScore {

--- a/agon_ui/src/components/agon/CricketScoreFields.tsx
+++ b/agon_ui/src/components/agon/CricketScoreFields.tsx
@@ -217,7 +217,10 @@ export function CricketScoreFields({
     const a = totals[sideA.id] ?? 0
     const b = totals[sideB.id] ?? 0
     const winnerSideId = a === b ? undefined : a > b ? sideA.id : sideB.id
-    onChange({ score: { type: 'Cricket', innings: built }, winnerSideId })
+    // `players` (the score's resolved-name map) is server-only — the backend
+    // never persists it (see `CricketScore.players`'s doc comment) — so a
+    // manually-built score has nothing to put here.
+    onChange({ score: { type: 'Cricket', innings: built, players: {} }, winnerSideId })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [innings, sideA.id, sideB.id])
 

--- a/agon_ui/src/components/agon/CricketScorecard.tsx
+++ b/agon_ui/src/components/agon/CricketScorecard.tsx
@@ -89,7 +89,7 @@ function InningsCard({ match, innings }: { match: Match; innings: CricketInnings
             {batting.map((b: CricketBattingEntry) => (
               <TableRow key={b.player_id}>
                 <TableCell>
-                  <p className="font-medium">{playerNameFor(match, b.player_id)}</p>
+                  <p className="font-medium">{playerNameFor(match, b.player_id) ?? '—'}</p>
                   <p className="text-[11px] text-muted-foreground">
                     {b.dismissal ? dismissalLabel(b.dismissal.kind) : 'not out'}
                   </p>
@@ -118,7 +118,7 @@ function InningsCard({ match, innings }: { match: Match; innings: CricketInnings
           <TableBody>
             {bowling.map((bw: CricketBowlingEntry) => (
               <TableRow key={bw.player_id}>
-                <TableCell className="font-medium">{playerNameFor(match, bw.player_id)}</TableCell>
+                <TableCell className="font-medium">{playerNameFor(match, bw.player_id) ?? '—'}</TableCell>
                 <TableCell className="w-12 text-right tabular-nums">{formatOvers(bw.overs)}</TableCell>
                 <TableCell className="w-12 text-right tabular-nums">{bw.maidens}</TableCell>
                 <TableCell className="w-12 text-right tabular-nums">{bw.runs_conceded}</TableCell>

--- a/agon_ui/src/components/agon/CricketScorecard.tsx
+++ b/agon_ui/src/components/agon/CricketScorecard.tsx
@@ -9,6 +9,7 @@ import {
   type CricketInningsWithDeliveries,
 } from '@/lib/cricketScore'
 import { cricketFormat } from '@/lib/matchFormat'
+import type { ScorePlayers } from '@/lib/members'
 import { CricketRunRateChart, type RunRateSeries } from './CricketRunRateChart'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 
@@ -25,8 +26,21 @@ function sideNameFor(match: Match, sideId: string): string {
  * ball-by-ball-scored innings, followed by each innings' batting/bowling
  * cards. Renders nothing if there's no per-innings detail to show (e.g. only
  * a headline score was ever recorded).
+ *
+ * `match` is always the full detail-page `Match` here (own roster included),
+ * so `players` (the score's resolved-name map) is a redundant-but-cheap
+ * first lookup rather than the only source `CricketMatchBlock`'s feed card
+ * relies on — see `playerNameFor`.
  */
-export function CricketScorecard({ match, innings }: { match: Match; innings: CricketInningsWithDeliveries[] }) {
+export function CricketScorecard({
+  match,
+  innings,
+  players,
+}: {
+  match: Match
+  innings: CricketInningsWithDeliveries[]
+  players?: ScorePlayers
+}) {
   if (innings.length === 0) return null
 
   const format = cricketFormat(match.format)
@@ -51,13 +65,21 @@ export function CricketScorecard({ match, innings }: { match: Match; innings: Cr
       )}
 
       {innings.map((inn, i) => (
-        <InningsCard key={`${inn.batting_side_id}-${i}`} match={match} innings={inn} />
+        <InningsCard key={`${inn.batting_side_id}-${i}`} match={match} innings={inn} players={players} />
       ))}
     </div>
   )
 }
 
-function InningsCard({ match, innings }: { match: Match; innings: CricketInningsWithDeliveries }) {
+function InningsCard({
+  match,
+  innings,
+  players,
+}: {
+  match: Match
+  innings: CricketInningsWithDeliveries
+  players?: ScorePlayers
+}) {
   const batting = innings.batting ?? []
   const bowling = innings.bowling ?? []
   if (batting.length === 0 && bowling.length === 0) return null
@@ -89,7 +111,7 @@ function InningsCard({ match, innings }: { match: Match; innings: CricketInnings
             {batting.map((b: CricketBattingEntry) => (
               <TableRow key={b.player_id}>
                 <TableCell>
-                  <p className="font-medium">{playerNameFor(match, b.player_id) ?? '—'}</p>
+                  <p className="font-medium">{playerNameFor(match, b.player_id, players) ?? '—'}</p>
                   <p className="text-[11px] text-muted-foreground">
                     {b.dismissal ? dismissalLabel(b.dismissal.kind) : 'not out'}
                   </p>
@@ -118,7 +140,7 @@ function InningsCard({ match, innings }: { match: Match; innings: CricketInnings
           <TableBody>
             {bowling.map((bw: CricketBowlingEntry) => (
               <TableRow key={bw.player_id}>
-                <TableCell className="font-medium">{playerNameFor(match, bw.player_id) ?? '—'}</TableCell>
+                <TableCell className="font-medium">{playerNameFor(match, bw.player_id, players) ?? '—'}</TableCell>
                 <TableCell className="w-12 text-right tabular-nums">{formatOvers(bw.overs)}</TableCell>
                 <TableCell className="w-12 text-right tabular-nums">{bw.maidens}</TableCell>
                 <TableCell className="w-12 text-right tabular-nums">{bw.runs_conceded}</TableCell>

--- a/agon_ui/src/components/agon/FootballScoreFields.tsx
+++ b/agon_ui/src/components/agon/FootballScoreFields.tsx
@@ -117,9 +117,13 @@ export function FootballScoreFields({ sideA, sideB, players, initial, onChange }
       onChange(null)
       return
     }
+    // `players` (the score's resolved-name map) is server-only — the backend
+    // never persists it (see `FootballScore.players`'s doc comment) — so a
+    // manually-built score has nothing to put here.
     const score: Score = {
       type: 'Football',
       score: { [aId]: a, [bId]: b },
+      players: {},
       ...(hasDetail ? { goals, cards, substitutions } : {}),
     }
     const winnerSideId = a === b ? undefined : a > b ? aId : bId

--- a/agon_ui/src/components/agon/FootballScorecard.tsx
+++ b/agon_ui/src/components/agon/FootballScorecard.tsx
@@ -35,7 +35,7 @@ export function FootballScorecard({ match, detail }: { match: Match; detail: Foo
               <span className="font-medium tabular-nums text-muted-foreground">
                 {minuteLabel(event.minute)}
               </span>
-              <span>{describeEvent(event, match)}</span>
+              <span>{describeEvent(event, match, detail.players)}</span>
             </p>
           )
         })}

--- a/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
@@ -105,11 +105,15 @@ export function CricketMatchBlock({
   const battingName = sideNameFor(match, innings.batting_side_id)
   const bowlingName = sideNameFor(match, innings.bowling_side_id)
   const next = state.next_ball_context
-  // `null` on a feed/search card (no `players` list to resolve against) —
-  // rather than showing a "—" placeholder, the line below is omitted
-  // entirely when neither name is known.
-  const strikerName = next ? playerNameFor(match, next.striker_player_id) : null
-  const nonStrikerName = next ? playerNameFor(match, next.non_striker_player_id) : null
+  // The server resolves these (`Api::hydrate_current_batters`) so they're
+  // available even on a feed/search card, whose trimmed match type carries
+  // no player roster to resolve `playerNameFor` against locally — that's
+  // only a fallback here for the (match-detail-only) case where the score
+  // predates the hydration, e.g. a cached query result. Neither known →
+  // the line below is omitted entirely rather than showing a placeholder.
+  const strikerName = state.current_striker?.name || playerNameFor(match, next?.striker_player_id)
+  const nonStrikerName =
+    state.current_non_striker?.name || playerNameFor(match, next?.non_striker_player_id)
   const overBalls = currentOverDeliveries(state.recent_deliveries ?? [])
   const crr = runRate(innings.runs, innings.overs, format.balls_per_over)
 

--- a/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
@@ -105,6 +105,11 @@ export function CricketMatchBlock({
   const battingName = sideNameFor(match, innings.batting_side_id)
   const bowlingName = sideNameFor(match, innings.bowling_side_id)
   const next = state.next_ball_context
+  // `null` on a feed/search card (no `players` list to resolve against) —
+  // rather than showing a "—" placeholder, the line below is omitted
+  // entirely when neither name is known.
+  const strikerName = next ? playerNameFor(match, next.striker_player_id) : null
+  const nonStrikerName = next ? playerNameFor(match, next.non_striker_player_id) : null
   const overBalls = currentOverDeliveries(state.recent_deliveries ?? [])
   const crr = runRate(innings.runs, innings.overs, format.balls_per_over)
 
@@ -121,11 +126,11 @@ export function CricketMatchBlock({
               {crr.toFixed(2)})
             </span>
           </p>
-          {next && (next.striker_player_id || next.non_striker_player_id) && (
+          {(strikerName || nonStrikerName) && (
             <p className="mt-0.5 truncate text-xs text-muted-foreground">
-              {next.striker_player_id && <>{playerNameFor(match, next.striker_player_id)}*</>}
-              {next.striker_player_id && next.non_striker_player_id && ' · '}
-              {next.non_striker_player_id && <>{playerNameFor(match, next.non_striker_player_id)}</>}
+              {strikerName && <>{strikerName}*</>}
+              {strikerName && nonStrikerName && ' · '}
+              {nonStrikerName && <>{nonStrikerName}</>}
             </p>
           )}
           {showDescription && description && (

--- a/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/CricketMatchBlock.tsx
@@ -105,15 +105,13 @@ export function CricketMatchBlock({
   const battingName = sideNameFor(match, innings.batting_side_id)
   const bowlingName = sideNameFor(match, innings.bowling_side_id)
   const next = state.next_ball_context
-  // The server resolves these (`Api::hydrate_current_batters`) so they're
-  // available even on a feed/search card, whose trimmed match type carries
-  // no player roster to resolve `playerNameFor` against locally — that's
-  // only a fallback here for the (match-detail-only) case where the score
-  // predates the hydration, e.g. a cached query result. Neither known →
-  // the line below is omitted entirely rather than showing a placeholder.
-  const strikerName = state.current_striker?.name || playerNameFor(match, next?.striker_player_id)
-  const nonStrikerName =
-    state.current_non_striker?.name || playerNameFor(match, next?.non_striker_player_id)
+  // `state.players` is resolved server-side (`Api::hydrate_score_players`)
+  // for exactly the ids this score references, so it's available even on a
+  // feed/search card, whose trimmed match type carries no player roster to
+  // resolve `playerNameFor` against locally. Neither known → the line below
+  // is omitted entirely rather than showing a placeholder.
+  const strikerName = playerNameFor(match, next?.striker_player_id, state.players)
+  const nonStrikerName = playerNameFor(match, next?.non_striker_player_id, state.players)
   const overBalls = currentOverDeliveries(state.recent_deliveries ?? [])
   const crr = runRate(innings.runs, innings.overs, format.balls_per_over)
 

--- a/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
@@ -96,7 +96,7 @@ export function LiveMatchBlock({
                 {event.minute !== undefined && (
                   <span className="font-medium text-foreground">{event.minute}'</span>
                 )}
-                <span className="truncate">{describeEvent(event, match)}</span>
+                <span className="truncate">{describeEvent(event, match, state.players)}</span>
               </p>
             )
           })}

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -365,18 +365,20 @@ export function sideNameFor(match: Pick<Match, 'sides'>, sideId: string): string
   return match.sides.find((s) => s.id === sideId)?.name?.trim() || 'This side'
 }
 
-/** Player display name for a member id, if it's on the roster. A feed card's
- *  `FeedMatch` never carries one (see `cricketStateDescription`), so a
- *  batter/bowler name on a live feed card falls back to "—" rather than
- *  crashing — full names are available on the match detail view. */
+/** Player display name for a member id, if it's on the roster — `null` if
+ *  not (a feed/search card's trimmed match type never carries a `players`
+ *  list at all, see `cricketStateDescription`), same "can't resolve → null,
+ *  let the caller decide how to degrade" contract as football's
+ *  `playerNameFor` in `lib/liveScore.ts`. Full names are always resolvable
+ *  from the match detail view, which does carry the full roster. */
 export function playerNameFor(
   match: MatchLike,
   playerId: string | undefined | null,
-): string {
-  if (!playerId) return '—'
+): string | null {
+  if (!playerId) return null
   const players = ('players' in match && match.players) || []
   const player = players.find((p) => p.member.id === playerId)
-  return player ? memberName(player.member) : '—'
+  return player ? memberName(player.member) : null
 }
 
 // `NextBallContext` (who's on strike/bowling for the next delivery) is now

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -1,5 +1,5 @@
 import type { components } from '@/types/api'
-import { memberName } from './members'
+import { memberName, type ScorePlayers } from './members'
 import type { CricketFormat } from './matchFormat'
 
 export type CricketDelivery = components['schemas']['CricketDelivery']
@@ -365,17 +365,24 @@ export function sideNameFor(match: Pick<Match, 'sides'>, sideId: string): string
   return match.sides.find((s) => s.id === sideId)?.name?.trim() || 'This side'
 }
 
-/** Player display name for a member id, if it's on the roster — `null` if
- *  not (a feed/search card's trimmed match type never carries a `players`
- *  list at all, see `cricketStateDescription`), same "can't resolve → null,
- *  let the caller decide how to degrade" contract as football's
- *  `playerNameFor` in `lib/liveScore.ts`. Full names are always resolvable
- *  from the match detail view, which does carry the full roster. */
+/** Player display name for a match-scoped player id — `null` if it can't be
+ *  resolved (same "can't resolve → null, let the caller decide how to
+ *  degrade" contract as football's `playerNameFor` in `lib/liveScore.ts`).
+ *
+ *  Checks `scorePlayers` first — `CricketScore.players`, resolved
+ *  server-side for exactly the ids a score references (see its backend doc
+ *  comment) — since that's the only source a feed/search card's trimmed
+ *  match type has at all (it never carries a `players` list). Falls back to
+ *  scanning the match's own roster, always present on the full `Match` type
+ *  a detail view uses. */
 export function playerNameFor(
   match: MatchLike,
   playerId: string | undefined | null,
+  scorePlayers?: ScorePlayers,
 ): string | null {
   if (!playerId) return null
+  const resolved = scorePlayers?.[playerId]
+  if (resolved) return resolved.name
   const players = ('players' in match && match.players) || []
   const player = players.find((p) => p.member.id === playerId)
   return player ? memberName(player.member) : null

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -1,5 +1,5 @@
 import type { components } from '@/types/api'
-import { memberName } from './members'
+import { memberName, type ScorePlayers } from './members'
 
 export type FootballPeriod = components['schemas']['FootballPeriod']
 export type FootballGoalEvent = components['schemas']['FootballGoalEvent']
@@ -30,11 +30,15 @@ export function footballScoreFrom(score: Score | null | undefined): FootballScor
 /** What `eventsFromDetail` actually reads off a `FootballScore` — narrowed
  *  so a finished match's `Score.Football` (whose `goals`/`cards`/
  *  `substitutions` are optional) and a live one (same optionality now) can
- *  both feed the same timeline via `footballEventSourceFromScore`. */
+ *  both feed the same timeline via `footballEventSourceFromScore`. Carries
+ *  `players` (the score's resolved-name map) alongside so `describeEvent`
+ *  can name scorers/assists/subs on a feed/search card too — see
+ *  `playerNameFor`. */
 export type FootballEventSource = {
   goals: FootballGoalEvent[]
   cards: FootballCardEvent[]
   substitutions: FootballSubstitutionEvent[]
+  players: ScorePlayers
 }
 
 /** A football match's event timeline straight off its score — `null` if
@@ -49,6 +53,7 @@ export function footballEventSourceFromScore(score: Score | null | undefined): F
     goals: score.goals ?? [],
     cards: score.cards ?? [],
     substitutions: score.substitutions ?? [],
+    players: score.players,
   }
 }
 
@@ -172,6 +177,7 @@ export function recentEvents(detail: FootballScore, limit: number): FootballEven
     goals: detail.goals ?? [],
     cards: detail.cards ?? [],
     substitutions: detail.substitutions ?? [],
+    players: detail.players,
   })
     .reverse()
     .slice(0, limit)
@@ -188,9 +194,21 @@ export function recentGoalEvents(goals: FootballGoalEvent[], limit: number): Foo
     .slice(0, limit)
 }
 
-/** Player display name for a member id, if it's on the roster. */
-function playerNameFor(match: MatchLike, playerId: string | undefined): string | null {
+/** Player display name for a match-scoped player id. Checks `scorePlayers`
+ *  first — `FootballScore.players`, resolved server-side for exactly the
+ *  ids a score references (see its backend doc comment) — since that's the
+ *  only source a feed/search card's trimmed match type has at all (it never
+ *  carries a `players` list). Falls back to scanning the match's own roster,
+ *  always present on the full `Match` type a detail view uses. Same
+ *  contract as cricket's `playerNameFor` in `lib/cricketScore.ts`. */
+function playerNameFor(
+  match: MatchLike,
+  playerId: string | undefined,
+  scorePlayers?: ScorePlayers,
+): string | null {
   if (!playerId) return null
+  const resolved = scorePlayers?.[playerId]
+  if (resolved) return resolved.name
   const players = ('players' in match && match.players) || []
   const player = players.find((p) => p.member.id === playerId)
   return player ? memberName(player.member) : null
@@ -200,14 +218,19 @@ function playerNameFor(match: MatchLike, playerId: string | undefined): string |
  *  (A. Silva)" or "Sub — Moreno on for Khan" — used by the event log and
  *  mini-ticker. Which side it belongs to isn't repeated in the text; callers
  *  convey that by aligning/positioning the row using `event.side_id`
- *  instead (see `LiveScoringPage`/`LiveMatchBlock`). */
-export function describeEvent(event: FootballEventView, match: MatchLike): string {
-  const scorer = playerNameFor(match, event.player_id)
+ *  instead (see `LiveScoringPage`/`LiveMatchBlock`). `scorePlayers` is the
+ *  owning score's resolved-name map — see `playerNameFor`. */
+export function describeEvent(
+  event: FootballEventView,
+  match: MatchLike,
+  scorePlayers?: ScorePlayers,
+): string {
+  const scorer = playerNameFor(match, event.player_id, scorePlayers)
 
   switch (event.kind) {
     case 'goal':
     case 'penalty': {
-      const assist = playerNameFor(match, event.assist_player_id)
+      const assist = playerNameFor(match, event.assist_player_id, scorePlayers)
       const base = scorer ? `${eventLabel(event.kind)} — ${scorer}` : eventLabel(event.kind)
       return assist ? `${base} (${assist})` : base
     }
@@ -217,7 +240,7 @@ export function describeEvent(event: FootballEventView, match: MatchLike): strin
     case 'red_card':
       return scorer ? `${eventLabel(event.kind)} — ${scorer}` : eventLabel(event.kind)
     case 'substitution': {
-      const out = playerNameFor(match, event.substituted_player_id)
+      const out = playerNameFor(match, event.substituted_player_id, scorePlayers)
       return scorer && out ? `Sub — ${scorer} on for ${out}` : 'Substitution'
     }
   }

--- a/agon_ui/src/lib/members.ts
+++ b/agon_ui/src/lib/members.ts
@@ -7,6 +7,16 @@ type Match = components['schemas']['Match']
 type FeedMatch = components['schemas']['FeedMatch']
 type SearchMatch = components['schemas']['SearchMatch']
 type Invitation = components['schemas']['Invitation']
+/** Name/avatar only, not the full `Member` shape — a side's `roster_preview`
+ *  entry, or a resolved id in a cricket/football score's `players` map (see
+ *  `CricketScore.players`'s backend doc comment). */
+export type RosterPreviewPlayer = components['schemas']['RosterPreviewPlayer']
+/** A cricket or football score's resolved-name lookup (`CricketScore.players`
+ *  / `FootballScore.players`), keyed by match-scoped player id — what
+ *  `playerNameFor` (both sports' versions) checks before falling back to
+ *  scanning the match's full roster, which a feed/search card doesn't carry
+ *  at all. */
+export type ScorePlayers = Record<string, RosterPreviewPlayer>
 // The generated `invitation.kind` type erases the discriminant (`Omit<…,"type">
 // & unknown`), so `.type` won't narrow. Use the real union for token extraction.
 type InvitationKind = components['schemas']['InvitationKind']

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -387,12 +387,14 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
         <div className="mt-3 space-y-1 border-t pt-3 text-sm">
           {effectiveStriker && (
             <div className="flex items-center justify-between">
-              <span className="font-medium">{playerNameFor(match, effectiveStriker) ?? '—'}*</span>
+              <span className="font-medium">
+                {playerNameFor(match, effectiveStriker, state?.players) ?? '—'}*
+              </span>
             </div>
           )}
           {effectiveNonStriker && (
             <div className="flex items-center justify-between">
-              <span>{playerNameFor(match, effectiveNonStriker) ?? '—'}</span>
+              <span>{playerNameFor(match, effectiveNonStriker, state?.players) ?? '—'}</span>
             </div>
           )}
           {effectiveBowler && (
@@ -400,7 +402,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
               <span className="text-muted-foreground">
                 Bowling:{' '}
                 <span className="font-medium text-foreground">
-                  {playerNameFor(match, effectiveBowler) ?? '—'}
+                  {playerNameFor(match, effectiveBowler, state?.players) ?? '—'}
                 </span>
               </span>
             </div>

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -387,18 +387,21 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
         <div className="mt-3 space-y-1 border-t pt-3 text-sm">
           {effectiveStriker && (
             <div className="flex items-center justify-between">
-              <span className="font-medium">{playerNameFor(match, effectiveStriker)}*</span>
+              <span className="font-medium">{playerNameFor(match, effectiveStriker) ?? '—'}*</span>
             </div>
           )}
           {effectiveNonStriker && (
             <div className="flex items-center justify-between">
-              <span>{playerNameFor(match, effectiveNonStriker)}</span>
+              <span>{playerNameFor(match, effectiveNonStriker) ?? '—'}</span>
             </div>
           )}
           {effectiveBowler && (
             <div className="mt-1.5 flex items-center justify-between border-t pt-1.5 text-xs">
               <span className="text-muted-foreground">
-                Bowling: <span className="font-medium text-foreground">{playerNameFor(match, effectiveBowler)}</span>
+                Bowling:{' '}
+                <span className="font-medium text-foreground">
+                  {playerNameFor(match, effectiveBowler) ?? '—'}
+                </span>
               </span>
             </div>
           )}

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -247,6 +247,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
         goals: state.goals ?? [],
         cards: state.cards ?? [],
         substitutions: state.substitutions ?? [],
+        players: state.players,
       }).reverse()
     : []
 
@@ -417,7 +418,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
                     {event.minute !== undefined ? `${event.minute}'` : ''}
                   </span>
                   <span aria-hidden>{eventEmoji(event.kind)}</span>
-                  <span className="min-w-0 truncate">{describeEvent(event, match)}</span>
+                  <span className="min-w-0 truncate">{describeEvent(event, match, state?.players)}</span>
                 </div>
               )
             })}

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -142,7 +142,10 @@ function MatchDetail({
   const footballState = isCurrentlyLive ? footballScoreFrom(scoreQuery.data) : null
   const cricketState = isCurrentlyLive ? cricketScoreFrom(scoreQuery.data) : null
   const hasLiveState = !!footballState || !!cricketState
-  const cricketScore = scoreInfo ? cricketScoreFrom(scoreInfo.score) : null
+  // Same "live while in progress, else confirmed/pending" source as
+  // `cricketScoreInnings` below — needed here just for `.players` (the
+  // score's resolved-name map), passed to `CricketScorecard`.
+  const cricketScore = cricketScoreFrom(isCurrentlyLive ? scoreQuery.data : scoreInfo?.score)
   // `FootballScorecard`'s event timeline: the live running score while the
   // match is in progress, else straight off the confirmed/pending score —
   // stays visible once the match is completed, unlike `footballState` above.
@@ -322,7 +325,7 @@ function MatchDetail({
           once there's per-innings detail recorded (live-scored or entered
           directly). */}
       {cricketInnings && cricketInnings.length > 0 && (
-        <CricketScorecard match={match} innings={cricketInnings} />
+        <CricketScorecard match={match} innings={cricketInnings} players={cricketScore?.players} />
       )}
 
       {/* Football event timeline: goals/cards/subs, once there's detail


### PR DESCRIPTION
Two unrelated pieces landed on this branch together (rebased onto latest `main` after PR #54 merged and `main` moved on):

## 1. CI: don't fail the UI image build on a flaky GHA cache export

`docker-ui.yml` was failing with:

```
#22 ERROR: failed to parse error response 504: <!DOCTYPE html>
```

That's the Buildx `type=gha` cache-export backend choking on an HTML error page from a transient 504 on GitHub's cache API — not a problem with the Dockerfile or app code. The image itself builds and would push fine; only the cache-upload step was failing, and that was taking the whole job down with it. Fix: `ignore-error=true` on `cache-to`, the documented workaround — a failed cache export becomes non-fatal instead of failing the build/push.

## 2. Resolved player names on cricket/football scores

The feed showed cricket's "who's batting" line as placeholder dashes, because `FeedMatch`/`SearchMatch` (the trimmed match shapes the feed/search use, see PR #54) never carry a full player roster to resolve names from locally, and nothing resolved them server-side either.

Rather than patching just the two "current batter" ids, added one general mechanism covering every player id either sport's score references:

- `CricketScore.players` / `FootballScore.players` (`HashMap<player_id, RosterPreviewPlayer>`, reusing the same type `MatchSide.roster_preview` already uses): every player id referenced anywhere in that score — cricket's `next_ball_context`, batting/bowling cards, fall-of-wickets, `recent_deliveries`; football's goal scorers/assists, cards, substitutions — resolved once, keyed by that same match-scoped id.
- `Api::hydrate_score_players`: walks the score once to collect every referenced id, then a single `Dao::batch_get_match_players` (new — a targeted `BatchGetItem` for known player ids, not a full roster `Query`) + `batch_get_users` pass resolves them all.
- Frontend: `playerNameFor` (both sports' versions) now checks the score's `players` map before falling back to scanning the match's own roster (only ever available on the full `Match` detail view). `describeEvent`/`FootballEventSource` thread the map through so football's goal/card/substitution descriptions resolve on feed/search cards too, not just cricket's batters.

Regenerated the OpenAPI schema and both clients. Verified: `cargo build/clippy/fmt/test` across `agon_core`/`agon_service`/`agon_worker`, `agon_tests` compiles against the regenerated client, and `tsc -b && vite build && eslint` on the frontend — all clean, including after rebasing onto `main`'s cricket bowler-stats-columns change (PR #57), which touched the same file.

---
🤖 Generated with [Claude Code](https://claude.ai/code)
