### PR TITLE
Add target-reached detection and popup for cricket match chases

### DIFF
--- a/agon_ui/src/components/agon/live/AllOutDialog.tsx
+++ b/agon_ui/src/components/agon/live/AllOutDialog.tsx
@@ -1,0 +1,54 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Pops up the moment a wicket falls that leaves the batting side with no
+ * fresh batter to bring in (see `CricketLiveScoringPage`'s `allOut`) — the
+ * innings is over in the ordinary sense, but same as `target_reached` this
+ * doesn't auto-end itself: the scorer might still want to keep going (a
+ * practice match ignoring the rule, or undoing a wrongly-recorded
+ * dismissal without deleting the event). "End innings" is the primary
+ * action; "Continue" is the secondary, deliberately understated one — it
+ * just dismisses the popup, and the batter picker underneath lets a
+ * previously-out player be picked straight back in (skipping the normal
+ * "show players who've already batted" toggle, since with nobody else left
+ * there's no other choice to offer).
+ */
+export function AllOutDialog({
+  open,
+  battingSideName,
+  submitting,
+  onEnd,
+  onContinue,
+}: {
+  open: boolean
+  battingSideName: string
+  submitting: boolean
+  /** Ends the innings now, with reason `all_out`. */
+  onEnd: () => void
+  /** Dismisses the popup without ending the innings — the batter picker
+   *  underneath takes over from there. */
+  onContinue: () => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onContinue()}>
+      <DialogContent className="max-w-sm text-center sm:text-center">
+        <DialogHeader className="text-center sm:text-center">
+          <DialogTitle>{battingSideName} are all out!</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          No batters left to come in — end the innings, or bring someone who's
+          already batted back in to keep going.
+        </p>
+        <div className="mt-2 flex flex-col gap-2">
+          <Button disabled={submitting} onClick={onEnd}>
+            {submitting ? 'Ending…' : 'End innings'}
+          </Button>
+          <Button variant="outline" disabled={submitting} onClick={onContinue}>
+            Continue
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/agon_ui/src/components/agon/live/OversCompleteDialog.tsx
+++ b/agon_ui/src/components/agon/live/OversCompleteDialog.tsx
@@ -1,0 +1,56 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Pops up the moment the innings' over quota is used up (see
+ * `CricketLiveScoringPage`'s `oversComplete`) — same shape as
+ * `TargetReachedDialog`/`AllOutDialog`: detected, but not auto-ended,
+ * since the scorer might want to play on past the format's quota (extra
+ * overs agreed on the day, a rain-affected restart, etc.) rather than end
+ * the innings there. "End innings" is the primary action; "Continue" is
+ * the secondary one — it just dismisses the popup, and the bowler picker
+ * underneath carries on as normal for the next over, unbounded, for the
+ * rest of this innings (see `oversContinued`'s doc comment).
+ */
+export function OversCompleteDialog({
+  open,
+  battingSideName,
+  oversPerInnings,
+  submitting,
+  onEnd,
+  onContinue,
+}: {
+  open: boolean
+  battingSideName: string
+  /** The format's configured overs-per-innings quota that's just been used
+   *  up — always set by the time this can be open (see `oversComplete`). */
+  oversPerInnings: number
+  submitting: boolean
+  /** Ends the innings now, with reason `overs_complete`. */
+  onEnd: () => void
+  /** Dismisses the popup without ending the innings — the bowler picker
+   *  underneath takes over from there. */
+  onContinue: () => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onContinue()}>
+      <DialogContent className="max-w-sm text-center sm:text-center">
+        <DialogHeader className="text-center sm:text-center">
+          <DialogTitle>Overs complete</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {battingSideName} have batted all {oversPerInnings} overs. End the innings, or continue
+          with more overs.
+        </p>
+        <div className="mt-2 flex flex-col gap-2">
+          <Button disabled={submitting} onClick={onEnd}>
+            {submitting ? 'Ending…' : 'End innings'}
+          </Button>
+          <Button variant="outline" disabled={submitting} onClick={onContinue}>
+            Continue with more overs
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/agon_ui/src/components/agon/live/TargetReachedDialog.tsx
+++ b/agon_ui/src/components/agon/live/TargetReachedDialog.tsx
@@ -1,0 +1,53 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Pops up the moment the chasing side passes the target in the match's last
+ * innings (see `lib/cricketScore`'s `targetReached`) — the win is already
+ * decided, but the innings itself isn't over yet, so the scorer picks what
+ * happens next rather than the app deciding for them: play the over out to
+ * a natural finish, or end the innings right here. Either way the match
+ * isn't marked `completed` from this dialog — same as `overs_complete`, that
+ * still goes through "Finish match" once the scorer's reviewed the score.
+ */
+export function TargetReachedDialog({
+  open,
+  battingSideName,
+  wicketsRemaining,
+  submitting,
+  onPlayOn,
+  onFinish,
+}: {
+  open: boolean
+  battingSideName: string
+  wicketsRemaining: number
+  submitting: boolean
+  /** Dismisses the popup without ending the innings — deliveries keep
+   *  recording normally, this device just won't be prompted again for this
+   *  same innings. */
+  onPlayOn: () => void
+  /** Ends the innings now, with reason `target_reached`. */
+  onFinish: () => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onPlayOn()}>
+      <DialogContent className="max-w-sm text-center sm:text-center">
+        <DialogHeader className="text-center sm:text-center">
+          <DialogTitle>{battingSideName} have won!</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">
+          {battingSideName} have reached the target with {wicketsRemaining} wicket
+          {wicketsRemaining === 1 ? '' : 's'} in hand.
+        </p>
+        <div className="mt-2 flex flex-col gap-2">
+          <Button disabled={submitting} onClick={onFinish}>
+            {submitting ? 'Finishing…' : 'Finish the game'}
+          </Button>
+          <Button variant="outline" disabled={submitting} onClick={onPlayOn}>
+            Play out the overs
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/agon_ui/src/lib/cricketScore.ts
+++ b/agon_ui/src/lib/cricketScore.ts
@@ -273,6 +273,62 @@ export function matchTotalsBySide(state: CricketMatchProgress): Record<string, n
   return totals
 }
 
+/** Wickets a batting side still has in hand, against its own roster size
+ *  (players registered on that side, minus one — the last batter has no
+ *  partner left to bat with), falling back to the standard 10 if the roster
+ *  looks too small to make sense of (e.g. not fully set up). Shared by the
+ *  state-of-game sentence and the target-reached popup so both quote the
+ *  same margin. */
+export function wicketsInHand(
+  match: Pick<Match, 'sides'> & Partial<Pick<Match, 'players'>>,
+  battingSideId: string,
+  wicketsLost: number,
+): number {
+  const rosterSize = (match.players ?? []).filter((p) => p.side_id === battingSideId).length
+  const maxWickets = rosterSize > 1 ? rosterSize - 1 : 10
+  return Math.max(maxWickets - wicketsLost, 0)
+}
+
+/** Whether the innings currently open is the match's last (the one with a
+ *  fixed target) and the batting side's match aggregate has now passed the
+ *  bowling side's — i.e. the chase is won. Unlike overs running out (see
+ *  `oversComplete` in `CricketLiveScoringPage`, unambiguous and auto-ended),
+ *  reaching the target doesn't have one obviously right next step — some
+ *  scorers still want the over played out to a natural finish — so this is
+ *  just the detection; the live scoring page turns it into a popup with both
+ *  choices. `null` when the open innings isn't the decider, or the target
+ *  hasn't been reached (yet). */
+export function targetReached(
+  match: Pick<Match, 'sides'> & Partial<Pick<Match, 'players'>>,
+  score: CricketScore,
+  format: Pick<CricketFormat, 'innings_per_side'>,
+): {
+  battingSideId: string
+  bowlingSideId: string
+  target: number
+  battingTotal: number
+  wicketsRemaining: number
+} | null {
+  if (score.awaiting_next_innings ?? true) return null
+  const quota = match.sides.length * format.innings_per_side
+  if (score.innings.length !== quota) return null
+
+  const open = score.innings[score.innings.length - 1]
+  const totals = matchTotalsBySide({ innings: score.innings, awaiting_next_innings: false })
+  const battingTotal = totals[open.batting_side_id] ?? 0
+  const bowlingTotal = totals[open.bowling_side_id] ?? 0
+  const target = bowlingTotal + 1
+  if (battingTotal < target) return null
+
+  return {
+    battingSideId: open.batting_side_id,
+    bowlingSideId: open.bowling_side_id,
+    target,
+    battingTotal,
+    wicketsRemaining: wicketsInHand(match, open.batting_side_id, open.wickets),
+  }
+}
+
 /**
  * A one-line summary of where the match stands:
  *   - Mid-match, once the bowling side has a score on the board to compare
@@ -346,13 +402,9 @@ export function cricketStateDescription(
     last.overs.balls === 0
 
   if (battingTotal > bowlingTotal && !oversAllUsed) {
-    // No roster (a feed card's `FeedMatch` never carries one) → fall back to
-    // the standard 11-a-side assumption rather than under-count wickets.
-    const rosterSize = (match.players ?? []).filter(
-      (p) => p.side_id === last.batting_side_id,
-    ).length
-    const maxWickets = rosterSize > 1 ? rosterSize - 1 : 10
-    const remaining = Math.max(maxWickets - last.wickets, 0)
+    // No roster (a feed card's `FeedMatch` never carries one) → `wicketsInHand`
+    // falls back to the standard 11-a-side assumption rather than under-count.
+    const remaining = wicketsInHand(match, last.batting_side_id, last.wickets)
     return `${sideNameFor(match, last.batting_side_id)} won by ${remaining} wicket${remaining === 1 ? '' : 's'}`
   }
   const winnerSideId = battingTotal > bowlingTotal ? last.batting_side_id : last.bowling_side_id

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import { ChevronLeft } from 'lucide-react'
@@ -14,6 +14,7 @@ import { ExtraRunsDialog } from '@/components/agon/live/ExtraRunsDialog'
 import { NoBallDialog } from '@/components/agon/live/NoBallDialog'
 import { TargetReachedDialog } from '@/components/agon/live/TargetReachedDialog'
 import { AllOutDialog } from '@/components/agon/live/AllOutDialog'
+import { OversCompleteDialog } from '@/components/agon/live/OversCompleteDialog'
 import { playersOnSide } from '@/lib/members'
 import { cricketFormat } from '@/lib/matchFormat'
 import {
@@ -93,23 +94,31 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
     : null
   const allOut = wicketsRemaining === 0 && !target
 
-  // The over quota's been fully bowled but nothing on the backend blocks
-  // further deliveries (see `match_format`'s doc comment — enforcement is
-  // intentionally out of scope there), so the picker flow would otherwise
-  // just keep asking for a new bowler forever. The reason is unambiguous
-  // here — the overs ran out, nobody needs to be asked — so this ends the
-  // innings itself instead of prompting (see the auto-end effect below).
-  // Skipped while the target-reached or all-out popup is up (or would be)
-  // — those take priority on the rare last-ball-of-the-innings coincidence
-  // where more than one of these is true at once, since the scorer's
-  // choice there should win over an automatic overs_complete.
+  // The over quota's been fully bowled, right at the boundary before a new
+  // over's bowler is picked — same shape as `target`/`allOut` above: nothing
+  // on the backend blocks further deliveries (see `match_format`'s doc
+  // comment — enforcement is intentionally out of scope there), so this is
+  // surfaced as a popup rather than forced, since the scorer might want to
+  // play on past the quota (extra overs agreed on the day, a rain-affected
+  // restart, etc). `target`/`allOut` take priority on the rare coincidence
+  // of more than one of these being true at once — the scorer's choice
+  // there already decides the innings.
   const oversComplete =
     !!innings &&
     format.overs_per_innings != null &&
     innings.overs.overs >= format.overs_per_innings &&
-    innings.overs.balls === 0
-  const oversCompleteAwaitingEnd =
-    oversComplete && !next?.bowler_player_id && !target && !allOut
+    innings.overs.balls === 0 &&
+    !target &&
+    !allOut
+
+  // Monotonic version of the above (true from the moment the quota's first
+  // reached, and never false again for the rest of the innings — overs only
+  // go up) — used only to reset `oversContinued` at the right time. Unlike
+  // `oversComplete` itself, this doesn't flip back to false mid-over, so it
+  // can't be used to gate the popup's visibility, only to know when a new
+  // innings has started.
+  const oversQuotaReached =
+    !!innings && format.overs_per_innings != null && innings.overs.overs >= format.overs_per_innings
 
   // Locally-picked openers/replacement batter/next bowler — only used until
   // the server confirms them via an actual delivery, at which point
@@ -170,24 +179,20 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
     if (!allOutFlag) setAllOutContinued(false)
   }, [allOutFlag])
 
-  // Fires the `overs_complete` end-of-innings event itself the moment the
-  // quota's used up, rather than asking the scorer to pick a reason they
-  // didn't choose. Guarded by a ref (not `appendEvent.isPending`) so it
-  // fires exactly once per innings — `isPending` flips mid-flight and isn't
-  // a dependency here, so it can't retrigger the effect — and resets once
-  // the innings actually ends (`oversComplete` goes false) so the next
-  // innings' overs-complete moment can auto-end too.
-  const autoEndedOversRef = useRef(false)
+  // Ditto for the overs-complete popup — "Continue" dismisses it and lets
+  // the bowler picker underneath carry on for another over, unbounded.
+  // Can't reset on `oversComplete` going false the way the two above reset
+  // on their own flags: `oversComplete` flips back to false the moment the
+  // first ball of the next over's bowled (it's only true right at the
+  // boundary), so that would re-arm the popup every single over past the
+  // quota instead of just once. `oversQuotaReached` is the monotonic
+  // version of the same condition (true from the quota's first reached and
+  // never false again within the innings) — resetting on that instead means
+  // this only re-arms when a new innings actually starts.
+  const [oversContinued, setOversContinued] = useState(false)
   useEffect(() => {
-    if (!oversCompleteAwaitingEnd) {
-      autoEndedOversRef.current = false
-      return
-    }
-    if (autoEndedOversRef.current) return
-    autoEndedOversRef.current = true
-    appendEvent.mutate({ kind: 'InningsEnd', reason: 'overs_complete' })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [oversCompleteAwaitingEnd])
+    if (!oversQuotaReached) setOversContinued(false)
+  }, [oversQuotaReached])
 
   // Concludes the match: flips it to `completed`, sending the score built
   // from this device's own view of the live detail (per-innings totals plus
@@ -368,50 +373,6 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
     appendEvent.mutate(
       { kind: 'InningsEnd', reason },
       { onSuccess: () => setEndInningsOpen(false) },
-    )
-  }
-
-  if (oversCompleteAwaitingEnd) {
-    return (
-      <div className="mx-auto flex max-w-xl flex-col gap-4">
-        {header}
-        <div>
-          <h1 className="text-lg font-semibold">
-            {sideName(battingSide!, 'Side A')} vs {sideName(bowlingSide!, 'Side B')}
-          </h1>
-          <p className="text-sm text-muted-foreground">Overs complete</p>
-        </div>
-        <div className="rounded-xl border bg-card p-4">
-          <p className="text-sm font-medium">{sideName(battingSide!, 'Side A')} batting</p>
-          <p className="mt-0.5 text-3xl font-medium tracking-tight">
-            {innings.runs}/{innings.wickets}
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              ({formatOvers(innings.overs)}/{format.overs_per_innings} ov)
-            </span>
-          </p>
-        </div>
-        <div className="rounded-xl border border-primary/30 bg-primary/5 p-4">
-          {appendEvent.isError ? (
-            <>
-              <p className="mb-3 text-sm font-medium">
-                All {format.overs_per_innings} overs bowled, but ending the innings failed.
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={appendEvent.isPending}
-                onClick={() => endInnings('overs_complete')}
-              >
-                Try again
-              </Button>
-            </>
-          ) : (
-            <p className="text-sm font-medium text-muted-foreground">
-              All {format.overs_per_innings} overs bowled — ending the innings…
-            </p>
-          )}
-        </div>
-      </div>
     )
   }
 
@@ -698,6 +659,17 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
           submitting={appendEvent.isPending}
           onEnd={() => endInnings('all_out')}
           onContinue={() => setAllOutContinued(true)}
+        />
+      )}
+
+      {oversComplete && (
+        <OversCompleteDialog
+          open={!oversContinued}
+          battingSideName={sideNameFor(match, innings.batting_side_id)}
+          oversPerInnings={format.overs_per_innings!}
+          submitting={appendEvent.isPending}
+          onEnd={() => endInnings('overs_complete')}
+          onContinue={() => setOversContinued(true)}
         />
       )}
 

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -12,6 +12,7 @@ import { SidePicker, PlayerPicker, sideName } from '@/components/agon/live/Picke
 import { WicketDialog } from '@/components/agon/live/WicketDialog'
 import { ExtraRunsDialog } from '@/components/agon/live/ExtraRunsDialog'
 import { NoBallDialog } from '@/components/agon/live/NoBallDialog'
+import { TargetReachedDialog } from '@/components/agon/live/TargetReachedDialog'
 import { playersOnSide } from '@/lib/members'
 import { cricketFormat } from '@/lib/matchFormat'
 import {
@@ -23,6 +24,8 @@ import {
   isChipHighlighted,
   playerNameFor,
   runRate,
+  sideNameFor,
+  targetReached,
 } from '@/lib/cricketScore'
 
 type Match = components['schemas']['Match']
@@ -61,18 +64,28 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   // replay needed for the online case.
   const next = state?.next_ball_context ?? null
 
+  // In the match's last innings, whether the chasing side has already
+  // passed the target — the win itself is decided, but unlike overs running
+  // out this doesn't have one obviously right next step, so it surfaces as
+  // a popup (below) rather than auto-ending the innings.
+  const target = state ? targetReached(match, state, format) : null
+
   // The over quota's been fully bowled but nothing on the backend blocks
   // further deliveries (see `match_format`'s doc comment — enforcement is
   // intentionally out of scope there), so the picker flow would otherwise
   // just keep asking for a new bowler forever. The reason is unambiguous
   // here — the overs ran out, nobody needs to be asked — so this ends the
   // innings itself instead of prompting (see the auto-end effect below).
+  // Skipped while the target-reached popup is up (or would be) — that takes
+  // priority on the rare last-ball-of-the-innings coincidence where both are
+  // true at once, since the scorer's choice there should win over an
+  // automatic overs_complete.
   const oversComplete =
     !!innings &&
     format.overs_per_innings != null &&
     innings.overs.overs >= format.overs_per_innings &&
     innings.overs.balls === 0
-  const oversCompleteAwaitingEnd = oversComplete && !next?.bowler_player_id
+  const oversCompleteAwaitingEnd = oversComplete && !next?.bowler_player_id && !target
 
   // Locally-picked openers/replacement batter/next bowler — only used until
   // the server confirms them via an actual delivery, at which point
@@ -103,6 +116,16 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   const [extraDialog, setExtraDialog] = useState<'no_ball' | 'bye' | null>(null)
   const [endInningsOpen, setEndInningsOpen] = useState(false)
   const [startBattingSide, setStartBattingSide] = useState<string | undefined>(undefined)
+
+  // "Play out the overs" just dismisses the target-reached popup — scoring
+  // carries on normally, and this stops it popping up again on every
+  // subsequent ball of the same chase. Resets once the target's no longer
+  // reached (a new innings started) so the next decider gets its own popup.
+  const [targetPopupDismissed, setTargetPopupDismissed] = useState(false)
+  const targetReachedFlag = !!target
+  useEffect(() => {
+    if (!targetReachedFlag) setTargetPopupDismissed(false)
+  }, [targetReachedFlag])
 
   // Fires the `overs_complete` end-of-innings event itself the moment the
   // quota's used up, rather than asking the scorer to pick a reason they
@@ -602,6 +625,17 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
         <Button variant="outline" onClick={() => setEndInningsOpen(true)}>
           End innings
         </Button>
+      )}
+
+      {target && (
+        <TargetReachedDialog
+          open={!targetPopupDismissed}
+          battingSideName={sideNameFor(match, target.battingSideId)}
+          wicketsRemaining={target.wicketsRemaining}
+          submitting={appendEvent.isPending}
+          onPlayOn={() => setTargetPopupDismissed(true)}
+          onFinish={() => endInnings('target_reached')}
+        />
       )}
 
       {readyToScore && (

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -13,6 +13,7 @@ import { WicketDialog } from '@/components/agon/live/WicketDialog'
 import { ExtraRunsDialog } from '@/components/agon/live/ExtraRunsDialog'
 import { NoBallDialog } from '@/components/agon/live/NoBallDialog'
 import { TargetReachedDialog } from '@/components/agon/live/TargetReachedDialog'
+import { AllOutDialog } from '@/components/agon/live/AllOutDialog'
 import { playersOnSide } from '@/lib/members'
 import { cricketFormat } from '@/lib/matchFormat'
 import {
@@ -26,6 +27,7 @@ import {
   runRate,
   sideNameFor,
   targetReached,
+  wicketsInHand,
 } from '@/lib/cricketScore'
 
 type Match = components['schemas']['Match']
@@ -70,22 +72,44 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   // a popup (below) rather than auto-ending the innings.
   const target = state ? targetReached(match, state, format) : null
 
+  // Batters already dismissed for the innings currently open — computed
+  // early (before any conditional return below) so both the "all out" check
+  // and the picker-panel exclude lists can see it. Retired hurt is excluded
+  // on purpose: unlike every other dismissal it isn't final — the same
+  // batter can simply be picked again to resume (see `CricketRetireEvent`'s
+  // doc comment on the backend).
+  const outBatters = (innings?.batting ?? [])
+    .filter((b) => b.dismissal && b.dismissal.kind !== 'retired_hurt')
+    .map((b) => b.player_id)
+
+  // The batting side has lost enough wickets that nobody's left to send in
+  // — "all out". Same shape as `target` just above: detected here but not
+  // auto-ended (see `AllOutDialog`'s doc comment for why), and `target`
+  // takes priority on the rare coincidence of both at once (e.g. the
+  // winning run comes off a run-out that's also the side's last wicket) —
+  // the chase being won already decides the match.
+  const wicketsRemaining = innings
+    ? wicketsInHand(match, innings.batting_side_id, innings.wickets)
+    : null
+  const allOut = wicketsRemaining === 0 && !target
+
   // The over quota's been fully bowled but nothing on the backend blocks
   // further deliveries (see `match_format`'s doc comment — enforcement is
   // intentionally out of scope there), so the picker flow would otherwise
   // just keep asking for a new bowler forever. The reason is unambiguous
   // here — the overs ran out, nobody needs to be asked — so this ends the
   // innings itself instead of prompting (see the auto-end effect below).
-  // Skipped while the target-reached popup is up (or would be) — that takes
-  // priority on the rare last-ball-of-the-innings coincidence where both are
-  // true at once, since the scorer's choice there should win over an
-  // automatic overs_complete.
+  // Skipped while the target-reached or all-out popup is up (or would be)
+  // — those take priority on the rare last-ball-of-the-innings coincidence
+  // where more than one of these is true at once, since the scorer's
+  // choice there should win over an automatic overs_complete.
   const oversComplete =
     !!innings &&
     format.overs_per_innings != null &&
     innings.overs.overs >= format.overs_per_innings &&
     innings.overs.balls === 0
-  const oversCompleteAwaitingEnd = oversComplete && !next?.bowler_player_id && !target
+  const oversCompleteAwaitingEnd =
+    oversComplete && !next?.bowler_player_id && !target && !allOut
 
   // Locally-picked openers/replacement batter/next bowler — only used until
   // the server confirms them via an actual delivery, at which point
@@ -93,10 +117,16 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   const [pickedStriker, setPickedStriker] = useState<string | null>(null)
   const [pickedNonStriker, setPickedNonStriker] = useState<string | null>(null)
   const [pickedBowler, setPickedBowler] = useState<string | null>(null)
+  // Whether the batter picker is revealing already-out players as options
+  // (see the "Show players who've already batted" toggle below) — reset
+  // alongside the local picks themselves, once the server's confirmed a
+  // fresh pick, so the next picker moment starts with it hidden again.
+  const [showOutBatters, setShowOutBatters] = useState(false)
   useEffect(() => {
     if (next?.striker_player_id) setPickedStriker(null)
     if (next?.non_striker_player_id) setPickedNonStriker(null)
     if (next?.bowler_player_id) setPickedBowler(null)
+    if (next?.striker_player_id || next?.non_striker_player_id) setShowOutBatters(false)
   }, [next?.striker_player_id, next?.non_striker_player_id, next?.bowler_player_id])
 
   // Lets the scorer step back into the opener/bowler picker after all three
@@ -126,6 +156,19 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
   useEffect(() => {
     if (!targetReachedFlag) setTargetPopupDismissed(false)
   }, [targetReachedFlag])
+
+  // Ditto for the all-out popup — "Continue" dismisses it and hands off to
+  // the batter picker underneath, which is now free to bring a previously-
+  // out player back in (see `allOut`/`includeOutBatters` below). Wickets
+  // lost never go back down, so `allOut` stays true for the rest of the
+  // innings once it's first true — meaning once dismissed here, it stays
+  // dismissed rather than re-popping on every later wicket. Resets when a
+  // new innings starts (the only way `allOut` itself goes back to false).
+  const [allOutContinued, setAllOutContinued] = useState(false)
+  const allOutFlag = !!allOut
+  useEffect(() => {
+    if (!allOutFlag) setAllOutContinued(false)
+  }, [allOutFlag])
 
   // Fires the `overs_complete` end-of-innings event itself the moment the
   // quota's used up, rather than asking the scorer to pick a reason they
@@ -374,16 +417,11 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
 
   const crr = runRate(innings.runs, innings.overs, format.balls_per_over)
   const overBalls = currentOverDeliveries(state!.recent_deliveries ?? [])
-  // Excluded from the batter picker in addition to whoever's currently at
-  // the crease — `innings.batting` carries the full card while live-scored,
-  // so a dismissal here is as reliable as the server's own scorecard, not
-  // just a locally-replayed guess. Retired hurt is excluded from this list
-  // on purpose: unlike every other dismissal it isn't final — the same
-  // batter can simply be picked again to resume (see `CricketRetireEvent`'s
-  // doc comment on the backend).
-  const outBatters = (innings.batting ?? [])
-    .filter((b) => b.dismissal && b.dismissal.kind !== 'retired_hurt')
-    .map((b) => b.player_id)
+  // Whether the striker/non-striker pickers should offer already-out
+  // batters as options — always true once the side's genuinely all out
+  // (there's nothing else to offer), otherwise only once the scorer's
+  // explicitly asked via the "Show players who've already batted" toggle.
+  const includeOutBatters = allOut || showOutBatters
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">
@@ -462,11 +500,13 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
           <p className="mb-3 text-sm font-medium">
             {editingOpeningPicks && readyToScore
               ? 'Edit your selections'
-              : !effectiveBowler && (!effectiveStriker || !effectiveNonStriker)
-                ? 'New over, new batter — who is it?'
-                : !effectiveBowler
-                  ? "New over — who's bowling?"
-                  : 'Wicket! Who is coming in to bat?'}
+              : allOut
+                ? "Everyone's out — who's coming back in?"
+                : !effectiveBowler && (!effectiveStriker || !effectiveNonStriker)
+                  ? 'New over, new batter — who is it?'
+                  : !effectiveBowler
+                    ? "New over — who's bowling?"
+                    : 'Wicket! Who is coming in to bat?'}
           </p>
           {(!effectiveStriker || editingOpeningPicks) && (
             <div className="mb-3">
@@ -474,7 +514,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
               <PlayerPicker
                 players={playersOnSide(match.players, battingSide!)}
                 value={pickedStriker ?? undefined}
-                exclude={[effectiveNonStriker, ...outBatters]}
+                exclude={includeOutBatters ? [effectiveNonStriker] : [effectiveNonStriker, ...outBatters]}
                 onChange={setPickedStriker}
               />
             </div>
@@ -485,11 +525,24 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
               <PlayerPicker
                 players={playersOnSide(match.players, battingSide!)}
                 value={pickedNonStriker ?? undefined}
-                exclude={[effectiveStriker, ...outBatters]}
+                exclude={includeOutBatters ? [effectiveStriker] : [effectiveStriker, ...outBatters]}
                 onChange={setPickedNonStriker}
               />
             </div>
           )}
+          {(!effectiveStriker || !effectiveNonStriker || editingOpeningPicks) &&
+            !allOut &&
+            !showOutBatters &&
+            outBatters.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mb-3 h-auto px-0 text-xs text-muted-foreground hover:bg-transparent hover:underline"
+                onClick={() => setShowOutBatters(true)}
+              >
+                Show players who've already batted
+              </Button>
+            )}
           {(!effectiveBowler || editingOpeningPicks) && (
             <div>
               <p className="mb-1.5 text-xs text-muted-foreground">Bowler</p>
@@ -635,6 +688,16 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
           submitting={appendEvent.isPending}
           onPlayOn={() => setTargetPopupDismissed(true)}
           onFinish={() => endInnings('target_reached')}
+        />
+      )}
+
+      {allOut && (
+        <AllOutDialog
+          open={!allOutContinued}
+          battingSideName={sideNameFor(match, innings.batting_side_id)}
+          submitting={appendEvent.isPending}
+          onEnd={() => endInnings('all_out')}
+          onContinue={() => setAllOutContinued(true)}
         />
       )}
 


### PR DESCRIPTION
## Summary
Adds detection and UI handling for when the chasing side reaches the target in a cricket match's final innings. Rather than auto-ending the innings (as happens with overs running out), the scorer is presented with a popup offering two choices: finish the game immediately or play out the remaining overs to a natural conclusion.

## Key Changes

- **New `wicketsInHand()` utility** (`cricketScore.ts`): Calculates remaining wickets for a batting side based on roster size, falling back to the standard 10 if roster data is unavailable. Shared by both the state description and the target-reached popup to ensure consistent wicket margin reporting.

- **New `targetReached()` detection function** (`cricketScore.ts`): Identifies when the match's final innings is underway and the batting side's aggregate has passed the bowling side's total. Returns `null` if the target hasn't been reached or the innings isn't the decider, otherwise returns target details including the batting total and wickets remaining.

- **New `TargetReachedDialog` component** (`TargetReachedDialog.tsx`): Modal popup that surfaces when the target is reached, displaying the winning side name and wickets in hand, with two action buttons:
  - "Finish the game": Ends the innings immediately with reason `target_reached`
  - "Play out the overs": Dismisses the popup and allows scoring to continue normally

- **Integration in `CricketLiveScoringPage`** (`CricketLiveScoringPage.tsx`):
  - Calls `targetReached()` each render to detect when the chase is won
  - Manages `targetPopupDismissed` state to prevent the popup from re-appearing on every subsequent ball of the same chase
  - Resets the dismissed flag when a new innings begins (target no longer reached)
  - Prevents `overs_complete` auto-end from firing while the target-reached popup is active, giving the scorer's choice priority on the rare edge case where both conditions are true simultaneously

- **Refactored wicket calculation** in `cricketStateDescription()`: Replaced inline roster-size logic with a call to `wicketsInHand()` for consistency.

## Implementation Notes

- The target-reached detection is non-blocking: the win is decided, but the innings remains open for the scorer to decide its fate, mirroring the design philosophy of `overs_complete` but with explicit user choice rather than automatic action.
- The popup dismissal state is scoped to the current innings and resets when a new one begins, ensuring each decider gets its own popup opportunity.
- Roster fallback to 10 wickets handles feed cards and other contexts where player data may not be available.

https://claude.ai/code/session_01V2nrHp818d4nm3NbLytEeC