### PR TITLE
Track total known participants count in feed items

### DIFF
--- a/agon_core/src/dao/accept.rs
+++ b/agon_core/src/dao/accept.rs
@@ -76,8 +76,15 @@ impl Dao {
                         responded_at,
                     )
                     .await?;
-                let feed_item =
-                    self.feed_item(accepting_user_id, match_id, &starts_at, now, &[], side_id)?;
+                let feed_item = self.feed_item(
+                    accepting_user_id,
+                    match_id,
+                    &starts_at,
+                    now,
+                    &[],
+                    0,
+                    side_id,
+                )?;
                 let feed_put = Put::builder()
                     .table_name(self.table())
                     .set_item(Some(feed_item))

--- a/agon_core/src/dao/accept.rs
+++ b/agon_core/src/dao/accept.rs
@@ -18,6 +18,7 @@
 
 use aws_sdk_dynamodb::types::{Put, TransactWriteItem};
 
+use super::audience::AudienceMember;
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
 use super::item::{ATTR_PK, Item};
@@ -81,9 +82,10 @@ impl Dao {
                     match_id,
                     &starts_at,
                     now,
-                    &[],
-                    0,
-                    side_id,
+                    &AudienceMember {
+                        viewer_side_id: side_id,
+                        ..Default::default()
+                    },
                 )?;
                 let feed_put = Put::builder()
                     .table_name(self.table())

--- a/agon_core/src/dao/audience.rs
+++ b/agon_core/src/dao/audience.rs
@@ -38,12 +38,21 @@ const FOLLOWER_PAGE: u32 = 100;
 /// ("people you know are playing"). Keeps feed items small and, combined with
 /// the feed endpoint's own page-size cap, bounds the read-time
 /// `batch_get_users` hydration of known players to a single `BatchGetItem`.
+/// Only caps `AudienceMember::known_player_ids` — `known_player_count` still
+/// tracks the true total so a client can show it even past the cap.
 pub const MAX_KNOWN_PLAYERS: usize = 5;
 
 /// One audience member's per-viewer feed data — see the module doc comment.
 #[derive(Debug, Clone, Default)]
 pub struct AudienceMember {
+    /// Capped at `MAX_KNOWN_PLAYERS` — see `known_player_count` for the true,
+    /// uncapped total.
     pub known_player_ids: Vec<String>,
+    /// How many of the match's participants this viewer follows, in total —
+    /// unlike `known_player_ids`, never capped, so a client can render "+N
+    /// more" beyond the hydrated list even when more than `MAX_KNOWN_PLAYERS`
+    /// participants are followed.
+    pub known_player_count: u32,
     /// The side this viewer plays on, if they're themselves a participant —
     /// `None` for a viewer in the audience only via a follow (they're not
     /// playing) or a participant not yet assigned a side.
@@ -89,8 +98,9 @@ impl Dao {
     }
 
     /// Walk a participating user's followers, adding each to `audience` (as
-    /// an audience member) and, capped at `MAX_KNOWN_PLAYERS`, recording that
-    /// they follow `user_id`.
+    /// an audience member) and recording that they follow `user_id`: always
+    /// in `known_player_count`, and — capped at `MAX_KNOWN_PLAYERS` — in
+    /// `known_player_ids`.
     async fn collect_user_followers(
         &self,
         user_id: &str,
@@ -103,9 +113,12 @@ impl Dao {
                 .await?;
             for edge in &page.items {
                 let entry = audience.entry(edge.follower_id.clone()).or_default();
-                let known = &mut entry.known_player_ids;
-                if known.len() < MAX_KNOWN_PLAYERS && !known.iter().any(|id| id == user_id) {
-                    known.push(user_id.to_string());
+                if entry.known_player_ids.iter().any(|id| id == user_id) {
+                    continue;
+                }
+                entry.known_player_count += 1;
+                if entry.known_player_ids.len() < MAX_KNOWN_PLAYERS {
+                    entry.known_player_ids.push(user_id.to_string());
                 }
             }
             match page.next_cursor {

--- a/agon_core/src/dao/feed.rs
+++ b/agon_core/src/dao/feed.rs
@@ -61,6 +61,7 @@ impl Dao {
                     starts_at,
                     now,
                     &viewer.audience.known_player_ids,
+                    viewer.audience.known_player_count,
                     viewer.audience.viewer_side_id.clone(),
                 )?;
                 let put = PutRequest::builder()
@@ -78,9 +79,9 @@ impl Dao {
     /// Build one viewer's feed-entry item for a match. Idempotent on the sort key
     /// `<starts_at>#<matchId>`, so writing it again (via fan-out) overwrites the
     /// identical row. Shared with the accept / create transactions, which write a
-    /// participant's *own* row synchronously (with an empty `known_player_ids` —
-    /// it's their own match, not someone they follow playing in it — and their
-    /// own `side_id`, if assigned).
+    /// participant's *own* row synchronously (with an empty `known_player_ids` /
+    /// zero `known_player_count` — it's their own match, not someone they follow
+    /// playing in it — and their own `side_id`, if assigned).
     pub(super) fn feed_item(
         &self,
         viewer_id: &str,
@@ -88,6 +89,7 @@ impl Dao {
         starts_at: &str,
         now: &str,
         known_player_ids: &[String],
+        known_player_count: u32,
         viewer_side_id: Option<String>,
     ) -> DaoResult<super::item::Item> {
         let record = FeedItemRecord {
@@ -97,6 +99,7 @@ impl Dao {
             starts_at: starts_at.into(),
             created_at: now.into(),
             known_player_ids: known_player_ids.to_vec(),
+            known_player_count,
             viewer_side_id,
         };
         Ok(ItemBuilder::new(to_item(

--- a/agon_core/src/dao/feed.rs
+++ b/agon_core/src/dao/feed.rs
@@ -60,9 +60,7 @@ impl Dao {
                     match_id,
                     starts_at,
                     now,
-                    &viewer.audience.known_player_ids,
-                    viewer.audience.known_player_count,
-                    viewer.audience.viewer_side_id.clone(),
+                    &viewer.audience,
                 )?;
                 let put = PutRequest::builder()
                     .set_item(Some(item))
@@ -79,18 +77,17 @@ impl Dao {
     /// Build one viewer's feed-entry item for a match. Idempotent on the sort key
     /// `<starts_at>#<matchId>`, so writing it again (via fan-out) overwrites the
     /// identical row. Shared with the accept / create transactions, which write a
-    /// participant's *own* row synchronously (with an empty `known_player_ids` /
-    /// zero `known_player_count` — it's their own match, not someone they follow
-    /// playing in it — and their own `side_id`, if assigned).
+    /// participant's *own* row synchronously (with a default `AudienceMember` —
+    /// empty `known_player_ids`, zero `known_player_count` — it's their own
+    /// match, not someone they follow playing in it — plus their own `side_id`,
+    /// if assigned).
     pub(super) fn feed_item(
         &self,
         viewer_id: &str,
         match_id: &str,
         starts_at: &str,
         now: &str,
-        known_player_ids: &[String],
-        known_player_count: u32,
-        viewer_side_id: Option<String>,
+        audience: &AudienceMember,
     ) -> DaoResult<super::item::Item> {
         let record = FeedItemRecord {
             viewer_id: viewer_id.into(),
@@ -98,9 +95,9 @@ impl Dao {
             ref_id: match_id.into(),
             starts_at: starts_at.into(),
             created_at: now.into(),
-            known_player_ids: known_player_ids.to_vec(),
-            known_player_count,
-            viewer_side_id,
+            known_player_ids: audience.known_player_ids.clone(),
+            known_player_count: audience.known_player_count,
+            viewer_side_id: audience.viewer_side_id.clone(),
         };
         Ok(ItemBuilder::new(to_item(
             &Pk::UserFeed(viewer_id.into()),

--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -159,6 +159,7 @@ impl Dao {
                     &match_.starts_at,
                     &match_.created_at,
                     &[],
+                    0,
                     player.side_id.clone(),
                 )?;
                 let feed_put = Put::builder()

--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -8,6 +8,7 @@ use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::update_item::UpdateItemError;
 use aws_sdk_dynamodb::types::{AttributeValue, Put, TransactWriteItem};
 
+use super::audience::AudienceMember;
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
 use super::item::{ATTR_PK, ATTR_SK, ItemBuilder, from_item, item_pk, s, to_item};
@@ -158,9 +159,10 @@ impl Dao {
                     &match_.id,
                     &match_.starts_at,
                     &match_.created_at,
-                    &[],
-                    0,
-                    player.side_id.clone(),
+                    &AudienceMember {
+                        viewer_side_id: player.side_id.clone(),
+                        ..Default::default()
+                    },
                 )?;
                 let feed_put = Put::builder()
                     .table_name(self.table())

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -980,6 +980,14 @@ pub struct FeedItemRecord {
     /// feed items written before this field existed.
     #[serde(default)]
     pub known_player_ids: Vec<String>,
+    /// How many of the match's participants the viewer follows, in total —
+    /// unlike `known_player_ids`, never capped at `MAX_KNOWN_PLAYERS`, so the
+    /// feed can render "+N more" beyond the hydrated list. Same snapshot/
+    /// refresh characteristics as `known_player_ids`. `#[serde(default)]` for
+    /// feed items written before this field existed (back-fills to 0, which
+    /// undercounts pre-existing rows until their next fan-out re-run).
+    #[serde(default)]
+    pub known_player_count: u32,
     /// The side *this viewer* plays on, if they're themselves a participant
     /// in the match — lets their own feed card show the score confirm/dispute
     /// prompt without a live player query. `None` for a viewer in the

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -888,6 +888,11 @@ struct FeedMatch {
     /// empty if the viewer doesn't follow any participant directly (e.g. they
     /// only follow an involved team), or for the viewer's own matches.
     known_participants: Vec<UserProfile>,
+    /// How many of the match's participants the viewer follows, in total.
+    /// `known_participants` itself is capped (see
+    /// `agon_core::dao::audience::MAX_KNOWN_PLAYERS`), so this is what a
+    /// client uses to render "+N more" beyond the hydrated list.
+    known_participants_count: u32,
     /// The side *the caller themselves* plays on, if they're a participant in
     /// this match — `None` if they're not playing (they're seeing this card
     /// via a follow) or not yet assigned a side. Lets a client resolve the
@@ -1786,6 +1791,7 @@ impl Api {
         struct EligibleEntry {
             match_id: String,
             known_player_ids: Vec<String>,
+            known_player_count: u32,
             viewer_side_id: Option<String>,
         }
         let mut eligible: Vec<EligibleEntry> = Vec::with_capacity(page.items.len());
@@ -1802,6 +1808,7 @@ impl Api {
             eligible.push(EligibleEntry {
                 match_id: entry.ref_id.clone(),
                 known_player_ids: entry.known_player_ids.clone(),
+                known_player_count: entry.known_player_count,
                 viewer_side_id: entry.viewer_side_id.clone(),
             });
         }
@@ -1860,6 +1867,7 @@ impl Api {
                     &summary.sides,
                     &users,
                     known_participants,
+                    entry.known_player_count,
                     entry.viewer_side_id.clone(),
                     i_liked,
                 );

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -868,6 +868,7 @@ pub fn feed_match_from_records(
     sides: &[MatchSideRecord],
     users: &std::collections::HashMap<String, UserRecord>,
     known_participants: Vec<UserProfile>,
+    known_participants_count: u32,
     viewer_side_id: Option<String>,
     i_liked: bool,
 ) -> FeedMatch {
@@ -899,6 +900,7 @@ pub fn feed_match_from_records(
             })
             .collect(),
         known_participants,
+        known_participants_count,
         viewer_side_id,
         confirmed_score: rec
             .confirmed_score

--- a/agon_ui/src/components/agon/KnownPlayersRow.tsx
+++ b/agon_ui/src/components/agon/KnownPlayersRow.tsx
@@ -1,0 +1,68 @@
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { Avatar } from './Avatar'
+
+type UserProfile = components['schemas']['UserProfile']
+
+export interface KnownPlayersRowProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Up to `MAX_KNOWN_PLAYERS` participants the viewer follows — a feed
+   *  card's `FeedMatch.known_participants`. */
+  participants: UserProfile[]
+  /** The true, uncapped total the participants were followed out of — a feed
+   *  card's `FeedMatch.known_participants_count`. May exceed
+   *  `participants.length`, in which case the row falls back to "+N" for the
+   *  rest. */
+  count: number
+}
+
+/** Avatars rendered in the overlapping cluster, regardless of how many
+ *  hydrated profiles are available. */
+const MAX_AVATARS = 3
+/** Participants named directly before the rest collapse into "+N". */
+const MAX_NAMED = 2
+
+/**
+ * "You follow Sofia, Raj +1" — shown on a feed card when the viewer follows
+ * one or more of the match's participants. `count` (not
+ * `participants.length`) drives the "+N" suffix, since `participants` is
+ * capped server-side (`agon_core::dao::audience::MAX_KNOWN_PLAYERS`) while
+ * `count` is the true total — so the row stays accurate even when more
+ * participants are followed than were hydrated. Renders nothing if `count`
+ * is 0 (the viewer doesn't follow anyone playing, or this is their own
+ * match).
+ */
+export function KnownPlayersRow({
+  participants,
+  count,
+  className,
+  ...props
+}: KnownPlayersRowProps) {
+  if (count === 0) return null
+
+  const avatars = participants.slice(0, MAX_AVATARS)
+  const named = participants.slice(0, MAX_NAMED)
+  const remaining = count - named.length
+
+  return (
+    <div className={cn('flex items-center gap-2.5', className)} {...props}>
+      <div className="flex -space-x-2">
+        {avatars.map((p) => (
+          <Avatar
+            key={p.id}
+            name={p.name}
+            imageUrl={p.profile_image?.image_url}
+            size="sm"
+            className="ring-2 ring-card"
+          />
+        ))}
+      </div>
+      <p className="min-w-0 truncate text-xs text-muted-foreground">
+        You follow{' '}
+        <span className="font-medium text-foreground">
+          {named.map((p) => p.name).join(', ')}
+        </span>
+        {remaining > 0 && ` +${remaining}`}
+      </p>
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -17,6 +17,7 @@ import { LiveMatchBlock } from './live/LiveMatchBlock'
 import { CricketMatchBlock } from './live/CricketMatchBlock'
 import { CricketScoreBlock } from './CricketScoreBlock'
 import { LiveIndicator } from './live/LiveIndicator'
+import { KnownPlayersRow } from './KnownPlayersRow'
 import { useMatchScore } from '@/hooks/useMatchScore'
 import { describeEvent, eventEmoji, footballScoreFrom, recentGoalEvents } from '@/lib/liveScore'
 import {
@@ -388,6 +389,17 @@ export function MatchCard({
             )}
           </div>
         )
+      )}
+
+      {/* "You follow Sofia, Raj +1" — who among the match's participants the
+          viewer follows. Only a feed card's `FeedMatch` carries this (a
+          per-viewer fan-out concept); `Match`/`SearchMatch` don't. */}
+      {'known_participants' in match && (
+        <KnownPlayersRow
+          participants={match.known_participants}
+          count={match.known_participants_count}
+          className="mx-3.5 mb-3 rounded-lg bg-muted/50 px-3.5 py-2.5"
+        />
       )}
 
       {/* Header photo, when the match has one. The gap above comes from the

--- a/agon_worker/src/temporal/activities.rs
+++ b/agon_worker/src/temporal/activities.rs
@@ -24,6 +24,7 @@ pub struct AgonActivities {
 pub struct FeedViewer {
     pub viewer_id: String,
     pub known_player_ids: Vec<String>,
+    pub known_player_count: u32,
     pub viewer_side_id: Option<String>,
 }
 
@@ -85,6 +86,7 @@ impl AgonActivities {
             .map(|(viewer_id, member)| FeedViewer {
                 viewer_id,
                 known_player_ids: member.known_player_ids,
+                known_player_count: member.known_player_count,
                 viewer_side_id: member.viewer_side_id,
             })
             .collect();
@@ -110,6 +112,7 @@ impl AgonActivities {
                 viewer_id: v.viewer_id,
                 audience: agon_core::dao::audience::AudienceMember {
                     known_player_ids: v.known_player_ids,
+                    known_player_count: v.known_player_count,
                     viewer_side_id: v.viewer_side_id,
                 },
             })


### PR DESCRIPTION
## Summary
Add tracking of the total count of match participants a viewer follows, separate from the capped list of hydrated participant profiles. This allows feed cards to accurately display "+N more" indicators even when more participants are followed than the server hydrates.

## Changes

### Backend (agon_core, agon_service, agon_worker)
- **agon_core/src/dao/audience.rs**: Add `known_player_count: u32` field to `AudienceMember` to track the true, uncapped total of followed participants. Update `collect_user_followers` to always increment the count while capping the hydrated `known_player_ids` list at `MAX_KNOWN_PLAYERS`.
- **agon_core/src/dao/records.rs**: Add `known_player_count: u32` field to `FeedItemRecord` with `#[serde(default)]` for backward compatibility with pre-existing feed items.
- **agon_core/src/dao/feed.rs**: Thread `known_player_count` through `feed_item()` builder method and pass it when constructing feed entries during fan-out.
- **agon_core/src/dao/accept.rs** & **match_ops.rs**: Pass `0` for `known_player_count` when creating a participant's own feed entry (they don't "follow" their own match).
- **agon_service/src/main.rs**: Add `known_participants_count: u32` field to `FeedMatch` struct and thread it through the feed response mapping.
- **agon_service/src/mapping.rs**: Update `feed_match_from_records()` to accept and include `known_participants_count`.
- **agon_worker/src/temporal/activities.rs**: Add `known_player_count` to `FeedViewer` struct and propagate it through activity execution.

### Frontend (agon_ui)
- **agon_ui/src/components/agon/KnownPlayersRow.tsx** (new): New component that renders "You follow Sofia, Raj +1" on feed cards. Displays up to 3 overlapping avatars and names up to 2 participants, with a "+N" suffix for the remainder. Uses the uncapped `count` prop to accurately show how many additional participants are followed beyond the hydrated list.
- **agon_ui/src/components/agon/MatchCard.tsx**: Integrate `KnownPlayersRow` component for `FeedMatch` cards (which carry `known_participants` and `known_participants_count`), conditionally rendering only when the viewer follows at least one participant.

## Implementation Details
- The `known_player_count` is always incremented in `collect_user_followers`, ensuring the true total is tracked even when `known_player_ids` is capped at `MAX_KNOWN_PLAYERS`.
- Feed items written before this change will deserialize with `known_player_count: 0` (via `#[serde(default)]`), which undercounts pre-existing rows until their next fan-out refresh.
- The component gracefully handles the case where `count === 0` (viewer doesn't follow anyone playing) by rendering nothing.

https://claude.ai/code/session_01KwaSieT1cGt9SSRQSJPXF2