### PR TITLE
Show football scorers by side on finished match cards

### DIFF
--- a/agon_ui/src/components/agon/FootballScorersBySide.tsx
+++ b/agon_ui/src/components/agon/FootballScorersBySide.tsx
@@ -1,0 +1,76 @@
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { scorersBySide, type FootballScorerLine } from '@/lib/liveScore'
+import type { ScorePlayers } from '@/lib/members'
+
+type FootballGoalEvent = components['schemas']['FootballGoalEvent']
+type MatchSide = components['schemas']['MatchSide']
+type Match = components['schemas']['Match']
+type FeedMatch = components['schemas']['FeedMatch']
+type SearchMatch = components['schemas']['SearchMatch']
+
+/**
+ * Every football scorer for a finished match, grouped by side and merged
+ * onto one line per player with each minute they scored — e.g. "James Elgar
+ * 5', 53'" — laid out side-by-side under the score, aligned under `sideA`/
+ * `sideB` the same way the score header itself is. Shared between the feed/
+ * profile card (`MatchCard`) and the match detail page header; both show
+ * this in place of goals for a finished/confirmed-or-pending score.
+ * `FootballScorecard`'s full event timeline (goals *and* cards/subs) further
+ * down the detail page is unaffected — this is just the score header's
+ * summary. Renders nothing if neither side has a goal to show.
+ */
+export function FootballScorersBySide({
+  goals,
+  match,
+  players,
+  sideA,
+  sideB,
+  className,
+}: {
+  goals: FootballGoalEvent[]
+  match: Match | FeedMatch | SearchMatch
+  players?: ScorePlayers
+  sideA: MatchSide | undefined
+  sideB: MatchSide | undefined
+  className?: string
+}) {
+  const bySide = scorersBySide(goals, match, players)
+  const scorersA = bySide[sideA?.id ?? ''] ?? []
+  const scorersB = bySide[sideB?.id ?? ''] ?? []
+
+  if (scorersA.length === 0 && scorersB.length === 0) return null
+
+  return (
+    <div className={cn('flex justify-between gap-3 border-t pt-2 text-muted-foreground', className)}>
+      <ScorerColumn scorers={scorersA} />
+      <ScorerColumn scorers={scorersB} align="right" />
+    </div>
+  )
+}
+
+function ScorerColumn({
+  scorers,
+  align,
+}: {
+  scorers: FootballScorerLine[]
+  align?: 'right'
+}) {
+  return (
+    <div className={cn('min-w-0 flex-1 space-y-1', align === 'right' && 'text-right')}>
+      {scorers.map((s) => (
+        <p key={s.key} className="truncate">
+          {s.name}
+          {s.minutes.length > 0 && (
+            <>
+              {' '}
+              <span className="font-medium text-foreground">
+                {s.minutes.map((m) => `${m}'`).join(', ')}
+              </span>
+            </>
+          )}
+        </p>
+      ))}
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -17,8 +17,9 @@ import { LiveMatchBlock } from './live/LiveMatchBlock'
 import { CricketMatchBlock } from './live/CricketMatchBlock'
 import { CricketScoreBlock } from './CricketScoreBlock'
 import { KnownPlayersRow } from './KnownPlayersRow'
+import { FootballScorersBySide } from './FootballScorersBySide'
 import { useMatchScore } from '@/hooks/useMatchScore'
-import { footballScoreFrom, scorersBySide } from '@/lib/liveScore'
+import { footballScoreFrom } from '@/lib/liveScore'
 import {
   cricketProgressFromScore,
   cricketScoreFrom,
@@ -213,7 +214,7 @@ export function MatchCard({
   const isCurrentlyLive = isLiveSport && match.status === 'in_progress'
   // Only fetched while live — a finished match doesn't need it. Football's
   // confirmed/pending `Score.Football` already embeds its goals (see
-  // `footballGoalsFromScore`/`finishedScorersBySide` below), and cricket's
+  // `footballGoalsFromScore`/`FootballScorersBySide` below), and cricket's
   // confirmed `Score.Cricket` already embeds its per-innings detail
   // (`cricketScore` below) — both produced by finishing a live-scored match
   // (see `finishMatch` in `LiveScoringPage`/`CricketLiveScoringPage`), same
@@ -243,13 +244,6 @@ export function MatchCard({
   // player roster to resolve scorer names from locally.
   const finishedFootballScorePlayers =
     scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
-  // Every scorer, minutes merged onto one line each, grouped per side — see
-  // `scorersBySide`'s doc comment for why own goals never get a named line.
-  const finishedScorersBySide = finishedFootballGoals
-    ? scorersBySide(finishedFootballGoals, match, finishedFootballScorePlayers)
-    : null
-  const finishedScorersA = finishedScorersBySide?.[sideA?.id ?? ''] ?? []
-  const finishedScorersB = finishedScorersBySide?.[sideB?.id ?? ''] ?? []
   // A cricket match's confirmed score carries its own per-innings detail once
   // it's been live-scored (`Score::Cricket`; see `finishMatch` in
   // `CricketLiveScoringPage`) — a manually-logged result still degrades to
@@ -370,39 +364,15 @@ export function MatchCard({
                 ))}
               </div>
             )}
-            {(finishedScorersA.length > 0 || finishedScorersB.length > 0) && (
-              <div className="mt-2.5 flex justify-between gap-3 border-t pt-2 text-[11px] text-muted-foreground">
-                <div className="min-w-0 flex-1 space-y-1">
-                  {finishedScorersA.map((s) => (
-                    <p key={s.key} className="truncate">
-                      {s.name}
-                      {s.minutes.length > 0 && (
-                        <>
-                          {' '}
-                          <span className="font-medium text-foreground">
-                            {s.minutes.map((m) => `${m}'`).join(', ')}
-                          </span>
-                        </>
-                      )}
-                    </p>
-                  ))}
-                </div>
-                <div className="min-w-0 flex-1 space-y-1 text-right">
-                  {finishedScorersB.map((s) => (
-                    <p key={s.key} className="truncate">
-                      {s.name}
-                      {s.minutes.length > 0 && (
-                        <>
-                          {' '}
-                          <span className="font-medium text-foreground">
-                            {s.minutes.map((m) => `${m}'`).join(', ')}
-                          </span>
-                        </>
-                      )}
-                    </p>
-                  ))}
-                </div>
-              </div>
+            {finishedFootballGoals && (
+              <FootballScorersBySide
+                goals={finishedFootballGoals}
+                match={match}
+                players={finishedFootballScorePlayers}
+                sideA={sideA}
+                sideB={sideB}
+                className="mt-2.5 text-[11px]"
+              />
             )}
           </div>
         )

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -18,7 +18,7 @@ import { CricketMatchBlock } from './live/CricketMatchBlock'
 import { CricketScoreBlock } from './CricketScoreBlock'
 import { KnownPlayersRow } from './KnownPlayersRow'
 import { useMatchScore } from '@/hooks/useMatchScore'
-import { describeEvent, eventEmoji, footballScoreFrom, recentGoalEvents } from '@/lib/liveScore'
+import { footballScoreFrom, scorersBySide } from '@/lib/liveScore'
 import {
   cricketProgressFromScore,
   cricketScoreFrom,
@@ -213,7 +213,7 @@ export function MatchCard({
   const isCurrentlyLive = isLiveSport && match.status === 'in_progress'
   // Only fetched while live — a finished match doesn't need it. Football's
   // confirmed/pending `Score.Football` already embeds its goals (see
-  // `footballGoalsFromScore`/`finishedFootballEvents` below), and cricket's
+  // `footballGoalsFromScore`/`finishedScorersBySide` below), and cricket's
   // confirmed `Score.Cricket` already embeds its per-innings detail
   // (`cricketScore` below) — both produced by finishing a live-scored match
   // (see `finishMatch` in `LiveScoringPage`/`CricketLiveScoringPage`), same
@@ -232,18 +232,24 @@ export function MatchCard({
   // live block/badge for a match that finished after the card last mounted.
   const footballState = isCurrentlyLive ? footballScoreFrom(scoreQuery.data) : null
   const cricketState = isCurrentlyLive ? cricketScoreFrom(scoreQuery.data) : null
-  // Recent goals for a finished football match, read straight off the
+  // Goals for a finished football match, read straight off the
   // confirmed/pending score (no fetch) — shown under the plain score box
   // below (the live ticker in `LiveMatchBlock` only renders while
   // `footballState` is set, i.e. while still in progress).
   const finishedFootballGoals = scoreInfo && !isCurrentlyLive ? footballGoalsFromScore(scoreInfo.score) : null
-  const finishedFootballEvents = finishedFootballGoals ? recentGoalEvents(finishedFootballGoals, 3) : []
   // Resolved server-side on `confirmed_score`/`pending_score` itself (see
   // `Api::hydrate_confirmed_pending_score_players`) — this card's `match` is
   // a `FeedMatch`/`SearchMatch`/`Match`, none of which reliably carry a full
-  // player roster to resolve `describeEvent`'s names from locally.
+  // player roster to resolve scorer names from locally.
   const finishedFootballScorePlayers =
     scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
+  // Every scorer, minutes merged onto one line each, grouped per side — see
+  // `scorersBySide`'s doc comment for why own goals never get a named line.
+  const finishedScorersBySide = finishedFootballGoals
+    ? scorersBySide(finishedFootballGoals, match, finishedFootballScorePlayers)
+    : null
+  const finishedScorersA = finishedScorersBySide?.[sideA?.id ?? ''] ?? []
+  const finishedScorersB = finishedScorersBySide?.[sideB?.id ?? ''] ?? []
   // A cricket match's confirmed score carries its own per-innings detail once
   // it's been live-scored (`Score::Cricket`; see `finishMatch` in
   // `CricketLiveScoringPage`) — a manually-logged result still degrades to
@@ -364,25 +370,38 @@ export function MatchCard({
                 ))}
               </div>
             )}
-            {finishedFootballEvents.length > 0 && (
-              <div className="mt-2.5 space-y-1 border-t pt-2">
-                {finishedFootballEvents.map((event, i) => {
-                  const isSideB = event.side_id === sideB?.id
-                  return (
-                    <p
-                      key={i}
-                      className={`flex items-baseline gap-1.5 truncate text-[11px] text-muted-foreground ${isSideB ? 'flex-row-reverse text-right' : ''}`}
-                    >
-                      <span aria-hidden>{eventEmoji(event.kind)}</span>
-                      {event.minute !== undefined && (
-                        <span className="font-medium text-foreground">{event.minute}'</span>
+            {(finishedScorersA.length > 0 || finishedScorersB.length > 0) && (
+              <div className="mt-2.5 flex justify-between gap-3 border-t pt-2 text-[11px] text-muted-foreground">
+                <div className="min-w-0 flex-1 space-y-1">
+                  {finishedScorersA.map((s) => (
+                    <p key={s.key} className="truncate">
+                      {s.name}
+                      {s.minutes.length > 0 && (
+                        <>
+                          {' '}
+                          <span className="font-medium text-foreground">
+                            {s.minutes.map((m) => `${m}'`).join(', ')}
+                          </span>
+                        </>
                       )}
-                      <span className="truncate">
-                        {describeEvent(event, match, finishedFootballScorePlayers)}
-                      </span>
                     </p>
-                  )
-                })}
+                  ))}
+                </div>
+                <div className="min-w-0 flex-1 space-y-1 text-right">
+                  {finishedScorersB.map((s) => (
+                    <p key={s.key} className="truncate">
+                      {s.name}
+                      {s.minutes.length > 0 && (
+                        <>
+                          {' '}
+                          <span className="font-medium text-foreground">
+                            {s.minutes.map((m) => `${m}'`).join(', ')}
+                          </span>
+                        </>
+                      )}
+                    </p>
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -83,10 +83,9 @@ function cardKind(c: FootballCardEvent): FootballEventKind {
   return c.color === 'yellow' ? 'yellow_card' : 'red_card'
 }
 
-/** Maps a bare goals list — either `FootballScore.goals` or a finished
- *  match's goals (see `recentGoalEvents`) — to event views. Unsorted;
- *  callers order as needed (`eventsFromDetail` merges and sorts alongside
- *  cards/subs, `recentGoalEvents` sorts standalone). */
+/** Maps a bare goals list — `FootballScore.goals`, live or finished — to
+ *  event views. Unsorted; callers order as needed (`eventsFromDetail` merges
+ *  and sorts alongside cards/subs). */
 export function goalEventsToViews(goals: FootballGoalEvent[]): FootballEventView[] {
   return goals.map((g): FootballEventView => ({
     kind: goalKind(g),
@@ -183,15 +182,50 @@ export function recentEvents(detail: FootballScore, limit: number): FootballEven
     .slice(0, limit)
 }
 
-/** The most recent goals first, capped to `limit` — for a finished match's
- *  feed-card ticker, built straight from the goals embedded in its
+/** One goalscorer's line for a side's scorer list — every minute they scored
+ *  merged onto one row, e.g. "James Elgar 5', 53'". `key` is stable for React
+ *  lists (a player id, or `'own_goal'` — see `scorersBySide`). */
+export interface FootballScorerLine {
+  key: string
+  name: string
+  minutes: number[]
+}
+
+/** All of a football match's goals, grouped by crediting side and then by
+ *  scorer — a side-by-side scorer list for a finished match's feed card,
+ *  built straight from the goals embedded in its confirmed/pending
  *  `Score.Football` rather than a full live fetch, which a completed match
- *  no longer needs just to show who scored. */
-export function recentGoalEvents(goals: FootballGoalEvent[], limit: number): FootballEventView[] {
-  return goalEventsToViews(goals)
-    .sort((a, b) => (a.minute ?? Infinity) - (b.minute ?? Infinity))
-    .reverse()
-    .slice(0, limit)
+ *  no longer needs just to show who scored. Multiple goals by the same
+ *  player become one line with every minute, ascending; lines are ordered by
+ *  that player's first goal. Own goals never get a named line — regardless
+ *  of whether a scorer is recorded, they're grouped under a single "Own
+ *  goal" line per side, since `side_id` is the *benefiting* side, not the
+ *  own-goal scorer's own team (see `FootballGoalEvent`'s doc comment) —
+ *  naming them here would misattribute the scorer to the wrong side's
+ *  column. */
+export function scorersBySide(
+  goals: FootballGoalEvent[],
+  match: MatchLike,
+  scorePlayers?: ScorePlayers,
+): Record<string, FootballScorerLine[]> {
+  const bySide: Record<string, Map<string, FootballScorerLine>> = {}
+  for (const g of goals) {
+    const lines = (bySide[g.side_id] ??= new Map())
+    const key = g.own_goal ? 'own_goal' : (g.scorer_player_id ?? 'unknown')
+    const name = g.own_goal
+      ? 'Own goal'
+      : (playerNameFor(match, g.scorer_player_id, scorePlayers) ?? 'Unknown')
+    const line = lines.get(key) ?? { key, name, minutes: [] }
+    if (g.minute !== undefined) line.minutes.push(g.minute)
+    lines.set(key, line)
+  }
+  const out: Record<string, FootballScorerLine[]> = {}
+  for (const [sideId, lines] of Object.entries(bySide)) {
+    out[sideId] = [...lines.values()]
+      .map((line) => ({ ...line, minutes: [...line.minutes].sort((a, b) => a - b) }))
+      .sort((a, b) => (a.minutes[0] ?? Infinity) - (b.minutes[0] ?? Infinity))
+  }
+  return out
 }
 
 /** Player display name for a match-scoped player id. Checks `scorePlayers`

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -183,8 +183,10 @@ export function recentEvents(detail: FootballScore, limit: number): FootballEven
 }
 
 /** One goalscorer's line for a side's scorer list — every minute they scored
- *  merged onto one row, e.g. "James Elgar 5', 53'". `key` is stable for React
- *  lists (a player id, or `'own_goal'` — see `scorersBySide`). */
+ *  merged onto one row, e.g. "James Elgar 5', 53'" or "Own goal (J. Smith)
+ *  90'". `key` is stable for React lists (a player id, an
+ *  `own_goal:<player id>`, or `own_goal:unknown` for an unrecorded own-goal
+ *  scorer — see `scorersBySide`). */
 export interface FootballScorerLine {
   key: string
   name: string
@@ -197,12 +199,14 @@ export interface FootballScorerLine {
  *  `Score.Football` rather than a full live fetch, which a completed match
  *  no longer needs just to show who scored. Multiple goals by the same
  *  player become one line with every minute, ascending; lines are ordered by
- *  that player's first goal. Own goals never get a named line — regardless
- *  of whether a scorer is recorded, they're grouped under a single "Own
- *  goal" line per side, since `side_id` is the *benefiting* side, not the
- *  own-goal scorer's own team (see `FootballGoalEvent`'s doc comment) —
- *  naming them here would misattribute the scorer to the wrong side's
- *  column. */
+ *  that player's first goal. An own goal still lists under the *benefiting*
+ *  side's column, matching where it counts on the scoreboard (`side_id` is
+ *  the crediting side, not the own-goal scorer's own team — see
+ *  `FootballGoalEvent`'s doc comment), but is labeled "Own goal (Scorer)"
+ *  using the scorer's own name, resolved the same way a regular goal's is;
+ *  falls back to a bare "Own goal" line when no scorer was recorded. Own
+ *  goals by different players are never merged onto the same line, even
+ *  though they'd count for the same side. */
 export function scorersBySide(
   goals: FootballGoalEvent[],
   match: MatchLike,
@@ -211,10 +215,9 @@ export function scorersBySide(
   const bySide: Record<string, Map<string, FootballScorerLine>> = {}
   for (const g of goals) {
     const lines = (bySide[g.side_id] ??= new Map())
-    const key = g.own_goal ? 'own_goal' : (g.scorer_player_id ?? 'unknown')
-    const name = g.own_goal
-      ? 'Own goal'
-      : (playerNameFor(match, g.scorer_player_id, scorePlayers) ?? 'Unknown')
+    const scorer = playerNameFor(match, g.scorer_player_id, scorePlayers)
+    const key = g.own_goal ? `own_goal:${g.scorer_player_id ?? 'unknown'}` : (g.scorer_player_id ?? 'unknown')
+    const name = g.own_goal ? (scorer ? `Own goal (${scorer})` : 'Own goal') : (scorer ?? 'Unknown')
     const line = lines.get(key) ?? { key, name, minutes: [] }
     if (g.minute !== undefined) line.minutes.push(g.minute)
     lines.set(key, line)

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -16,12 +16,13 @@ import { CricketMatchBlock } from '@/components/agon/live/CricketMatchBlock'
 import { CricketScoreBlock } from '@/components/agon/CricketScoreBlock'
 import { CricketScorecard } from '@/components/agon/CricketScorecard'
 import { FootballScorecard } from '@/components/agon/FootballScorecard'
+import { FootballScorersBySide } from '@/components/agon/FootballScorersBySide'
 import { useLiveEvents } from '@/hooks/useLiveScore'
 import { useMatchScore } from '@/hooks/useMatchScore'
 import { footballScoreFrom, footballEventSourceFromScore } from '@/lib/liveScore'
 import { cricketInningsFor, cricketScoreFrom, inningsDeliveriesFromEvents } from '@/lib/cricketScore'
 import { useCurrentUserId } from '@/hooks/useCurrentUserId'
-import { displayScore, headlineBySide, headlineLabel, setLine } from '@/lib/score'
+import { displayScore, footballGoalsFromScore, headlineBySide, headlineLabel, setLine } from '@/lib/score'
 import {
   isParticipant,
   memberAvatarUrl,
@@ -143,6 +144,14 @@ function MatchDetail({
   const footballState = isCurrentlyLive ? footballScoreFrom(scoreQuery.data) : null
   const cricketState = isCurrentlyLive ? cricketScoreFrom(scoreQuery.data) : null
   const hasLiveState = !!footballState || !!cricketState
+  // Goals for a finished football match, read straight off the
+  // confirmed/pending score — shown as a scorer breakdown under the plain
+  // score box below (same as the feed/profile card's `MatchCard`); the full
+  // event timeline (goals *and* cards/subs) stays in `FootballScorecard`
+  // further down the page regardless.
+  const finishedFootballGoals = scoreInfo && !isCurrentlyLive ? footballGoalsFromScore(scoreInfo.score) : null
+  const finishedFootballScorePlayers =
+    scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
   // Same "live while in progress, else confirmed/pending" source as
   // `cricketScoreInnings` below — needed here just for `.players` (the
   // score's resolved-name map), passed to `CricketScorecard`.
@@ -256,6 +265,17 @@ function MatchDetail({
                 </span>
               ))}
             </div>
+          )}
+
+          {finishedFootballGoals && (
+            <FootballScorersBySide
+              goals={finishedFootballGoals}
+              match={match}
+              players={finishedFootballScorePlayers}
+              sideA={sideA}
+              sideB={sideB}
+              className="mt-2 text-xs"
+            />
           )}
 
           <div className="mt-3 flex items-center justify-between">


### PR DESCRIPTION
## Summary
Replaces the recent-goals event ticker on finished football match cards with a cleaner side-by-side scorer breakdown, showing each player's name and all minutes they scored (e.g., "James Elgar 5', 53'"). This matches the layout of the score header itself, with scorers aligned under their respective sides.

## Changes
- **New component `FootballScorersBySide`**: Displays all goalscorers for a finished match grouped by side, with multiple goals by the same player merged onto one line showing all minutes in ascending order. Own goals are labeled "Own goal (Scorer)" and credited to the benefiting side.

- **New function `scorersBySide`**: Core logic that groups goals by crediting side and scorer, merges multiple goals per player, sorts by first goal minute, and handles own goal labeling with fallback to "Unknown" when scorer data is unavailable.

- **Updated `MatchCard`**: Replaced the emoji-prefixed event ticker (which showed recent goals with `describeEvent`) with the new `FootballScorersBySide` component, reducing visual clutter while showing the same information more clearly.

- **Updated `MatchDetailPage`**: Added the same `FootballScorersBySide` component under the score box in the match detail header, keeping the full event timeline (`FootballScorecard`) unchanged further down the page.

- **Removed `recentGoalEvents`**: Replaced by `scorersBySide`, which provides a better data structure for the new UI.

## Implementation Details
- Own goals are credited to the *benefiting* side (matching the scoreboard), but labeled with the own-goal scorer's name for clarity
- Multiple goals by the same player are never merged for own goals, even if they'd count for the same side
- Scorer names are resolved server-side on the confirmed/pending score itself (via `hydrate_confirmed_pending_score_players`), so the card doesn't need a full player roster
- The component renders nothing if neither side has a goal, keeping the UI clean for scoreless matches

https://claude.ai/code/session_01C3EVgVA5Uki7yfoCAvZXKT