### PR TITLE
Resolve scorer names on finished matches' feed/search cards

### DIFF
--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -10,7 +10,7 @@ use aws_sdk_dynamodb::types::{AttributeValue, Put, TransactWriteItem};
 
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
-use super::item::{ATTR_PK, ATTR_SK, ItemBuilder, from_item, s, to_item};
+use super::item::{ATTR_PK, ATTR_SK, ItemBuilder, from_item, item_pk, s, to_item};
 use super::keys::{Pk, Sk};
 use super::records::{
     ConfirmedScoreRecord, HeaderPhotoRecord, MatchFormatRecord, MatchPlayerRecord, MatchRecord,
@@ -291,6 +291,56 @@ impl Dao {
         for item in items {
             let record: MatchPlayerRecord = from_item(item)?;
             out.insert(record.player_id.clone(), record);
+        }
+        Ok(out)
+    }
+
+    /// Fetch specific players spanning possibly many *different* matches, in
+    /// one round-trip — the multi-match counterpart to
+    /// [`batch_get_match_players`]. `BatchGetItem` doesn't care that the keys
+    /// span different partitions (a different match's `PK` each), so this is
+    /// still one request-shape whether `keys` names one match or a whole
+    /// feed/search page's worth. Used to resolve a page of matches'
+    /// `confirmed_score`/`pending_score` player ids without the cost scaling
+    /// with page size — see `Api::hydrate_score_players_across_matches`.
+    /// Keyed by `(match_id, player_id)` in the result (unlike the
+    /// single-match version, a bare player id isn't unique across matches).
+    /// Missing pairs are simply absent from the map.
+    ///
+    /// [`batch_get_match_players`]: Dao::batch_get_match_players
+    #[tracing::instrument(skip(self))]
+    pub async fn batch_get_players_across_matches(
+        &self,
+        keys: &[(String, String)],
+    ) -> DaoResult<HashMap<(String, String), MatchPlayerRecord>> {
+        let mut seen = std::collections::HashSet::new();
+        let dynamo_keys: Vec<_> = keys
+            .iter()
+            .filter(|key| seen.insert((*key).clone()))
+            .map(|(match_id, player_id)| {
+                HashMap::from([
+                    (
+                        ATTR_PK.to_string(),
+                        s(Pk::Match(match_id.clone()).to_string()),
+                    ),
+                    (
+                        ATTR_SK.to_string(),
+                        s(Sk::Player(player_id.clone()).to_string()),
+                    ),
+                ])
+            })
+            .collect();
+
+        let items = self.batch_get_all(dynamo_keys, None).await?;
+        let mut out = HashMap::with_capacity(items.len());
+        for item in items {
+            let Pk::Match(match_id) = item_pk(&item)? else {
+                return Err(DaoError::Malformed(
+                    "batch_get_players_across_matches returned a non-match item".into(),
+                ));
+            };
+            let record: MatchPlayerRecord = from_item(item)?;
+            out.insert((match_id, record.player_id.clone()), record);
         }
         Ok(out)
     }

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -1873,6 +1873,17 @@ impl Api {
             }
         }
 
+        // `confirmed_score`/`pending_score`'s scorer/batter names — same
+        // batched-across-the-page treatment as everything else here, not a
+        // per-match live-score fetch (see
+        // `hydrate_confirmed_pending_score_players`'s doc comment).
+        let mut score_refs: Vec<_> = built
+            .iter_mut()
+            .map(|m| (m.id.as_str(), &mut m.confirmed_score, &mut m.pending_score))
+            .collect();
+        self.hydrate_confirmed_pending_score_players(dao, &mut score_refs)
+            .await?;
+
         let items = built.into_iter().map(FeedItem::Match).collect();
 
         Ok(GetFeedResponse::Feed(Json(FeedPage {
@@ -2012,6 +2023,17 @@ impl Api {
                 items.push(m);
             }
         }
+
+        // `confirmed_score`/`pending_score`'s scorer/batter names — same
+        // batched-across-the-page treatment as everything else here, not a
+        // per-match live-score fetch (see
+        // `hydrate_confirmed_pending_score_players`'s doc comment).
+        let mut score_refs: Vec<_> = items
+            .iter_mut()
+            .map(|m| (m.id.as_str(), &mut m.confirmed_score, &mut m.pending_score))
+            .collect();
+        self.hydrate_confirmed_pending_score_players(dao, &mut score_refs)
+            .await?;
 
         Ok(ListMatchesResponse::Matches(Json(MatchPage {
             items,
@@ -2819,10 +2841,63 @@ impl Api {
                 )
             })
             .collect();
-        match score {
-            Score::Cricket(s) => s.players = resolved,
-            Score::Football(s) => s.players = resolved,
-            Score::Simple(_) | Score::Sets(_) => {}
+        set_score_players(score, resolved);
+        Ok(())
+    }
+
+    /// Resolve `players` on every match's `confirmed_score`/`pending_score`
+    /// across a whole feed/search page in one shot — the completed/disputed-
+    /// result counterpart to [`Self::hydrate_score_players`] (which handles
+    /// a single match's *live* score, `GET /matches/:id/score`). Doing this
+    /// per match here would reintroduce the exact per-page-size cost this
+    /// whole endpoint was rewritten to avoid (see `batch_get_match_summaries`'s
+    /// doc comment), so instead every match's referenced player ids
+    /// (`score_player_ids`, paired with that match's own id) go into one
+    /// cross-match `BatchGetItem` (`Dao::batch_get_players_across_matches`)
+    /// regardless of how many distinct matches are on the page.
+    async fn hydrate_confirmed_pending_score_players(
+        &self,
+        dao: &dao::Dao,
+        matches: &mut [(&str, &mut Option<ConfirmedScore>, &mut Option<PendingScore>)],
+    ) -> Result<()> {
+        let mut keys: Vec<(String, String)> = Vec::new();
+        for (match_id, confirmed, pending) in matches.iter() {
+            if let Some(cs) = confirmed {
+                keys.extend(
+                    score_player_ids(&cs.score)
+                        .into_iter()
+                        .map(|pid| (match_id.to_string(), pid)),
+                );
+            }
+            if let Some(ps) = pending {
+                keys.extend(
+                    score_player_ids(&ps.score)
+                        .into_iter()
+                        .map(|pid| (match_id.to_string(), pid)),
+                );
+            }
+        }
+        if keys.is_empty() {
+            return Ok(());
+        }
+
+        let match_players = dao
+            .batch_get_players_across_matches(&keys)
+            .await
+            .map_err(dao_internal)?;
+        let user_ids: Vec<String> = match_players
+            .values()
+            .filter_map(|p| p.user_id.clone())
+            .collect();
+        let users = dao.batch_get_users(&user_ids).await.map_err(dao_internal)?;
+
+        for (match_id, confirmed, pending) in matches.iter_mut() {
+            if let Some(cs) = confirmed {
+                resolve_score_players_for_match(&mut cs.score, match_id, &match_players, &users);
+            }
+            if let Some(ps) = pending {
+                resolve_score_players_for_match(&mut ps.score, match_id, &match_players, &users);
+            }
         }
         Ok(())
     }
@@ -5134,6 +5209,45 @@ fn resolve_score_ids(
             }))
         }
     }
+}
+
+/// Set a score's resolved-players map (`CricketScore.players`/
+/// `FootballScore.players`), whichever variant it is. No-op for
+/// `Score::Simple`/`Score::Sets`, which have no such field.
+fn set_score_players(score: &mut Score, resolved: HashMap<String, RosterPreviewPlayer>) {
+    match score {
+        Score::Cricket(s) => s.players = resolved,
+        Score::Football(s) => s.players = resolved,
+        Score::Simple(_) | Score::Sets(_) => {}
+    }
+}
+
+/// Look up `score`'s own referenced player ids (`score_player_ids`) in a
+/// cross-match batch result (keyed by `(match_id, player_id)`) and set
+/// `score`'s resolved-players map from whichever of them belong to
+/// `match_id`. Shared by [`Api::hydrate_confirmed_pending_score_players`]'s
+/// `confirmed_score`/`pending_score` handling.
+fn resolve_score_players_for_match(
+    score: &mut Score,
+    match_id: &str,
+    match_players: &HashMap<(String, String), dao::records::MatchPlayerRecord>,
+    users: &HashMap<String, dao::records::UserRecord>,
+) {
+    let ids = score_player_ids(score);
+    if ids.is_empty() {
+        return;
+    }
+    let resolved: HashMap<String, RosterPreviewPlayer> = ids
+        .into_iter()
+        .filter_map(|pid| {
+            let p = match_players.get(&(match_id.to_string(), pid.clone()))?;
+            Some((
+                pid,
+                roster_preview_player(p.user_id.as_deref(), p.display_name.as_deref(), users),
+            ))
+        })
+        .collect();
+    set_score_players(score, resolved);
 }
 
 /// Every player id referenced anywhere in a score — the set

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -238,6 +238,12 @@ export function MatchCard({
   // `footballState` is set, i.e. while still in progress).
   const finishedFootballGoals = scoreInfo && !isCurrentlyLive ? footballGoalsFromScore(scoreInfo.score) : null
   const finishedFootballEvents = finishedFootballGoals ? recentGoalEvents(finishedFootballGoals, 3) : []
+  // Resolved server-side on `confirmed_score`/`pending_score` itself (see
+  // `Api::hydrate_confirmed_pending_score_players`) — this card's `match` is
+  // a `FeedMatch`/`SearchMatch`/`Match`, none of which reliably carry a full
+  // player roster to resolve `describeEvent`'s names from locally.
+  const finishedFootballScorePlayers =
+    scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
   const hasLiveState = !!footballState || !!cricketState
   // A cricket match's confirmed score carries its own per-innings detail once
   // it's been live-scored (`Score::Cricket`; see `finishMatch` in
@@ -372,7 +378,9 @@ export function MatchCard({
                       {event.minute !== undefined && (
                         <span className="font-medium text-foreground">{event.minute}'</span>
                       )}
-                      <span className="truncate">{describeEvent(event, match)}</span>
+                      <span className="truncate">
+                        {describeEvent(event, match, finishedFootballScorePlayers)}
+                      </span>
                     </p>
                   )
                 })}


### PR DESCRIPTION
`MatchCard` reads a completed match's goal ticker straight off its embedded `confirmed_score`/`pending_score` (no live-score fetch — by design, a finished match doesn't need to poll `/score`). That embedded `Score` was never hydrated with the `players` map added for the live `GET /matches/:id/score` endpoint, so `describeEvent` had nothing to resolve scorer/assist names from on a `FeedMatch`/`SearchMatch` card — those trimmed match types carry no player roster to fall back to either. Goals rendered with just the emoji and minute, no name.

Fixes it at the same batched-per-page cost everything else on these endpoints already keeps to, rather than a per-match fetch:

- **`Dao::batch_get_players_across_matches`** — the multi-match counterpart to `batch_get_match_players`. `BatchGetItem` doesn't care that its keys span different match partitions, so this resolves a whole page's worth of `(match_id, player_id)` pairs in one request, regardless of how many distinct matches are involved.
- **`Api::hydrate_confirmed_pending_score_players`** — walks every match's `confirmed_score`/`pending_score` once (reusing `score_player_ids`), batches the union across the page, and fills in each score's `players` map. Wired into both `GET /feed` and `GET /matches`.
- `MatchCard` passes the resolved players through to `describeEvent`.

`GET /matches/:id` (the full match detail page) doesn't need this: the full `Match` always carries its own player roster, so `describeEvent` already resolves names from there without the score needing its own copy.

No API shape change (confirmed via a `schema.json` diff), so no client regeneration was needed.

Verified: `cargo build/clippy/fmt/test` across `agon_core`/`agon_service`/`agon_worker`, `agon_tests` compiles against the (unchanged) client, and `tsc -b && vite build && eslint` on the frontend — all clean.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XGxban1VFLCqzt2ruj5hGc)_