### PR TITLE
Link roster players to their profile in match details

### DIFF
--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -589,10 +589,25 @@ function SideRoster({ title, players }: { title: string; players: MatchPlayer[] 
           // Token-invited (external) players have a shareable link; offer to
           // copy it instead of the bare "invited" label.
           const inviteToken = memberInviteToken(p.member)
+          // Only linked Agon users have a profile to open — external players
+          // (invited by name only) have no `user_id` and stay plain text.
+          const userId = p.member.type === 'User' ? p.member.user_id : undefined
           return (
             <div key={i} className="flex items-center gap-2">
-              <Avatar name={name} imageUrl={avatarUrl} size="md" />
-              <span className="flex-1 truncate text-sm">{name}</span>
+              {userId ? (
+                <Link
+                  to={`/users/${userId}`}
+                  className="flex min-w-0 flex-1 items-center gap-2"
+                >
+                  <Avatar name={name} imageUrl={avatarUrl} size="md" />
+                  <span className="flex-1 truncate text-sm">{name}</span>
+                </Link>
+              ) : (
+                <>
+                  <Avatar name={name} imageUrl={avatarUrl} size="md" />
+                  <span className="flex-1 truncate text-sm">{name}</span>
+                </>
+              )}
               {inviteToken ? (
                 <CopyInviteButton token={inviteToken} />
               ) : (


### PR DESCRIPTION
Clicking a linked Agon user in a match's side roster now navigates to
their profile (/users/:userId). External players (invited by name
only, with no linked account) have no profile to open and stay plain
text.