### PR TITLE
Fix match side resolution in tests by roster membership

### DIFF
--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -1734,8 +1734,11 @@ async fn match_with_a_confirmed_score() -> (
     let created = matches_post(&owner_config, input)
         .await
         .expect("create match");
-    let side_a = created.sides[0].id.clone();
-    let side_b = created.sides[1].id.clone();
+    // `created.sides` is keyed (and returned) by side id, not creation order,
+    // so `sides[0]`/`sides[1]` aren't reliably "a" then "b" — resolve each
+    // real side id off the roster instead, by who's on it.
+    let side_a = side_id_for_user(&created, &owner.profile.id);
+    let side_b = side_id_for_user(&created, &opponent.profile.id);
     let first_submission_id = created
         .pending_score
         .as_ref()
@@ -2761,6 +2764,20 @@ fn external_invite_token(match_: &models::Match) -> String {
 // ---------------------------------------------------------------------------
 // Local helpers
 // ---------------------------------------------------------------------------
+
+/// The real side id a linked Agon user is assigned to on a match. Sides are
+/// returned keyed (and sorted) by side id, not creation order, so
+/// `match_.sides[0]`/`[1]` don't reliably correspond to a particular
+/// `side_client_id` used at create time — resolve by roster membership
+/// instead.
+fn side_id_for_user(match_: &models::Match, user_id: &str) -> String {
+    match_
+        .players
+        .iter()
+        .find(|p| matches!(&*p.member, models::Member::User(u) if u.user_id == user_id))
+        .and_then(|p| p.side_id.clone())
+        .expect("player with a side assigned")
+}
 
 /// The (linked user id, stable membership id) of each team member that is a
 /// linked Agon user. External (unlinked) members have no user id, so they're


### PR DESCRIPTION
## Summary
Fixes a test reliability issue where match sides were being resolved by array index order rather than by actual roster membership. Since the API returns sides keyed and sorted by side ID (not creation order), the previous approach of using `sides[0]` and `sides[1]` to identify "side a" and "side b" was unreliable.

## Changes
- **Updated `match_with_a_confirmed_score` test**: Replaced direct array indexing with a new helper function `side_id_for_user()` to resolve each player's actual side ID by finding them in the match roster
- **Added `side_id_for_user()` helper**: New utility function that looks up a user's assigned side by searching the match's player roster for the given user ID, ensuring reliable side identification regardless of API response ordering

## Implementation Details
The new helper function iterates through `match_.players` to find the player matching the given `user_id`, then returns their assigned `side_id`. This approach is more robust than relying on response ordering and makes the test intent clearer by explicitly resolving sides based on roster membership rather than positional assumptions.

https://claude.ai/code/session_01PXCqSZEH7ZfozNREVYu6UK