### PR TITLE
Add pre-game roster editor: drag between sides, remove players

### DIFF
--- a/agon_core/src/dao/batch.rs
+++ b/agon_core/src/dao/batch.rs
@@ -1,6 +1,6 @@
 //! Shared batch-operation plumbing: `BatchGetItem` with unprocessed-key retry,
-//! and the backoff used between attempts by both the batch get here and the
-//! `BatchWriteItem` fan-out in `feed.rs`.
+//! `BatchWriteItem` with unprocessed-item retry, and the backoff used between
+//! attempts by both.
 //!
 //! `BatchGetItem` / `BatchWriteItem` can partially complete on a *successful*
 //! (200) response — under throttling or the 16 MB response cap DynamoDB returns
@@ -10,7 +10,7 @@
 
 use std::time::Duration;
 
-use aws_sdk_dynamodb::types::KeysAndAttributes;
+use aws_sdk_dynamodb::types::{KeysAndAttributes, WriteRequest};
 
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
@@ -20,6 +20,10 @@ use super::item::Item;
 /// at a time, which the service caps (`MAX_PAGE_LIMIT`) well below this, so no
 /// request ever needs splitting.
 pub(super) const BATCH_GET_MAX: usize = 100;
+
+/// DynamoDB's hard cap on items per `BatchWriteItem` request (puts and deletes
+/// alike). Callers chunk their requests into pages of this size.
+pub(super) const BATCH_WRITE_MAX: usize = 25;
 
 /// How many times to re-request unprocessed keys/items before giving up. A
 /// couple of retries clears transient throttling; past that we fail the whole
@@ -123,5 +127,47 @@ impl Dao {
         }
 
         Ok(out)
+    }
+
+    /// Submit one `BatchWriteItem` request's worth of work (at most
+    /// [`BATCH_WRITE_MAX`] requests — puts and/or deletes), retrying any
+    /// `UnprocessedItems` DynamoDB returns (throttling) with [`backoff`]
+    /// between attempts until the batch fully drains. Shared by every
+    /// batch-write caller (feed fan-out, roster removal, …) so they don't
+    /// each re-implement the retry loop.
+    pub(super) async fn flush_batch_write(&self, requests: Vec<WriteRequest>) -> DaoResult<()> {
+        debug_assert!(
+            requests.len() <= BATCH_WRITE_MAX,
+            "flush_batch_write called with more than the BatchWriteItem request limit"
+        );
+        let mut pending = requests;
+        for attempt in 0..MAX_BATCH_ATTEMPTS {
+            if pending.is_empty() {
+                return Ok(());
+            }
+            backoff(attempt).await;
+
+            let out = self
+                .client
+                .batch_write_item()
+                .request_items(self.table(), std::mem::take(&mut pending))
+                .send()
+                .await
+                .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+
+            if let Some(unprocessed) = out.unprocessed_items
+                && let Some(items) = unprocessed.get(self.table())
+                && !items.is_empty()
+            {
+                pending = items.clone();
+            }
+        }
+        if pending.is_empty() {
+            Ok(())
+        } else {
+            Err(DaoError::Dynamo(
+                "batch write did not drain unprocessed items".into(),
+            ))
+        }
     }
 }

--- a/agon_core/src/dao/feed.rs
+++ b/agon_core/src/dao/feed.rs
@@ -14,6 +14,7 @@
 use aws_sdk_dynamodb::types::{PutRequest, WriteRequest};
 
 use super::audience::AudienceMember;
+use super::batch::BATCH_WRITE_MAX;
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
 use super::item::{ItemBuilder, to_item};
@@ -22,9 +23,6 @@ use super::page::Page;
 use super::records::FeedItemRecord;
 
 pub const TYPE_FEED_ITEM: &str = "feed_item";
-
-/// DynamoDB's hard cap on items per `BatchWriteItem` request.
-const BATCH_WRITE_MAX: usize = 25;
 
 /// One viewer's feed entry to write for a match — the viewer id plus their
 /// [`AudienceMember`] data (known-players list / own side, see
@@ -133,41 +131,5 @@ impl Dao {
             limit,
         )
         .await
-    }
-
-    /// Submit a batch of write requests, retrying `UnprocessedItems` (which
-    /// DynamoDB returns under throttling) with backoff until the batch fully
-    /// drains. Shares the attempt cap + backoff schedule with the batch-get side
-    /// (see `dao::batch`).
-    async fn flush_batch_write(&self, requests: Vec<WriteRequest>) -> DaoResult<()> {
-        let mut pending = requests;
-        for attempt in 0..super::batch::MAX_BATCH_ATTEMPTS {
-            if pending.is_empty() {
-                return Ok(());
-            }
-            super::batch::backoff(attempt).await;
-
-            let out = self
-                .client
-                .batch_write_item()
-                .request_items(self.table(), std::mem::take(&mut pending))
-                .send()
-                .await
-                .map_err(|e| DaoError::Dynamo(e.to_string()))?;
-
-            if let Some(unprocessed) = out.unprocessed_items
-                && let Some(items) = unprocessed.get(self.table())
-                && !items.is_empty()
-            {
-                pending = items.clone();
-            }
-        }
-        if pending.is_empty() {
-            Ok(())
-        } else {
-            Err(DaoError::Dynamo(
-                "batch write did not drain unprocessed items".into(),
-            ))
-        }
     }
 }

--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -6,7 +6,9 @@ use std::collections::HashMap;
 
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::update_item::UpdateItemError;
-use aws_sdk_dynamodb::types::{AttributeValue, Put, TransactWriteItem};
+use aws_sdk_dynamodb::types::{
+    AttributeValue, DeleteRequest, Put, TransactWriteItem, WriteRequest,
+};
 
 use super::audience::AudienceMember;
 use super::client::Dao;
@@ -594,19 +596,39 @@ impl Dao {
         Ok(())
     }
 
-    /// Remove a player from a match's roster entirely (not just unassign their
-    /// side — see `put_match_player` with `side_id: None` for that). Idempotent
-    /// (deleting a missing player is a no-op).
+    /// Remove players from a match's roster entirely (not just unassign their
+    /// side — see `put_match_player` with `side_id: None` for that), in one
+    /// batch delete (`BatchWriteItem`, `BATCH_WRITE_MAX` items/request — see
+    /// `dao::batch`) rather than a `DeleteItem` per player. Idempotent
+    /// (deleting a missing player is a no-op); a no-op itself for an empty
+    /// `player_ids`.
     #[tracing::instrument(skip(self))]
-    pub async fn remove_match_player(&self, match_id: &str, player_id: &str) -> DaoResult<()> {
-        self.client
-            .delete_item()
-            .table_name(self.table())
-            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
-            .key(ATTR_SK, s(Sk::Player(player_id.into()).to_string()))
-            .send()
-            .await
-            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+    pub async fn remove_match_players(
+        &self,
+        match_id: &str,
+        player_ids: &[String],
+    ) -> DaoResult<()> {
+        for chunk in player_ids.chunks(super::batch::BATCH_WRITE_MAX) {
+            let mut requests = Vec::with_capacity(chunk.len());
+            for player_id in chunk {
+                let key = HashMap::from([
+                    (
+                        ATTR_PK.to_string(),
+                        s(Pk::Match(match_id.into()).to_string()),
+                    ),
+                    (
+                        ATTR_SK.to_string(),
+                        s(Sk::Player(player_id.clone()).to_string()),
+                    ),
+                ]);
+                let delete = DeleteRequest::builder()
+                    .set_key(Some(key))
+                    .build()
+                    .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+                requests.push(WriteRequest::builder().delete_request(delete).build());
+            }
+            self.flush_batch_write(requests).await?;
+        }
         Ok(())
     }
 

--- a/agon_core/src/dao/match_ops.rs
+++ b/agon_core/src/dao/match_ops.rs
@@ -563,6 +563,22 @@ impl Dao {
         Ok(())
     }
 
+    /// Remove a player from a match's roster entirely (not just unassign their
+    /// side — see `put_match_player` with `side_id: None` for that). Idempotent
+    /// (deleting a missing player is a no-op).
+    #[tracing::instrument(skip(self))]
+    pub async fn remove_match_player(&self, match_id: &str, player_id: &str) -> DaoResult<()> {
+        self.client
+            .delete_item()
+            .table_name(self.table())
+            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
+            .key(ATTR_SK, s(Sk::Player(player_id.into()).to_string()))
+            .send()
+            .await
+            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+        Ok(())
+    }
+
     /// Recompute and store every side's `player_count`/`roster_preview` from
     /// the match's *current* player collection. Call after any write that can
     /// change a side's composition or a player's identity within it —

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2757,11 +2757,9 @@ impl Api {
             }
         }
         if let Some(removed_ids) = &input.removed_player_ids {
-            for player_id in removed_ids {
-                dao.remove_match_player(&match_id, player_id)
-                    .await
-                    .map_err(dao_internal)?;
-            }
+            dao.remove_match_players(&match_id, removed_ids)
+                .await
+                .map_err(dao_internal)?;
         }
         if let Some(assignments) = &input.side_assignments {
             // Reassign an existing player's side. Fetch current roster (after

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -823,6 +823,11 @@ struct UpdateMatchInput {
     added_players: Option<Vec<AddMatchPlayerInput>>,
     /// Reassign existing players to sides (late changes to who played for whom).
     side_assignments: Option<Vec<SetPlayerSideInput>>,
+    /// Drop players from the roster entirely, by member id (e.g. someone added
+    /// by mistake, or who dropped out before the match). Unlike `side_assignments`
+    /// with a `None` side, this removes the player record itself rather than
+    /// just unassigning them from a side.
+    removed_player_ids: Option<Vec<String>>,
     /// The result. Creates a score submission when changed; for a not-yet-played
     /// match this also completes it. `side_id`s reference the match's sides.
     /// Required to complete a match — there is no server-side fallback if
@@ -2698,9 +2703,16 @@ impl Api {
                     .map_err(dao_internal)?;
             }
         }
+        if let Some(removed_ids) = &input.removed_player_ids {
+            for player_id in removed_ids {
+                dao.remove_match_player(&match_id, player_id)
+                    .await
+                    .map_err(dao_internal)?;
+            }
+        }
         if let Some(assignments) = &input.side_assignments {
-            // Reassign an existing player's side. Fetch current roster to
-            // preserve the player's other fields.
+            // Reassign an existing player's side. Fetch current roster (after
+            // any adds/removes above) to preserve the player's other fields.
             let current = dao.get_match(&match_id).await.map_err(dao_internal)?;
             if let Some(agg) = current {
                 for a in assignments {
@@ -2715,10 +2727,13 @@ impl Api {
                 }
             }
         }
-        // A roster change can move players between sides (or add new ones) —
+        // A roster change can move players between sides (or add/remove them) —
         // refresh each side's cached roster preview once from the now-current
         // roster, rather than per player_id above.
-        if input.added_players.is_some() || input.side_assignments.is_some() {
+        if input.added_players.is_some()
+            || input.side_assignments.is_some()
+            || input.removed_player_ids.is_some()
+        {
             dao.refresh_side_roster_previews(&match_id)
                 .await
                 .map_err(dao_internal)?;

--- a/agon_ui/src/components/agon/MatchRosterEditor.tsx
+++ b/agon_ui/src/components/agon/MatchRosterEditor.tsx
@@ -16,8 +16,16 @@ import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Avatar } from './Avatar'
 import { memberAvatarUrl, memberName, playerId } from '@/lib/members'
+
+/** "Alice", "Alice and Bob", or "Alice, Bob and Charlie" — for the removal
+ *  confirmation's "you're removing …" sentence. */
+function joinNames(names: string[]): string {
+  if (names.length <= 1) return names[0] ?? ''
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`
+}
 
 type Match = components['schemas']['Match']
 type MatchPlayer = components['schemas']['MatchPlayer']
@@ -30,9 +38,12 @@ const UNASSIGNED = '__unassigned__'
  * Pre-game (or any time before it's locked in) roster editor: drag players
  * between sides — or into "Unassigned" — and remove anyone who shouldn't be
  * on the roster at all. Purely local state until "Save", which diffs against
- * the match's current roster and sends only what changed: `side_assignments`
- * for anyone whose side moved, `removed_player_ids` for anyone dropped.
- * Shown in place of the read-only roster grid when a participant taps "Edit".
+ * the match's current roster and sends only what changed — `side_assignments`
+ * for anyone whose side moved, `removed_player_ids` for anyone dropped — in
+ * one `PATCH`. Saving with any pending removals detours through a confirm
+ * dialog naming who's being cut, since that part can't be undone once it's
+ * sent; a save with only side moves goes straight through. Shown in place of
+ * the read-only roster grid when a participant taps "Edit".
  */
 export function MatchRosterEditor({
   match,
@@ -51,6 +62,7 @@ export function MatchRosterEditor({
   )
   const [removedIds, setRemovedIds] = useState<Set<string>>(new Set())
   const [activeId, setActiveId] = useState<string | null>(null)
+  const [confirmOpen, setConfirmOpen] = useState(false)
 
   const playersById = useMemo(
     () => new Map(match.players.map((p) => [playerId(p), p])),
@@ -136,6 +148,22 @@ export function MatchRosterEditor({
     },
   })
 
+  // Removing someone is destructive (no undo once saved), so saving with any
+  // pending removals detours through a confirmation naming who's being cut,
+  // rather than applying silently. A save with only side moves — reversible,
+  // no data lost — goes straight through.
+  const removedNames = Array.from(removedIds)
+    .map((id) => playersById.get(id))
+    .filter((p): p is MatchPlayer => !!p)
+    .map((p) => memberName(p.member))
+  const handleSaveClick = () => {
+    if (removedIds.size > 0) {
+      setConfirmOpen(true)
+    } else {
+      save.mutate()
+    }
+  }
+
   const activePlayer = activeId ? playersById.get(activeId) : undefined
 
   return (
@@ -210,7 +238,7 @@ export function MatchRosterEditor({
         <Button
           size="sm"
           disabled={!dirty || save.isPending}
-          onClick={() => save.mutate()}
+          onClick={handleSaveClick}
         >
           {save.isPending ? 'Saving…' : 'Save'}
         </Button>
@@ -223,6 +251,41 @@ export function MatchRosterEditor({
           Cancel
         </Button>
       </div>
+
+      <Dialog open={confirmOpen} onOpenChange={(open) => !save.isPending && setConfirmOpen(open)}>
+        <DialogContent className="max-w-sm text-center sm:text-center">
+          <DialogHeader className="text-center sm:text-center">
+            <DialogTitle>Remove {removedNames.length === 1 ? 'this player' : 'these players'}?</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            You're removing {joinNames(removedNames)} from the match. This can't be undone
+            once saved.
+          </p>
+          {save.isError && (
+            <p className="text-xs text-destructive">
+              Something went wrong. Please try again.
+            </p>
+          )}
+          <div className="mt-2 flex flex-col gap-2">
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={save.isPending}
+              onClick={() => save.mutate()}
+            >
+              {save.isPending ? 'Saving…' : 'Yes, remove them'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={save.isPending}
+              onClick={() => setConfirmOpen(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/agon_ui/src/components/agon/MatchRosterEditor.tsx
+++ b/agon_ui/src/components/agon/MatchRosterEditor.tsx
@@ -1,0 +1,332 @@
+import { useMemo, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import { GripVertical, X } from 'lucide-react'
+import { fetchClient } from '@/lib/api-client'
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Avatar } from './Avatar'
+import { memberAvatarUrl, memberName, playerId } from '@/lib/members'
+
+type Match = components['schemas']['Match']
+type MatchPlayer = components['schemas']['MatchPlayer']
+
+/** Drop-zone id for players with no side yet (`side_id` unset). Distinct from
+ *  any real side id, which the server mints as an opaque generated string. */
+const UNASSIGNED = '__unassigned__'
+
+/**
+ * Pre-game (or any time before it's locked in) roster editor: drag players
+ * between sides — or into "Unassigned" — and remove anyone who shouldn't be
+ * on the roster at all. Purely local state until "Save", which diffs against
+ * the match's current roster and sends only what changed: `side_assignments`
+ * for anyone whose side moved, `removed_player_ids` for anyone dropped.
+ * Shown in place of the read-only roster grid when a participant taps "Edit".
+ */
+export function MatchRosterEditor({
+  match,
+  onDone,
+}: {
+  match: Match
+  onDone: () => void
+}) {
+  const queryClient = useQueryClient()
+
+  // player_id -> side_id (or undefined for unassigned). Seeded from the
+  // match's current roster; only local edits (drag / remove) touch it from
+  // here on.
+  const [assignments, setAssignments] = useState<Map<string, string | undefined>>(
+    () => new Map(match.players.map((p) => [playerId(p), p.side_id])),
+  )
+  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set())
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const playersById = useMemo(
+    () => new Map(match.players.map((p) => [playerId(p), p])),
+    [match.players],
+  )
+
+  const columns = useMemo(() => {
+    const cols = new Map<string, MatchPlayer[]>()
+    for (const side of match.sides) cols.set(side.id, [])
+    cols.set(UNASSIGNED, [])
+    for (const [id, sideId] of assignments) {
+      if (removedIds.has(id)) continue
+      const player = playersById.get(id)
+      if (!player) continue
+      const key = sideId && cols.has(sideId) ? sideId : UNASSIGNED
+      cols.get(key)!.push(player)
+    }
+    return cols
+  }, [assignments, removedIds, playersById, match.sides])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+  )
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(String(event.active.id))
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveId(null)
+    const { active, over } = event
+    if (!over) return
+    const id = String(active.id)
+    const targetSideId = String(over.id)
+    setAssignments((prev) => {
+      const next = new Map(prev)
+      next.set(id, targetSideId === UNASSIGNED ? undefined : targetSideId)
+      return next
+    })
+  }
+
+  const remove = (id: string) => {
+    setRemovedIds((prev) => new Set(prev).add(id))
+  }
+
+  const undoRemove = (id: string) => {
+    setRemovedIds((prev) => {
+      const next = new Set(prev)
+      next.delete(id)
+      return next
+    })
+  }
+
+  // What changed vs. the match's own current state — sent as-is even if
+  // empty (a no-op save is harmless, and keeps the mutation body uniform).
+  const sideAssignmentsBody = useMemo(
+    () =>
+      match.players
+        .filter((p) => !removedIds.has(playerId(p)))
+        .filter((p) => assignments.get(playerId(p)) !== p.side_id)
+        .map((p) => ({ player_id: playerId(p), side_id: assignments.get(playerId(p)) })),
+    [match.players, assignments, removedIds],
+  )
+  const removedIdsBody = useMemo(() => Array.from(removedIds), [removedIds])
+  const dirty = sideAssignmentsBody.length > 0 || removedIdsBody.length > 0
+
+  const save = useMutation({
+    mutationFn: async () => {
+      const body: components['schemas']['UpdateMatchInput'] = {}
+      if (sideAssignmentsBody.length > 0) body.side_assignments = sideAssignmentsBody
+      if (removedIdsBody.length > 0) body.removed_player_ids = removedIdsBody
+      if (!dirty) return
+      const { error } = await fetchClient.PATCH('/matches/{match_id}', {
+        params: { path: { match_id: match.id } },
+        body,
+      })
+      if (error) throw new Error('Failed to save the roster')
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['match', match.id] })
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
+      onDone()
+    },
+  })
+
+  const activePlayer = activeId ? playersById.get(activeId) : undefined
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border bg-card p-4">
+      <p className="text-xs text-muted-foreground">
+        Drag a player to move them to another side, or remove them from the match.
+      </p>
+
+      <DndContext
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="flex flex-col gap-3">
+          {match.sides.map((side) => (
+            <RosterColumn
+              key={side.id}
+              id={side.id}
+              title={side.name?.trim() || 'Side'}
+              players={columns.get(side.id) ?? []}
+              onRemove={remove}
+            />
+          ))}
+          <RosterColumn
+            id={UNASSIGNED}
+            title="Unassigned"
+            players={columns.get(UNASSIGNED) ?? []}
+            onRemove={remove}
+          />
+        </div>
+
+        <DragOverlay>
+          {activePlayer && <PlayerChip player={activePlayer} overlay />}
+        </DragOverlay>
+      </DndContext>
+
+      {removedIds.size > 0 && (
+        <div className="rounded-lg border border-dashed p-2.5">
+          <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Removed
+          </p>
+          <div className="flex flex-col gap-1">
+            {Array.from(removedIds).map((id) => {
+              const player = playersById.get(id)
+              if (!player) return null
+              return (
+                <div key={id} className="flex items-center justify-between gap-2 text-sm">
+                  <span className="truncate text-muted-foreground line-through">
+                    {memberName(player.member)}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => undoRemove(id)}
+                    className="shrink-0 text-xs text-primary hover:underline"
+                  >
+                    Undo
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {save.isError && (
+        <p className="text-xs text-destructive">
+          Something went wrong. Please try again.
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <Button
+          size="sm"
+          disabled={!dirty || save.isPending}
+          onClick={() => save.mutate()}
+        >
+          {save.isPending ? 'Saving…' : 'Save'}
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={save.isPending}
+          onClick={onDone}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/** One side's (or "Unassigned"'s) drop zone: a titled list of draggable
+ *  player chips. Highlights while a dragged player is over it. */
+function RosterColumn({
+  id,
+  title,
+  players,
+  onRemove,
+}: {
+  id: string
+  title: string
+  players: MatchPlayer[]
+  onRemove: (id: string) => void
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        'rounded-lg border bg-muted/40 p-2.5 transition-colors',
+        isOver && 'border-primary bg-primary/5',
+      )}
+    >
+      <p className="mb-2 truncate text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+        {title}
+      </p>
+      <div className="flex min-h-11 flex-col gap-1.5">
+        {players.length === 0 && (
+          <p className="px-1 py-1 text-xs text-muted-foreground">
+            {id === UNASSIGNED ? 'Drop a player here to unassign them.' : 'No players.'}
+          </p>
+        )}
+        {players.map((p) => (
+          <DraggablePlayer key={playerId(p)} player={p} onRemove={onRemove} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function DraggablePlayer({
+  player,
+  onRemove,
+}: {
+  player: MatchPlayer
+  onRemove: (id: string) => void
+}) {
+  const id = playerId(player)
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id })
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className={cn('touch-none', isDragging && 'opacity-30')}
+    >
+      <PlayerChip player={player} onRemove={onRemove} />
+    </div>
+  )
+}
+
+/** The visual row shared by a column's live chip and the drag overlay clone. */
+function PlayerChip({
+  player,
+  onRemove,
+  overlay = false,
+}: {
+  player: MatchPlayer
+  onRemove?: (id: string) => void
+  overlay?: boolean
+}) {
+  const name = memberName(player.member)
+  const avatarUrl = memberAvatarUrl(player.member)
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 rounded-md bg-card px-2 py-1.5',
+        overlay && 'border shadow-lg',
+      )}
+    >
+      <GripVertical className="size-3.5 shrink-0 text-muted-foreground" />
+      <Avatar name={name} imageUrl={avatarUrl} size="md" />
+      <span className="flex-1 truncate text-sm">{name}</span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={(e) => {
+            // The chip's whole surface starts a drag — keep the remove click
+            // from also being read as one.
+            e.stopPropagation()
+            onRemove(playerId(player))
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          aria-label={`Remove ${name}`}
+          className="text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <X className="size-4" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -34,6 +34,7 @@ import { CopyInviteButton } from '@/components/agon/CopyInviteButton'
 import { MatchDetailsEditor } from '@/components/agon/MatchDetailsEditor'
 import { MatchFormatCard } from '@/components/agon/MatchFormatCard'
 import { MatchResultEditor } from '@/components/agon/MatchResultEditor'
+import { MatchRosterEditor } from '@/components/agon/MatchRosterEditor'
 import { InvitePlayers } from '@/components/agon/InvitePlayers'
 import { MatchComments } from '@/components/agon/MatchComments'
 import { useToggleLike } from '@/hooks/useToggleLike'
@@ -109,6 +110,7 @@ function MatchDetail({
 }) {
   const [editingDetails, setEditingDetails] = useState(false)
   const [editingResult, setEditingResult] = useState(false)
+  const [editingRoster, setEditingRoster] = useState(false)
   const [inviting, setInviting] = useState(false)
 
   const canEdit = isParticipant(match, currentUserId)
@@ -308,17 +310,36 @@ function MatchDetail({
         )
       )}
 
-      {/* Rosters, one column per side */}
-      <div className="grid grid-cols-2 gap-3">
-        <SideRoster
-          title={nameA}
-          players={match.players.filter((p) => p.side_id === sideA?.id)}
-        />
-        <SideRoster
-          title={nameB}
-          players={match.players.filter((p) => p.side_id === sideB?.id)}
-        />
-      </div>
+      {/* Rosters, one column per side — or the drag-to-reassign/remove editor
+          in place of it, for a participant reconciling the line-up. */}
+      {editingRoster ? (
+        <MatchRosterEditor match={match} onDone={() => setEditingRoster(false)} />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {canEdit && !cancelled && (
+            <div className="flex justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 gap-1 px-2 text-xs text-muted-foreground"
+                onClick={() => setEditingRoster(true)}
+              >
+                <Pencil className="size-3" /> Edit roster
+              </Button>
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-3">
+            <SideRoster
+              title={nameA}
+              players={match.players.filter((p) => p.side_id === sideA?.id)}
+            />
+            <SideRoster
+              title={nameB}
+              players={match.players.filter((p) => p.side_id === sideB?.id)}
+            />
+          </div>
+        </div>
+      )}
 
       {/* Cricket scorecard: run progression + per-player batting/bowling,
           once there's per-innings detail recorded (live-scored or entered


### PR DESCRIPTION
Backend:
- agon_core: new Dao::remove_match_player to delete a MatchPlayerRecord
  entirely (distinct from put_match_player with side_id: None, which
  just unassigns).
- agon_service: UpdateMatchInput gains removed_player_ids, handled in
  update_match alongside the existing added_players/side_assignments
  roster reconciliation, with a roster-preview refresh on any of the
  three.

Frontend:
- New MatchRosterEditor: drag-and-drop (dnd-kit, already a dependency)
  between each side and an "Unassigned" column, plus a remove/undo
  action per player. Diffs local state against the match's current
  roster on Save and sends only side_assignments/removed_player_ids
  that actually changed.
- MatchDetailPage: "Edit roster" toggle (participants only, same gate
  as the other inline editors) swaps the read-only roster grid for the
  editor.