### PR TITLE
Restrict goal/card/sub recording to phases where play is live

### DIFF
--- a/agon_ui/src/components/agon/live/UndoLastEventButton.tsx
+++ b/agon_ui/src/components/agon/live/UndoLastEventButton.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { Undo2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { useUndoLastLiveEvent } from '@/hooks/useLiveScore'
+
+/**
+ * "Undo" for the live scoring screens (football and cricket alike) —
+ * deletes the most recently recorded event outright via
+ * `useUndoLastLiveEvent`. That's the only correction the backend supports:
+ * no arbitrary-position edits, just undo-the-tip (see `delete_live_event`'s
+ * doc comment on the server) — so this is deliberately a single "undo last"
+ * action rather than a per-event delete button in the event log.
+ *
+ * Renders nothing once there's no `seq` yet (scoring hasn't started on this
+ * match) — same "nothing to undo" gate the disabled state would otherwise
+ * need to express. Confirms first since this genuinely deletes history
+ * rather than marking it undone; there's no redo.
+ */
+export function UndoLastEventButton({
+  matchId,
+  seq,
+}: {
+  matchId: string
+  /** The log's current tip, e.g. from `useLiveSeq` — `undefined` while
+   *  still loading, `0` before anything's been recorded. */
+  seq: number | undefined
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const undo = useUndoLastLiveEvent(matchId)
+
+  if (!seq) return null
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="text-muted-foreground"
+        onClick={() => setConfirmOpen(true)}
+      >
+        <Undo2 className="size-3.5" /> Undo last
+      </Button>
+
+      <Dialog open={confirmOpen} onOpenChange={(open) => !undo.isPending && setConfirmOpen(open)}>
+        <DialogContent className="max-w-sm text-center sm:text-center">
+          <DialogHeader className="text-center sm:text-center">
+            <DialogTitle>Undo the last event?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            This removes the most recently recorded event for good — there's no redo.
+          </p>
+          {undo.isError && (
+            <p className="text-xs text-destructive">{(undo.error as Error).message}</p>
+          )}
+          <div className="mt-2 flex flex-col gap-2">
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={undo.isPending}
+              onClick={() => undo.mutate(seq, { onSuccess: () => setConfirmOpen(false) })}
+            >
+              {undo.isPending ? 'Undoing…' : 'Yes, undo it'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={undo.isPending}
+              onClick={() => setConfirmOpen(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -122,3 +122,41 @@ export function useAppendFootballEvent(matchId: string) {
 export function useAppendCricketEvent(matchId: string) {
   return useAppendLiveEvent<CricketLiveEvent>(matchId, 'Cricket')
 }
+
+/**
+ * Undoes the most recently recorded live event — `DELETE
+ * /matches/:match_id/live/events/:seq`, which the server restricts to the
+ * current log tip (see `delete_live_event` on the backend): pass anything
+ * else and it 400s rather than deleting mid-log. Callers pass the `seq`
+ * they believe is the tip (typically straight off `useLiveSeq`) rather than
+ * this hook reading the cache itself, so a stale button — rendered before an
+ * in-flight append's response lands — surfaces that mismatch as an error
+ * instead of silently undoing the wrong thing.
+ *
+ * On success, updates the tip/score caches the same way `useAppendLiveEvent`
+ * does, from the response's already-recomputed snapshot rather than an
+ * extra refetch.
+ */
+export function useUndoLastLiveEvent(matchId: string) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (seq: number) => {
+      const { data, error, response } = await fetchClient.DELETE(
+        '/matches/{match_id}/live/events/{seq}',
+        { params: { path: { match_id: matchId, seq } } },
+      )
+      if (response.status === 400) {
+        throw new Error('Only the most recently recorded event can be undone')
+      }
+      if (error || !data) throw new Error('Failed to undo that event')
+      return data
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(liveSeqQueryKey(matchId), data.last_seq)
+      queryClient.setQueryData(matchScoreQueryKey(matchId), data.score)
+      queryClient.invalidateQueries({ queryKey: ['match', matchId] })
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
+    },
+  })
+}

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -428,6 +428,23 @@ export function currentMinute(state: FootballScore, now: Date = new Date()): num
   }
 }
 
+/** Whether the ball is actually in play right now — the phases where a goal
+ *  (or card/sub) can meaningfully happen. Excludes not just `penalties`
+ *  (which has its own dedicated recording UI) but every clock-stopped phase —
+ *  `not_started`, `half_time`, `full_time`, `extra_time_half_time`,
+ *  `extra_time_full_time` — since nothing should be recorded as happening
+ *  during a break that hasn't been played yet. Used to gate the live
+ *  scoring screen's Goal/Card/Sub quick actions on the current phase, not
+ *  just `!== 'penalties'` (see `LiveScoringPage`). */
+export function isLivePlayPhase(phase: ClockPhase): boolean {
+  return (
+    phase === 'first_half' ||
+    phase === 'second_half' ||
+    phase === 'extra_time_first_half' ||
+    phase === 'extra_time_second_half'
+  )
+}
+
 /** Human label for the current phase, e.g. "2nd half" / "Half-time". */
 export function phaseLabel(phase: ClockPhase): string {
   switch (phase) {

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button'
 import { useAppendCricketEvent, useLiveSeq } from '@/hooks/useLiveScore'
 import { matchScoreQueryKey, useMatchScore } from '@/hooks/useMatchScore'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
+import { UndoLastEventButton } from '@/components/agon/live/UndoLastEventButton'
 import { SidePicker, PlayerPicker, sideName } from '@/components/agon/live/Pickers'
 import { WicketDialog } from '@/components/agon/live/WicketDialog'
 import { ExtraRunsDialog } from '@/components/agon/live/ExtraRunsDialog'
@@ -247,7 +248,10 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
       <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${match.id}`)}>
         <ChevronLeft className="size-4" /> Back
       </Button>
-      <LiveIndicator />
+      <div className="flex items-center gap-1">
+        <UndoLastEventButton matchId={match.id} seq={seq.data} />
+        <LiveIndicator />
+      </div>
     </div>
   )
 

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -9,6 +9,7 @@ import { useAppendFootballEvent, useLiveSeq } from '@/hooks/useLiveScore'
 import { matchScoreQueryKey, useMatchScore } from '@/hooks/useMatchScore'
 import { RecordEventDialog, type EventKind } from '@/components/agon/live/RecordEventDialog'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
+import { UndoLastEventButton } from '@/components/agon/live/UndoLastEventButton'
 import { CricketLiveScoringPage } from './CricketLiveScoringPage'
 import { footballFormat } from '@/lib/matchFormat'
 import {
@@ -265,7 +266,10 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
         <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${match.id}`)}>
           <ChevronLeft className="size-4" /> Back
         </Button>
-        <LiveIndicator />
+        <div className="flex items-center gap-1">
+          <UndoLastEventButton matchId={match.id} seq={seq.data} />
+          <LiveIndicator />
+        </div>
       </div>
 
       <div>

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -17,6 +17,7 @@ import {
   eventEmoji,
   eventsFromDetail,
   footballScoreFrom,
+  isLivePlayPhase,
   loadTrackPrefs,
   nextPeriodForPhase,
   nextPhaseActionLabel,
@@ -193,17 +194,22 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
   ]
   const showAdvanceClockTile = advanceClockPhases.includes(phase)
 
+  // Goal/card/sub are only offered while the ball's actually in play — not
+  // before kickoff, not at half-time/full-time, not during extra-time's
+  // break, and not during the penalty shootout (which has its own recording
+  // panel below). The clock-advance tile (kick off / start 2nd half / etc.)
+  // is offered independently via `showAdvanceClockTile`, so a break phase
+  // still gets its "move to the next phase" action even with no live events.
   const actions: {
     key: EventKind | 'half_ft'
     label: string
     icon: React.ReactNode
     onClick: () => void
     disabled?: boolean
-  }[] =
-    phase === 'penalties'
-      ? []
-      : [
-          { key: 'goal', label: 'Goal', icon: <CircleDot className="size-5" />, onClick: () => setDialogKind('goal') },
+  }[] = [
+    ...(isLivePlayPhase(phase)
+      ? [
+          { key: 'goal' as const, label: 'Goal', icon: <CircleDot className="size-5" />, onClick: () => setDialogKind('goal') },
           ...(prefs.cards
             ? [{ key: 'card' as const, label: 'Card', icon: <Flag className="size-5" />, onClick: () => setDialogKind('card') }]
             : []),
@@ -217,18 +223,20 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
                 },
               ]
             : []),
-          ...(showAdvanceClockTile
-            ? [
-                {
-                  key: 'half_ft' as const,
-                  label: nextPhaseActionLabel(phase, progressionCtx),
-                  icon: <TimerReset className="size-5" />,
-                  onClick: handleHalfFt,
-                  disabled: nextPeriodForPhase(phase, progressionCtx) === null,
-                },
-              ]
-            : []),
         ]
+      : []),
+    ...(showAdvanceClockTile
+      ? [
+          {
+            key: 'half_ft' as const,
+            label: nextPhaseActionLabel(phase, progressionCtx),
+            icon: <TimerReset className="size-5" />,
+            onClick: handleHalfFt,
+            disabled: nextPeriodForPhase(phase, progressionCtx) === null,
+          },
+        ]
+      : []),
+  ]
 
   // At full-time/extra-time-full-time still level, the format may call for
   // more play — offer it, with an explicit override to finish as a draw


### PR DESCRIPTION
Goal, card, and substitution quick actions on the live scoring screen
were only excluded during the penalty shootout, so it was possible to
log a goal during half-time (or before kickoff, or during any other
clock-stopped break). Gate them on a new isLivePlayPhase() check
instead, which only allows recording during first_half, second_half,
extra_time_first_half, and extra_time_second_half. The clock-advance
tile (Kick off / Start 2nd half / etc.) is unaffected.