### PR TITLE
Make comment authors linkable to user profiles

### DIFF
--- a/agon_ui/src/components/agon/MatchComments.tsx
+++ b/agon_ui/src/components/agon/MatchComments.tsx
@@ -4,6 +4,7 @@ import {
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
 import { MessageCircle, Pencil, Trash2 } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
@@ -210,16 +211,35 @@ function CommentRow({
     )
   }
 
+  // Only a live (non-tombstone) comment has an author to link to.
+  const authorId = deleted ? undefined : comment.author?.id
+
   return (
     <div className="flex gap-2.5">
-      <Avatar
-        name={name}
-        imageUrl={comment.author?.profile_image?.image_url}
-        size="md"
-      />
+      {authorId ? (
+        <Link to={`/users/${authorId}`} className="shrink-0">
+          <Avatar
+            name={name}
+            imageUrl={comment.author?.profile_image?.image_url}
+            size="md"
+          />
+        </Link>
+      ) : (
+        <Avatar
+          name={name}
+          imageUrl={comment.author?.profile_image?.image_url}
+          size="md"
+        />
+      )}
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2 text-xs">
-          <span className="font-medium">{deleted ? 'Deleted' : name}</span>
+          {authorId ? (
+            <Link to={`/users/${authorId}`} className="font-medium hover:underline">
+              {name}
+            </Link>
+          ) : (
+            <span className="font-medium">{deleted ? 'Deleted' : name}</span>
+          )}
           <span className="text-muted-foreground">
             {relativeTime(comment.created_at)}
           </span>


### PR DESCRIPTION
## Summary
Updated the `MatchComments` component to make comment author names and avatars clickable links to their user profiles, while preserving the current display for deleted comments.

## Changes
- Added `react-router-dom` import for client-side navigation
- Wrapped author avatar in a `Link` component that routes to `/users/{authorId}` when the comment is not deleted
- Wrapped author name in a `Link` component with hover underline styling for non-deleted comments
- Preserved the original display behavior for deleted comments (tombstones), which show "Deleted" text and have no clickable elements
- Added logic to conditionally set `authorId` only for live comments (when `deleted` is false)

## Implementation Details
- The change uses conditional rendering to distinguish between live comments (with author links) and deleted comments (without links)
- Both the avatar and author name link to the same user profile route for consistency
- Deleted comments continue to display as before, with no interactive author elements

https://claude.ai/code/session_01Rxeu3rUv55KbuMYZLGgwrW