### PR TITLE
Remove duplicate LIVE indicator on live matches

### DIFF
--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -16,7 +16,6 @@ import { InvitationResponseDialog } from './InvitationResponseDialog'
 import { LiveMatchBlock } from './live/LiveMatchBlock'
 import { CricketMatchBlock } from './live/CricketMatchBlock'
 import { CricketScoreBlock } from './CricketScoreBlock'
-import { LiveIndicator } from './live/LiveIndicator'
 import { KnownPlayersRow } from './KnownPlayersRow'
 import { useMatchScore } from '@/hooks/useMatchScore'
 import { describeEvent, eventEmoji, footballScoreFrom, recentGoalEvents } from '@/lib/liveScore'
@@ -245,7 +244,6 @@ export function MatchCard({
   // player roster to resolve `describeEvent`'s names from locally.
   const finishedFootballScorePlayers =
     scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
-  const hasLiveState = !!footballState || !!cricketState
   // A cricket match's confirmed score carries its own per-innings detail once
   // it's been live-scored (`Score::Cricket`; see `finishMatch` in
   // `CricketLiveScoringPage`) — a manually-logged result still degrades to
@@ -452,11 +450,7 @@ export function MatchCard({
           <MessageCircle className="size-3.5" /> {comment_count}
         </button>
         <ShareMatchButton match={match} />
-        {hasLiveState ? (
-          <LiveIndicator className="ml-auto" />
-        ) : (
-          <StatusBadge status={matchBadgeStatus(match)} className="ml-auto" />
-        )}
+        <StatusBadge status={matchBadgeStatus(match)} className="ml-auto" />
       </div>
     </div>
   )

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -16,7 +16,6 @@ import { CricketMatchBlock } from '@/components/agon/live/CricketMatchBlock'
 import { CricketScoreBlock } from '@/components/agon/CricketScoreBlock'
 import { CricketScorecard } from '@/components/agon/CricketScorecard'
 import { FootballScorecard } from '@/components/agon/FootballScorecard'
-import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { useLiveEvents } from '@/hooks/useLiveScore'
 import { useMatchScore } from '@/hooks/useMatchScore'
 import { footballScoreFrom, footballEventSourceFromScore } from '@/lib/liveScore'
@@ -258,7 +257,7 @@ function MatchDetail({
           )}
 
           <div className="mt-3 flex items-center justify-between">
-            {hasLiveState ? <LiveIndicator /> : <StatusBadge status={matchBadgeStatus(match)} />}
+            <StatusBadge status={matchBadgeStatus(match)} />
             <div className="flex items-center gap-1">
               {canEdit && isLiveSport && !cancelled && match.status !== 'completed' && (
                 <Button asChild variant="ghost" size="sm" className="h-7 gap-1 px-2 text-xs text-primary">


### PR DESCRIPTION
The match card footer and match detail page status row each showed a
second LiveIndicator in place of the confirmed/unconfirmed status
badge while a match was being scored live — on top of the LiveIndicator
LiveMatchBlock/CricketMatchBlock already render next to the score
itself. Drop the duplicate and always show StatusBadge there, which
already reads "In progress" for a live match.