### PR TITLE
Allow editing a match side's custom name after creation

### DIFF
--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -546,6 +546,85 @@ impl Dao {
         }
     }
 
+    /// Update the custom `name` on one or more of a match's sides, in place
+    /// on the embedded `sides` map (validation — e.g. the team/name
+    /// exclusivity rule — is the caller's job, same division of labor as
+    /// `create_match`). `Some(name)` sets it; `None` removes the attribute,
+    /// falling back at read time to the priority chain `Api::resolve_side_names`
+    /// implements (sole player, then team, then a neutral default). Only the
+    /// sides named in `updates` are touched. A no-op for an empty slice.
+    /// `NotFound` if the match doesn't exist.
+    #[tracing::instrument(skip(self))]
+    pub async fn update_match_side_names(
+        &self,
+        match_id: &str,
+        updates: &[(String, Option<String>)],
+    ) -> DaoResult<()> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
+        let mut set_clauses = Vec::new();
+        let mut remove_clauses = Vec::new();
+        let mut names: HashMap<String, String> = HashMap::new();
+        let mut values: HashMap<String, AttributeValue> = HashMap::new();
+        names.insert("#name".into(), "name".into());
+        names.insert("#pk".into(), ATTR_PK.into());
+
+        for (i, (side_id, name)) in updates.iter().enumerate() {
+            let side_alias = format!("#s{i}");
+            names.insert(side_alias.clone(), side_id.clone());
+            match name {
+                Some(n) => {
+                    let value_alias = format!(":n{i}");
+                    set_clauses.push(format!("sides.{side_alias}.#name = {value_alias}"));
+                    values.insert(value_alias, s(n));
+                }
+                None => {
+                    remove_clauses.push(format!("sides.{side_alias}.#name"));
+                }
+            }
+        }
+
+        let mut expr = String::new();
+        if !set_clauses.is_empty() {
+            expr.push_str("SET ");
+            expr.push_str(&set_clauses.join(", "));
+        }
+        if !remove_clauses.is_empty() {
+            if !expr.is_empty() {
+                expr.push(' ');
+            }
+            expr.push_str("REMOVE ");
+            expr.push_str(&remove_clauses.join(", "));
+        }
+
+        let result = self
+            .client
+            .update_item()
+            .table_name(self.table())
+            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
+            .key(ATTR_SK, s(Sk::Meta.to_string()))
+            .update_expression(expr)
+            .condition_expression("attribute_exists(#pk)")
+            .set_expression_attribute_names(Some(names))
+            .set_expression_attribute_values(if values.is_empty() {
+                None
+            } else {
+                Some(values)
+            })
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => Ok(()),
+            Err(e) if is_update_conditional_failure(&e) => {
+                Err(DaoError::NotFound(format!("match {match_id}")))
+            }
+            Err(e) => Err(DaoError::Dynamo(e.to_string())),
+        }
+    }
+
     /// Add or update a single match player (roster reconciliation / late adds).
     #[tracing::instrument(skip(self, player), fields(player_id = %player.player_id))]
     pub async fn put_match_player(

--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -417,6 +417,16 @@ impl Dao {
     /// `description`, `status`, `starts_at`, `location` (Some(None) clears it),
     /// and the resolved `confirmed_score`/`pending_score` blobs. `NotFound` if
     /// the match is absent.
+    ///
+    /// `side_names` renames one or more sides in the same `UpdateItem` call as
+    /// everything else here — both target the same item, so folding it in
+    /// (rather than a second call) makes a request that edits, say, the
+    /// match's `name` and a side's `name` together atomic: either both land
+    /// or neither does, instead of one succeeding and the other failing
+    /// independently. `(side_id, Some(name))` sets that side's custom name;
+    /// `(side_id, None)` removes it, falling back at read time to the
+    /// priority chain `Api::resolve_side_names` implements (sole player, then
+    /// team, then a neutral default). An empty slice touches no sides.
     #[allow(clippy::too_many_arguments)]
     #[tracing::instrument(skip(self))]
     pub async fn update_match_meta(
@@ -436,6 +446,7 @@ impl Dao {
         // overwrites. No "clear" case yet (Phase 1 doesn't need one — a
         // match's sport, and so its format shape, doesn't change).
         format: Option<MatchFormatRecord>,
+        side_names: &[(String, Option<String>)],
     ) -> DaoResult<()> {
         let mut set: Vec<String> = Vec::new();
         let mut remove: Vec<String> = Vec::new();
@@ -501,6 +512,26 @@ impl Dao {
             names.insert("#fmt".into(), "format".into());
             values.insert(":fmt".into(), to_attr(&fmt)?);
         }
+        if !side_names.is_empty() {
+            // Same literal attribute name ("name") as the top-level `#name`
+            // alias above — reinserting it with the same value is harmless,
+            // and lets a top-level rename and a side rename share one alias.
+            names.insert("#name".into(), "name".into());
+            for (i, (side_id, side_name)) in side_names.iter().enumerate() {
+                let side_alias = format!("#s{i}");
+                names.insert(side_alias.clone(), side_id.clone());
+                match side_name {
+                    Some(n) => {
+                        let value_alias = format!(":n{i}");
+                        set.push(format!("sides.{side_alias}.#name = {value_alias}"));
+                        values.insert(value_alias, s(n));
+                    }
+                    None => {
+                        remove.push(format!("sides.{side_alias}.#name"));
+                    }
+                }
+            }
+        }
 
         if set.is_empty() && remove.is_empty() {
             return Ok(());
@@ -526,85 +557,6 @@ impl Dao {
             .table_name(self.table())
             .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
             .key("SK", s(Sk::Meta.to_string()))
-            .update_expression(expr)
-            .condition_expression("attribute_exists(#pk)")
-            .set_expression_attribute_names(Some(names))
-            .set_expression_attribute_values(if values.is_empty() {
-                None
-            } else {
-                Some(values)
-            })
-            .send()
-            .await;
-
-        match result {
-            Ok(_) => Ok(()),
-            Err(e) if is_update_conditional_failure(&e) => {
-                Err(DaoError::NotFound(format!("match {match_id}")))
-            }
-            Err(e) => Err(DaoError::Dynamo(e.to_string())),
-        }
-    }
-
-    /// Update the custom `name` on one or more of a match's sides, in place
-    /// on the embedded `sides` map (validation — e.g. the team/name
-    /// exclusivity rule — is the caller's job, same division of labor as
-    /// `create_match`). `Some(name)` sets it; `None` removes the attribute,
-    /// falling back at read time to the priority chain `Api::resolve_side_names`
-    /// implements (sole player, then team, then a neutral default). Only the
-    /// sides named in `updates` are touched. A no-op for an empty slice.
-    /// `NotFound` if the match doesn't exist.
-    #[tracing::instrument(skip(self))]
-    pub async fn update_match_side_names(
-        &self,
-        match_id: &str,
-        updates: &[(String, Option<String>)],
-    ) -> DaoResult<()> {
-        if updates.is_empty() {
-            return Ok(());
-        }
-
-        let mut set_clauses = Vec::new();
-        let mut remove_clauses = Vec::new();
-        let mut names: HashMap<String, String> = HashMap::new();
-        let mut values: HashMap<String, AttributeValue> = HashMap::new();
-        names.insert("#name".into(), "name".into());
-        names.insert("#pk".into(), ATTR_PK.into());
-
-        for (i, (side_id, name)) in updates.iter().enumerate() {
-            let side_alias = format!("#s{i}");
-            names.insert(side_alias.clone(), side_id.clone());
-            match name {
-                Some(n) => {
-                    let value_alias = format!(":n{i}");
-                    set_clauses.push(format!("sides.{side_alias}.#name = {value_alias}"));
-                    values.insert(value_alias, s(n));
-                }
-                None => {
-                    remove_clauses.push(format!("sides.{side_alias}.#name"));
-                }
-            }
-        }
-
-        let mut expr = String::new();
-        if !set_clauses.is_empty() {
-            expr.push_str("SET ");
-            expr.push_str(&set_clauses.join(", "));
-        }
-        if !remove_clauses.is_empty() {
-            if !expr.is_empty() {
-                expr.push(' ');
-            }
-            expr.push_str("REMOVE ");
-            expr.push_str(&remove_clauses.join(", "));
-        }
-
-        let result = self
-            .client
-            .update_item()
-            .table_name(self.table())
-            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
-            .key(ATTR_SK, s(Sk::Meta.to_string()))
             .update_expression(expr)
             .condition_expression("attribute_exists(#pk)")
             .set_expression_attribute_names(Some(names))

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -727,6 +727,17 @@ struct SetPlayerSideInput {
     side_id: Option<String>,
 }
 
+/// Rename an existing side. `name: None` clears any custom name, falling
+/// back to the priority chain in `MatchSide::name`'s doc comment (the sole
+/// player's name, then the linked team's name, then a neutral default) —
+/// the same validation as at create time applies: a name alongside a
+/// `team_id` is only allowed when another side shares that team.
+#[derive(Object)]
+struct UpdateMatchSideNameInput {
+    side_id: String,
+    name: Option<String>,
+}
+
 /// A side to create as part of a new match. The server assigns the real side id;
 /// `client_id` lets the request reference this side from `invites` and `score`.
 #[derive(Object)]
@@ -823,6 +834,10 @@ struct UpdateMatchInput {
     added_players: Option<Vec<AddMatchPlayerInput>>,
     /// Reassign existing players to sides (late changes to who played for whom).
     side_assignments: Option<Vec<SetPlayerSideInput>>,
+    /// Rename one or more of the match's sides — the custom name given at
+    /// creation (or a previous edit here). Only the sides listed are
+    /// touched; every other side's name is left alone.
+    side_names: Option<Vec<UpdateMatchSideNameInput>>,
     /// The result. Creates a score submission when changed; for a not-yet-played
     /// match this also completes it. `side_id`s reference the match's sides.
     /// Required to complete a match — there is no server-side fallback if
@@ -2493,6 +2508,33 @@ impl Api {
         let valid_sides: std::collections::HashSet<&str> =
             agg.sides.iter().map(|s| s.side_id.as_str()).collect();
 
+        // Renaming a side: every referenced side must exist, and — mirroring
+        // `create_match`'s validation — a side already linked to a team can
+        // only get a custom name when another side shares that same team
+        // (otherwise the team is the source of truth for the name).
+        if let Some(renames) = &input.side_names {
+            for rename in renames {
+                let Some(side) = agg.sides.iter().find(|s| s.side_id == rename.side_id) else {
+                    return Ok(UpdateMatchResponse::ValidationError(PlainText(format!(
+                        "side `{}` is not part of this match",
+                        rename.side_id
+                    ))));
+                };
+                if let (Some(team_id), Some(_)) = (&side.team_id, &rename.name) {
+                    let team_shared = agg.sides.iter().any(|other| {
+                        other.side_id != side.side_id && other.team_id.as_deref() == Some(team_id)
+                    });
+                    if !team_shared {
+                        return Ok(UpdateMatchResponse::ValidationError(PlainText(format!(
+                            "side `{}` can't have both a name and a team unless another side \
+                             shares that team",
+                            rename.side_id
+                        ))));
+                    }
+                }
+            }
+        }
+
         // Completing a live-scored football/cricket match still requires an
         // explicit `score` from the client (see `LiveScoringPage`/
         // `CricketLiveScoringPage`'s `finishMatch`, which now builds one
@@ -2681,6 +2723,22 @@ impl Api {
             }
             other => dao_internal(other),
         })?;
+
+        // Apply any side renames, validated above.
+        if let Some(renames) = &input.side_names {
+            let updates: Vec<(String, Option<String>)> = renames
+                .iter()
+                .map(|r| (r.side_id.clone(), r.name.clone()))
+                .collect();
+            dao.update_match_side_names(&match_id, &updates)
+                .await
+                .map_err(|e| match e {
+                    dao::DaoError::NotFound(_) => {
+                        Error::from_string("match not found", StatusCode::NOT_FOUND)
+                    }
+                    other => dao_internal(other),
+                })?;
+        }
 
         // Roster: add ad-hoc players (no invitation) then apply side reassigns.
         if let Some(added) = &input.added_players {

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2701,7 +2701,17 @@ impl Api {
                 .map_err(dao_internal)?;
         }
 
-        // Apply metadata + resolved score in one update.
+        // Side renames, validated above — folded into the same `UpdateItem`
+        // call as the rest of the metadata below so the two are atomic
+        // together (both land, or neither does).
+        let side_name_updates: Vec<(String, Option<String>)> = input
+            .side_names
+            .iter()
+            .flatten()
+            .map(|r| (r.side_id.clone(), r.name.clone()))
+            .collect();
+
+        // Apply metadata + resolved score + side renames in one update.
         dao.update_match_meta(
             &match_id,
             input.name.as_deref(),
@@ -2715,6 +2725,7 @@ impl Api {
             pending_score.map(Some),
             header_photos,
             input.format.as_ref().map(match_format_to_record),
+            &side_name_updates,
         )
         .await
         .map_err(|e| match e {
@@ -2723,22 +2734,6 @@ impl Api {
             }
             other => dao_internal(other),
         })?;
-
-        // Apply any side renames, validated above.
-        if let Some(renames) = &input.side_names {
-            let updates: Vec<(String, Option<String>)> = renames
-                .iter()
-                .map(|r| (r.side_id.clone(), r.name.clone()))
-                .collect();
-            dao.update_match_side_names(&match_id, &updates)
-                .await
-                .map_err(|e| match e {
-                    dao::DaoError::NotFound(_) => {
-                        Error::from_string("match not found", StatusCode::NOT_FOUND)
-                    }
-                    other => dao_internal(other),
-                })?;
-        }
 
         // Roster: add ad-hoc players (no invitation) then apply side reassigns.
         if let Some(added) = &input.added_players {
@@ -3073,6 +3068,7 @@ impl Api {
                 None,
                 None,
                 None,
+                &[],
             )
             .await
             .map_err(dao_internal)?;
@@ -3479,6 +3475,7 @@ impl Api {
                     Some(None),
                     None,
                     None,
+                    &[],
                 )
                 .await
                 .map_err(dao_internal)?;
@@ -3535,6 +3532,7 @@ impl Api {
                         Some(None),
                         None,
                         None,
+                        &[],
                     )
                     .await
                     .map_err(dao_internal)?;
@@ -4179,6 +4177,7 @@ impl Api {
                 None,
                 None,
                 None,
+                &[],
             )
             .await
             .map_err(dao_internal)?;

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -486,6 +486,153 @@ async fn patch_match_updates_name() {
     assert_eq!(updated.name, "Renamed Match");
 }
 
+/// A match's ad-hoc side names (given at create time) can be edited afterwards
+/// via `side_names`, and clearing one (`name: None`) falls back to the
+/// server-resolved default rather than staying stuck on the old custom name.
+///
+/// Renames side "b" specifically: side "a" carries the sole invited player,
+/// and a side with exactly one player always displays *that player's* name
+/// ahead of any custom name (see `Api::resolve_side_names`'s priority chain),
+/// so a rename there wouldn't be observable in the resolved `name`. Side "b"
+/// has no players, so its resolved name is its custom name (or, once
+/// cleared, the neutral "Team B" fallback — the owner isn't a participant on
+/// either side, so no "Your side"/"Opposition" applies) — a rename there is
+/// directly observable.
+#[tokio::test]
+async fn patch_match_renames_sides() {
+    let (config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&config, create_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+    let side_b = created.sides[1].id.clone();
+    assert_eq!(created.sides[1].name.as_deref(), Some("Side B"));
+
+    let renamed = matches_match_id_patch(
+        &config,
+        &created.id,
+        models::UpdateMatchInput {
+            side_names: Some(vec![models::UpdateMatchSideNameInput {
+                side_id: side_b.clone(),
+                name: Some("The Champions".to_string()),
+            }]),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("patch side name");
+    let renamed_b = renamed.sides.iter().find(|s| s.id == side_b).unwrap();
+    let untouched_a = renamed.sides.iter().find(|s| s.id == side_a).unwrap();
+    assert_eq!(renamed_b.name.as_deref(), Some("The Champions"));
+    assert_eq!(
+        untouched_a.name.as_deref(),
+        Some("Test User"),
+        "a side not named in the request is left alone (still showing its sole player's name)"
+    );
+
+    // Clearing the custom name (name: None) falls back to the neutral
+    // "Team B" default (no team, no sole player, caller not a participant).
+    let cleared = matches_match_id_patch(
+        &config,
+        &created.id,
+        models::UpdateMatchInput {
+            side_names: Some(vec![models::UpdateMatchSideNameInput {
+                side_id: side_b.clone(),
+                name: None,
+            }]),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("clear side name");
+    let cleared_b = cleared.sides.iter().find(|s| s.id == side_b).unwrap();
+    assert_eq!(
+        cleared_b.name.as_deref(),
+        Some("Team B"),
+        "clearing the custom name must not leave the old value in place"
+    );
+}
+
+/// Renaming a side that isn't part of the match is rejected.
+#[tokio::test]
+async fn patch_match_rename_unknown_side_is_rejected() {
+    let (config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&config, create_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+
+    let response = matches_match_id_patch(
+        &config,
+        &created.id,
+        models::UpdateMatchInput {
+            side_names: Some(vec![models::UpdateMatchSideNameInput {
+                side_id: "not-a-real-side".to_string(),
+                name: Some("Ghost Team".to_string()),
+            }]),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_status_with_content(
+        response,
+        reqwest::StatusCode::BAD_REQUEST,
+        "not part of this match",
+    );
+}
+
+/// The same team/name exclusivity rule enforced at create time
+/// (`match_with_a_team_side_fans_out_to_team_followers`'s sibling case) also
+/// applies to a post-creation rename: a side linked to a team can't be given
+/// a custom name unless another side shares that team.
+#[tokio::test]
+async fn patch_match_rename_team_side_without_shared_team_is_rejected() {
+    let (owner_config, owner) = new_user().await;
+    let (_opponent_config, opponent) = new_user().await;
+
+    let team = teams_post(
+        &owner_config,
+        models::CreateTeamInput {
+            name: "Rename FC".to_string(),
+        },
+    )
+    .await
+    .expect("create team");
+
+    let mut input = match_between(
+        "Team Rename Match",
+        &[&owner.profile.id],
+        &[&opponent.profile.id],
+    );
+    input.sides[0].team_id = Some(team.id.clone());
+    input.sides[0].name = None;
+    let created = matches_post(&owner_config, input)
+        .await
+        .expect("create match");
+    let team_side = created.sides[0].id.clone();
+
+    let response = matches_match_id_patch(
+        &owner_config,
+        &created.id,
+        models::UpdateMatchInput {
+            side_names: Some(vec![models::UpdateMatchSideNameInput {
+                side_id: team_side,
+                name: Some("Not Allowed".to_string()),
+            }]),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_status_with_content(
+        response,
+        reqwest::StatusCode::BAD_REQUEST,
+        "can't have both a name and a team",
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Comments & likes
 // ---------------------------------------------------------------------------

--- a/agon_ui/src/components/agon/MatchDetailsEditor.tsx
+++ b/agon_ui/src/components/agon/MatchDetailsEditor.tsx
@@ -9,21 +9,32 @@ import { isoToDateTimeLocal } from '@/lib/datetime'
 import { MultiImageUploadField } from '@/components/agon/MultiImageUploadField'
 
 type Match = components['schemas']['Match']
+type MatchSide = components['schemas']['MatchSide']
+type UpdateMatchSideNameInput = components['schemas']['UpdateMatchSideNameInput']
+
+/** Whether a side can be given its own custom name: an ad-hoc side (no team)
+ *  always can; a team-linked side only when another side shares that same
+ *  team (otherwise the team's own name is the source of truth) — mirrors the
+ *  server's create/update validation. */
+function isRenameable(side: MatchSide, sides: MatchSide[]): boolean {
+  if (!side.team_id) return true
+  return sides.some((other) => other.id !== side.id && other.team_id === side.team_id)
+}
 
 /**
- * Inline editor for a match's metadata — name, description, start time, and
- * header photos — shown in place of the details card when a participant taps
- * "Edit". Saves via `PATCH /matches/{id}` (only the changed fields are sent)
- * and, on success, refreshes the match and feed then closes back to the
- * read-only card.
+ * Inline editor for a match's metadata — name, description, start time,
+ * header photos, and side names — shown in place of the details card when a
+ * participant taps "Edit". Saves via `PATCH /matches/{id}` (only the changed
+ * fields are sent) and, on success, refreshes the match and feed then closes
+ * back to the read-only card.
  *
  * Roster and result are edited elsewhere (invite control, result editor), so
- * this deliberately covers just the descriptive fields plus photos — useful
- * once a match is complete and there are photos from the game to add. The
- * server has no id-level append/reorder, only "replace with this full list",
- * so the photo field is seeded with the match's *current* photos (by asset
- * id) and the user's edits — reorder, remove, add — are applied on top of
- * that seed before being sent back as the complete list on save.
+ * this deliberately covers just the descriptive fields, photos, and side
+ * names. The server has no id-level append/reorder for photos, only "replace
+ * with this full list", so the photo field is seeded with the match's
+ * *current* photos (by asset id) and the user's edits — reorder, remove, add
+ * — are applied on top of that seed before being sent back as the complete
+ * list on save.
  */
 export function MatchDetailsEditor({
   match,
@@ -40,6 +51,14 @@ export function MatchDetailsEditor({
 
   const existingHeaderAssetIds = match.header_photos.map((p) => p.asset_id!)
   const [headerAssetIds, setHeaderAssetIds] = useState<string[]>(existingHeaderAssetIds)
+
+  // Seeded from each side's currently-*displayed* name (server-resolved —
+  // could be a custom name, a team's name, or a computed fallback). Editing
+  // and saving sets that side's custom name explicitly; clearing the field
+  // back to empty reverts to whatever the server would otherwise resolve.
+  const [sideNames, setSideNames] = useState<Record<string, string>>(
+    Object.fromEntries(match.sides.map((s) => [s.id, s.name ?? ''])),
+  )
 
   const nameError = name.trim().length === 0 ? 'A match needs a name' : null
   const timeError = Number.isNaN(new Date(startsAt).getTime())
@@ -59,6 +78,19 @@ export function MatchDetailsEditor({
       if (JSON.stringify(headerAssetIds) !== JSON.stringify(existingHeaderAssetIds)) {
         body.header_photo_asset_ids = headerAssetIds
       }
+
+      const sideNameUpdates: UpdateMatchSideNameInput[] = []
+      for (const side of match.sides) {
+        if (!isRenameable(side, match.sides)) continue
+        const original = (side.name ?? '').trim()
+        const next = (sideNames[side.id] ?? '').trim()
+        if (next === original) continue
+        // An empty field clears the custom name (omitting `name` — the
+        // server treats a missing key the same as `null`), falling back to
+        // the server-resolved default rather than sending an empty string.
+        sideNameUpdates.push(next ? { side_id: side.id, name: next } : { side_id: side.id })
+      }
+      if (sideNameUpdates.length > 0) body.side_names = sideNameUpdates
 
       if (Object.keys(body).length === 0) return // nothing changed
 
@@ -123,6 +155,37 @@ export function MatchDetailsEditor({
         {timeError && (
           <p className="mt-1 text-xs text-destructive">{timeError}</p>
         )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {match.sides.map((side, i) => {
+          const renameable = isRenameable(side, match.sides)
+          return (
+            <div key={side.id}>
+              <Label
+                htmlFor={`side-name-${side.id}`}
+                className="text-xs text-muted-foreground"
+              >
+                {i === 0 ? 'Side A name' : i === 1 ? 'Side B name' : `Side ${i + 1} name`}
+              </Label>
+              <Input
+                id={`side-name-${side.id}`}
+                value={sideNames[side.id] ?? ''}
+                onChange={(e) =>
+                  setSideNames((prev) => ({ ...prev, [side.id]: e.target.value }))
+                }
+                placeholder={renameable ? 'Optional' : undefined}
+                disabled={!renameable}
+                className="mt-1"
+              />
+              {!renameable && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Linked to a team — rename the team instead.
+                </p>
+              )}
+            </div>
+          )
+        })}
       </div>
 
       <div>


### PR DESCRIPTION
A match side's `name` (the ad-hoc label given at create time, distinct
from a linked team's name) could previously only be set at create time.
Add `UpdateMatchInput.side_names` so it can be edited afterwards:

- agon_core: new `Dao::update_match_side_names`, writing/removing the
  `sides.<id>.name` map entries directly.
- agon_service: new `UpdateMatchSideNameInput` + `UpdateMatchInput.side_names`.
  Validates every referenced side exists and re-applies the same
  team/name exclusivity rule enforced at create time (a side already
  linked to a team can only get a custom name when another side shares
  that team). `name: None` clears the custom name, falling back to the
  usual sole-player/team/neutral-default priority chain.
- agon_ui: `MatchDetailsEditor` gains a per-side name field, disabled
  for a team-linked side with no shared team.
- agon_tests: coverage for renaming, clearing back to the default, an
  unknown side id, and the team/name exclusivity rule.