### PR TITLE
Add rounders as a live-scored sport

### DIFF
--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -82,6 +82,15 @@ pub enum ScoreRecord {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         penalty_shootout_score: Option<HashMap<String, u32>>,
     },
+    Rounders {
+        innings: Vec<RoundersScoreInningsRecord>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        recent_deliveries: Option<Vec<RoundersDeliveryRecord>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        next_ball_context: Option<RoundersNextBallContextRecord>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        awaiting_next_innings: Option<bool>,
+    },
 }
 
 /// One innings' final totals, as stored on a match's confirmed/pending
@@ -170,6 +179,115 @@ pub struct CricketFallOfWicketRecord {
 pub struct OversRecord {
     pub overs: u32,
     pub balls: u32,
+}
+
+/// One innings' final totals, as stored on a match's confirmed/pending
+/// `Score` — mirrors the API's `RoundersScoreInnings`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersScoreInningsRecord {
+    pub batting_side_id: String,
+    pub fielding_side_id: String,
+    pub half_rounders: u32,
+    pub outs: u32,
+    pub good_balls_bowled: u32,
+    pub byes: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batting: Option<Vec<RoundersBattingEntryRecord>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bowling: Option<Vec<RoundersBowlingEntryRecord>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fall_of_outs: Option<Vec<RoundersFallOfOutRecord>>,
+}
+
+/// Mirrors the API's `detailed_score::rounders::RoundersOut`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersOutRecord {
+    pub kind: RoundersOutKindRecord,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fielder_player_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RoundersOutKindRecord {
+    Caught,
+    StumpedAtPost,
+    OvertookRunner,
+    Obstruction,
+    FailedToRun,
+}
+
+/// Mirrors the API's `main::RoundersBattingEntry`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersBattingEntryRecord {
+    pub player_id: String,
+    pub half_rounders: u32,
+    pub balls_faced: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub out: Option<RoundersOutRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batting_position: Option<u32>,
+}
+
+/// Mirrors the API's `main::RoundersBowlingEntry`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersBowlingEntryRecord {
+    pub player_id: String,
+    pub balls_bowled: u32,
+    pub no_balls: u32,
+    pub outs: u32,
+    pub half_rounders_conceded: u32,
+}
+
+/// Mirrors the API's `main::RoundersFallOfOut`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersFallOfOutRecord {
+    pub out_number: u32,
+    pub half_rounders: u32,
+    pub player_id: String,
+    pub kind: RoundersOutKindRecord,
+}
+
+/// The four posts a batter runs around — mirrors the API's
+/// `detailed_score::rounders::RoundersPost`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RoundersPostRecord {
+    First,
+    Second,
+    Third,
+    Fourth,
+}
+
+/// Mirrors the API's `detailed_score::rounders::RoundersRunnerMovement`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersRunnerMovementRecord {
+    pub player_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_reached: Option<RoundersPostRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub out: Option<RoundersOutRecord>,
+}
+
+/// Mirrors `detailed_score::rounders::RoundersDelivery` (reused verbatim as
+/// the API's live delivery payload).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersDeliveryRecord {
+    pub bowler_player_id: String,
+    pub striker_player_id: String,
+    pub no_ball: bool,
+    pub byes: bool,
+    pub movements: Vec<RoundersRunnerMovementRecord>,
+}
+
+/// Mirrors `detailed_score::rounders::RoundersNextBallContext`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersNextBallContextRecord {
+    #[serde(default)]
+    pub runners_on_base: HashMap<String, RoundersPostRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bowler_player_id: Option<String>,
+    pub balls_in_spell: u32,
 }
 
 /// The agreed, settled score of a match.
@@ -429,6 +547,7 @@ pub struct MatchRecord {
 pub enum MatchFormatRecord {
     Football(FootballFormatRecord),
     Cricket(CricketFormatRecord),
+    Rounders(RoundersFormatRecord),
 }
 
 /// Mirrors `agon_service::match_format::FootballFormat`.
@@ -463,6 +582,23 @@ pub struct CricketFormatRecord {
 
 fn default_true() -> bool {
     true
+}
+
+/// Mirrors `agon_service::match_format::RoundersFormat`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersFormatRecord {
+    pub innings_per_side: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub good_balls_per_innings: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub innings_length_minutes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_batter_bonus_balls: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub balls_per_bowling_spell: Option<u32>,
+    pub half_rounders_count: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_ball_penalty_threshold: Option<u32>,
 }
 
 /// `MATCH#<matchId>` / `SIDE#<sideId>` — one side of a match.
@@ -576,6 +712,7 @@ pub struct LiveEventRecord {
 pub enum LiveEventPayloadRecord {
     Football(FootballLiveEventRecord),
     Cricket(CricketLiveEventRecord),
+    Rounders(RoundersLiveEventRecord),
 }
 
 // ---- Football live events --------------------------------------------------
@@ -761,6 +898,36 @@ pub enum InningsEndReasonRecord {
     OversComplete,
     Declared,
     TargetReached,
+}
+
+// ---- Rounders live events ---------------------------------------------------
+
+/// Mirrors `agon_service::live_score::rounders::RoundersLiveEvent`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RoundersLiveEventRecord {
+    Delivery(RoundersDeliveryRecord),
+    InningsStart(RoundersInningsStartEventRecord),
+    InningsEnd(RoundersInningsEndEventRecord),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersInningsStartEventRecord {
+    pub batting_side_id: String,
+    pub fielding_side_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RoundersInningsEndEventRecord {
+    pub reason: RoundersInningsEndReasonRecord,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RoundersInningsEndReasonRecord {
+    AllBattersOut,
+    GoodBallsComplete,
+    TimeUp,
 }
 
 /// `MATCH#<matchId>` / `SCORESUB#<ts>#<subId>` — a score submission and its

--- a/agon_service/src/detailed_score/mod.rs
+++ b/agon_service/src/detailed_score/mod.rs
@@ -8,3 +8,4 @@
 
 pub mod cricket;
 pub mod football;
+pub mod rounders;

--- a/agon_service/src/detailed_score/rounders.rs
+++ b/agon_service/src/detailed_score/rounders.rs
@@ -1,0 +1,122 @@
+use poem_openapi::{Enum, Object};
+
+/// How many balls back `RoundersScore.recent_deliveries` keeps for a
+/// "recent balls" read — same role as cricket's `RECENT_DELIVERIES_LIMIT`.
+pub const RECENT_DELIVERIES_LIMIT: usize = 12;
+
+/// The four posts a batter runs around, in order — reaching the fourth
+/// (touching home/the batting square) completes the circuit.
+#[derive(Enum, Debug, Clone, Copy, PartialEq, Eq)]
+#[oai(rename_all = "snake_case")]
+pub enum RoundersPost {
+    First,
+    Second,
+    Third,
+    Fourth,
+}
+
+#[derive(Enum, Debug, Clone, Copy, PartialEq, Eq)]
+#[oai(rename_all = "snake_case")]
+pub enum RoundersOutKind {
+    /// A struck ball caught before it touches the ground.
+    Caught,
+    /// A fielder gets the ball to the post a runner is running to before
+    /// they arrive.
+    StumpedAtPost,
+    /// Runner passes/overtakes a teammate on the track.
+    OvertookRunner,
+    /// Deliberately obstructs a fielder going for the ball or a post.
+    Obstruction,
+    /// Struck the ball but made no attempt to run.
+    FailedToRun,
+}
+
+/// Doesn't carry which player was dismissed — always nested somewhere that
+/// already identifies them (`RoundersRunnerMovement.player_id`,
+/// `RoundersBattingEntry.player_id`), same convention as
+/// `detailed_score::cricket::CricketDismissal`.
+#[derive(Object, Clone)]
+pub struct RoundersOut {
+    pub kind: RoundersOutKind,
+    pub fielder_player_id: Option<String>,
+}
+
+/// One runner's outcome on a single delivery. A delivery carries a *list*
+/// of these — every runner already on a post can move independently of
+/// whatever the new striker does, since rounders (unlike cricket's
+/// striker/non-striker pair) can have several runners on the track from
+/// different batters' earlier turns at once.
+#[derive(Object, Clone)]
+pub struct RoundersRunnerMovement {
+    pub player_id: String,
+    /// `None` = stayed on their previous post (or the striker didn't run).
+    /// Whether reaching the fourth post here is a full or half rounder is
+    /// not stored — it's derived while folding, from whether `player_id`
+    /// is this delivery's `striker_player_id` (see
+    /// `RoundersLiveEvent::apply_delivery`'s doc comment).
+    pub post_reached: Option<RoundersPost>,
+    pub out: Option<RoundersOut>,
+}
+
+/// A single delivery (ball) in an innings — the live-scoring "delivery"
+/// event payload verbatim (see
+/// `crate::live_score::rounders::RoundersLiveEvent::Delivery`), same
+/// convention as `CricketDelivery`.
+#[derive(Object, Clone)]
+pub struct RoundersDelivery {
+    pub bowler_player_id: String,
+    /// The batter newly facing this ball. A batter's turn ends after one
+    /// good ball (the last-remaining batter in the order gets more — see
+    /// `crate::match_format::RoundersFormat::last_batter_bonus_balls`), then
+    /// the next name in the order comes in; the order loops back around for
+    /// anyone not yet out once everyone's had a turn, so the same
+    /// `player_id` can appear here again later in the innings.
+    pub striker_player_id: String,
+    /// Bowled unplayably (too high/wide/low/short). Doesn't count toward
+    /// the innings' good-ball cap and can't dismiss the striker at 1st
+    /// post — any reward for it is still expressed as an ordinary
+    /// `RoundersRunnerMovement`, not implied by this flag.
+    pub no_ball: bool,
+    /// Backstop missed/fumbled a ball the striker didn't hit, rather than
+    /// any runner advancing off a struck ball. Purely categorical — the
+    /// actual advancement (if any) is in `movements`. Kept as an explicit
+    /// flag rather than inferred, because "backstop's fault vs. a clean
+    /// take that just didn't get back in time" is the scorer's judgment
+    /// call, not an arithmetic fact — same reason
+    /// `CricketDeliveryWicket::kind` is stored explicitly rather than
+    /// derived.
+    pub byes: bool,
+    /// Every runner (including the striker, if they ran) who moved, stayed,
+    /// or got out on this ball.
+    pub movements: Vec<RoundersRunnerMovement>,
+}
+
+/// What's known about who's where for the *next* delivery, folded
+/// incrementally as events are recorded — the rounders analogue of
+/// cricket's `NextBallContext`, but tracking a variable number of
+/// concurrent runners instead of a fixed striker/non-striker pair (see
+/// `RoundersDelivery`'s doc comment on why more than one runner can be on
+/// the track at once).
+#[derive(Object, Clone)]
+pub struct RoundersNextBallContext {
+    /// Every runner still out on the track (not yet home, not yet out),
+    /// keyed by player id.
+    pub runners_on_base: std::collections::HashMap<String, RoundersPost>,
+    pub bowler_player_id: Option<String>,
+    /// Balls this bowler has sent down in their current spell — resets to 1
+    /// whenever the bowler changes. Format may cap this (see
+    /// `crate::match_format::RoundersFormat::balls_per_bowling_spell`),
+    /// same display role as cricket's over/ball counters.
+    pub balls_in_spell: u32,
+}
+
+impl RoundersNextBallContext {
+    /// The state before any delivery has been recorded in an innings.
+    pub fn opening() -> Self {
+        RoundersNextBallContext {
+            runners_on_base: std::collections::HashMap::new(),
+            bowler_player_id: None,
+            balls_in_spell: 0,
+        }
+    }
+}

--- a/agon_service/src/live_score/mod.rs
+++ b/agon_service/src/live_score/mod.rs
@@ -20,9 +20,11 @@ use poem_openapi::{Object, Union};
 
 pub mod cricket;
 pub mod football;
+pub mod rounders;
 
 pub use cricket::CricketLiveEvent;
 pub use football::FootballLiveEvent;
+pub use rounders::RoundersLiveEvent;
 
 /// A single live-scoring event, sport-first discriminated so a new sport is a
 /// new variant without touching existing ones — same pattern as `Score`.
@@ -33,6 +35,7 @@ pub use football::FootballLiveEvent;
 pub enum LiveEventInput {
     Football(FootballLiveEvent),
     Cricket(CricketLiveEvent),
+    Rounders(RoundersLiveEvent),
 }
 
 /// One event to append, before the server has assigned it a `seq`.

--- a/agon_service/src/live_score/rounders.rs
+++ b/agon_service/src/live_score/rounders.rs
@@ -1,0 +1,580 @@
+use poem_openapi::{Enum, Object, Union};
+
+use crate::detailed_score::rounders::{
+    RECENT_DELIVERIES_LIMIT, RoundersDelivery, RoundersNextBallContext, RoundersPost,
+};
+use crate::{RoundersBattingEntry, RoundersBowlingEntry, RoundersFallOfOut, RoundersScoreInnings};
+
+/// Rounders live-scoring events, nested under the outer sport union
+/// (`LiveEventInput::Rounders`), discriminated by `kind` — same pattern as
+/// `CricketLiveEvent`/`FootballLiveEvent`.
+#[derive(Union, Clone)]
+#[oai(one_of, discriminator_name = "kind")]
+pub enum RoundersLiveEvent {
+    /// One ball. Reuses `detailed_score::rounders::RoundersDelivery`
+    /// verbatim — same reasoning as `CricketLiveEvent::Delivery`.
+    Delivery(RoundersDelivery),
+    InningsStart(RoundersInningsStartEvent),
+    InningsEnd(RoundersInningsEndEvent),
+}
+
+#[derive(Object, Clone)]
+pub struct RoundersInningsStartEvent {
+    pub batting_side_id: String,
+    pub fielding_side_id: String,
+}
+
+#[derive(Enum, Clone)]
+#[oai(rename_all = "snake_case")]
+pub enum RoundersInningsEndReason {
+    /// All batting-order slots (the "Batters out" grid on the standard
+    /// scoresheet) marked out.
+    AllBattersOut,
+    /// The innings' good-ball cap reached (the "Good balls" grid) —
+    /// no-balls don't count toward it.
+    GoodBallsComplete,
+    /// A timed variant some leagues play instead of/alongside a ball cap.
+    TimeUp,
+}
+
+#[derive(Object, Clone)]
+pub struct RoundersInningsEndEvent {
+    pub reason: RoundersInningsEndReason,
+}
+
+fn batting_entry<'a>(
+    batting: &'a mut Vec<RoundersBattingEntry>,
+    player_id: &str,
+) -> &'a mut RoundersBattingEntry {
+    if let Some(pos) = batting.iter().position(|b| b.player_id == player_id) {
+        &mut batting[pos]
+    } else {
+        batting.push(RoundersBattingEntry {
+            player_id: player_id.to_string(),
+            half_rounders: 0,
+            balls_faced: 0,
+            out: None,
+            batting_position: Some(batting.len() as u32 + 1),
+        });
+        batting.last_mut().unwrap()
+    }
+}
+
+fn bowling_entry<'a>(
+    bowling: &'a mut Vec<RoundersBowlingEntry>,
+    player_id: &str,
+) -> &'a mut RoundersBowlingEntry {
+    if let Some(pos) = bowling.iter().position(|b| b.player_id == player_id) {
+        &mut bowling[pos]
+    } else {
+        bowling.push(RoundersBowlingEntry {
+            player_id: player_id.to_string(),
+            balls_bowled: 0,
+            no_balls: 0,
+            outs: 0,
+            half_rounders_conceded: 0,
+        });
+        bowling.last_mut().unwrap()
+    }
+}
+
+/// Folds one delivery into an innings already in progress — updates the
+/// good-ball/bye counters, the batting/bowling cards and fall-of-outs, and
+/// every runner's position — and returns the next-ball context that follows
+/// it. Same role and shape as cricket's `apply_delivery`: called once per
+/// new delivery on the append path, and repeatedly from
+/// `RoundersScore::from_events` to bootstrap or recover a `RoundersScore`
+/// from the full event log, so the two paths can't disagree.
+///
+/// Whether a movement reaching the fourth post is a full or half rounder is
+/// derived here rather than trusted from the input: `player_id ==
+/// d.striker_player_id` means they started this ball fresh from the
+/// batting square, so reaching home is a single uninterrupted hit (full,
+/// worth 2 half-rounder units); anyone else in `movements` reaching home
+/// was already a runner from an earlier delivery, so it necessarily took
+/// more than one hit (half, worth 1 unit). A client asserting the wrong
+/// one is therefore not possible — same reasoning that keeps cricket's
+/// fours/sixes/maidens derived from `runs_off_bat`/`runs_conceded_this_over`
+/// rather than stored as flags.
+pub fn apply_delivery(
+    innings: &mut RoundersScoreInnings,
+    context: &RoundersNextBallContext,
+    d: &RoundersDelivery,
+) -> RoundersNextBallContext {
+    if !d.no_ball {
+        innings.good_balls_bowled += 1;
+    }
+    if d.byes {
+        innings.byes += 1;
+    }
+
+    {
+        let bw = bowling_entry(
+            innings.bowling.get_or_insert_with(Vec::new),
+            &d.bowler_player_id,
+        );
+        if d.no_ball {
+            bw.no_balls += 1;
+        } else {
+            bw.balls_bowled += 1;
+        }
+    }
+
+    // Striker: faces a ball (excluding no-balls, same convention as
+    // cricket's `balls_faced`) regardless of whether they end up running.
+    if !d.no_ball {
+        batting_entry(
+            innings.batting.get_or_insert_with(Vec::new),
+            &d.striker_player_id,
+        )
+        .balls_faced += 1;
+    }
+
+    let mut runners_on_base = context.runners_on_base.clone();
+
+    for m in &d.movements {
+        if let Some(out) = &m.out {
+            runners_on_base.remove(&m.player_id);
+            innings.outs += 1;
+            batting_entry(innings.batting.get_or_insert_with(Vec::new), &m.player_id).out =
+                Some(out.clone());
+            innings
+                .fall_of_outs
+                .get_or_insert_with(Vec::new)
+                .push(RoundersFallOfOut {
+                    out_number: innings.outs,
+                    half_rounders: innings.half_rounders,
+                    player_id: m.player_id.clone(),
+                    kind: out.kind,
+                });
+            bowling_entry(
+                innings.bowling.get_or_insert_with(Vec::new),
+                &d.bowler_player_id,
+            )
+            .outs += 1;
+            continue;
+        }
+
+        match m.post_reached {
+            Some(RoundersPost::Fourth) => {
+                let half = m.player_id != d.striker_player_id;
+                let points = if half { 1 } else { 2 };
+                innings.half_rounders += points;
+                batting_entry(innings.batting.get_or_insert_with(Vec::new), &m.player_id)
+                    .half_rounders += points;
+                bowling_entry(
+                    innings.bowling.get_or_insert_with(Vec::new),
+                    &d.bowler_player_id,
+                )
+                .half_rounders_conceded += points;
+                runners_on_base.remove(&m.player_id);
+            }
+            Some(post) => {
+                runners_on_base.insert(m.player_id.clone(), post);
+            }
+            None => {
+                // Stayed on their existing post (if any), or the striker
+                // didn't run at all — nothing to update.
+            }
+        }
+    }
+
+    let mut balls_in_spell = context.balls_in_spell;
+    if context.bowler_player_id.as_deref() != Some(d.bowler_player_id.as_str()) {
+        balls_in_spell = 0;
+    }
+    balls_in_spell += 1;
+
+    RoundersNextBallContext {
+        runners_on_base,
+        bowler_player_id: Some(d.bowler_player_id.clone()),
+        balls_in_spell,
+    }
+}
+
+impl crate::RoundersScore {
+    /// Folds the whole event log into a `RoundersScore` from scratch — the
+    /// slow path, used to bootstrap a match's first score, recover from a
+    /// missing/unparseable cache, or rebuild after undoing the last event.
+    /// Just `apply_event` run once per event in order — the fast
+    /// (single-event) and slow (whole-log) paths share the exact same fold,
+    /// so they can't disagree, same pattern as `CricketScore::from_events`.
+    pub fn from_events(events: &[RoundersLiveEvent]) -> Self {
+        let mut score = crate::RoundersScore {
+            innings: Vec::new(),
+            recent_deliveries: None,
+            next_ball_context: None,
+            awaiting_next_innings: Some(true),
+            players: std::collections::HashMap::new(),
+        };
+        for event in events {
+            score.apply_event(event);
+        }
+        score
+    }
+
+    /// Folds one new event into this score in place — the fast path, run on
+    /// every append.
+    pub fn apply_event(&mut self, event: &RoundersLiveEvent) {
+        match event {
+            RoundersLiveEvent::InningsStart(start) => {
+                self.innings.push(RoundersScoreInnings::opening(
+                    start.batting_side_id.clone(),
+                    start.fielding_side_id.clone(),
+                ));
+                self.recent_deliveries = Some(Vec::new());
+                self.next_ball_context = Some(RoundersNextBallContext::opening());
+                self.awaiting_next_innings = Some(false);
+            }
+            RoundersLiveEvent::Delivery(d) => {
+                let Some(current) = self.innings.last_mut() else {
+                    // A delivery with no open innings is malformed input —
+                    // there's nothing to fold it into.
+                    return;
+                };
+                let context = self
+                    .next_ball_context
+                    .clone()
+                    .unwrap_or_else(RoundersNextBallContext::opening);
+                let next_context = apply_delivery(current, &context, d);
+                self.next_ball_context = Some(next_context);
+
+                let deliveries = self.recent_deliveries.get_or_insert_with(Vec::new);
+                deliveries.push(d.clone());
+                if deliveries.len() > RECENT_DELIVERIES_LIMIT {
+                    deliveries.remove(0);
+                }
+            }
+            RoundersLiveEvent::InningsEnd(_) => {
+                self.recent_deliveries = None;
+                self.next_ball_context = None;
+                self.awaiting_next_innings = Some(true);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detailed_score::rounders::{RoundersOut, RoundersOutKind, RoundersRunnerMovement};
+
+    fn delivery(
+        bowler: &str,
+        striker: &str,
+        movements: Vec<RoundersRunnerMovement>,
+    ) -> RoundersDelivery {
+        RoundersDelivery {
+            bowler_player_id: bowler.into(),
+            striker_player_id: striker.into(),
+            no_ball: false,
+            byes: false,
+            movements,
+        }
+    }
+
+    fn moved(player_id: &str, post: RoundersPost) -> RoundersRunnerMovement {
+        RoundersRunnerMovement {
+            player_id: player_id.into(),
+            post_reached: Some(post),
+            out: None,
+        }
+    }
+
+    fn score(events: &[RoundersLiveEvent]) -> crate::RoundersScore {
+        crate::RoundersScore::from_events(events)
+    }
+
+    #[test]
+    fn a_single_hit_all_the_way_around_is_a_full_rounder() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::Delivery(delivery(
+                "patel",
+                "sharma",
+                vec![moved("sharma", RoundersPost::Fourth)],
+            )),
+        ];
+
+        let d = score(&events);
+        assert_eq!(d.innings.len(), 1);
+        assert_eq!(
+            d.innings[0].half_rounders, 2,
+            "a full rounder is 2 half-rounder units"
+        );
+        assert_eq!(d.innings[0].good_balls_bowled, 1);
+        let sharma = d.innings[0]
+            .batting
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|b| b.player_id == "sharma")
+            .unwrap();
+        assert_eq!(sharma.half_rounders, 2);
+        assert!(
+            !d.next_ball_context
+                .as_ref()
+                .unwrap()
+                .runners_on_base
+                .contains_key("sharma")
+        );
+    }
+
+    #[test]
+    fn reaching_home_over_two_deliveries_is_a_half_rounder() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            // Sharma bats, stops at 2nd.
+            RoundersLiveEvent::Delivery(delivery(
+                "patel",
+                "sharma",
+                vec![moved("sharma", RoundersPost::Second)],
+            )),
+            // Verma bats next; sharma (already a runner) advances home off it.
+            RoundersLiveEvent::Delivery(delivery(
+                "patel",
+                "verma",
+                vec![moved("sharma", RoundersPost::Fourth)],
+            )),
+        ];
+
+        let d = score(&events);
+        assert_eq!(
+            d.innings[0].half_rounders, 1,
+            "took two deliveries, so only half a rounder"
+        );
+        let sharma = d.innings[0]
+            .batting
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|b| b.player_id == "sharma")
+            .unwrap();
+        assert_eq!(sharma.half_rounders, 1);
+        assert!(
+            !d.next_ball_context
+                .as_ref()
+                .unwrap()
+                .runners_on_base
+                .contains_key("sharma")
+        );
+    }
+
+    #[test]
+    fn stopping_short_of_home_scores_nothing_yet() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::Delivery(delivery(
+                "patel",
+                "sharma",
+                vec![moved("sharma", RoundersPost::Second)],
+            )),
+        ];
+
+        let d = score(&events);
+        assert_eq!(d.innings[0].half_rounders, 0);
+        assert_eq!(
+            d.next_ball_context
+                .as_ref()
+                .unwrap()
+                .runners_on_base
+                .get("sharma"),
+            Some(&RoundersPost::Second)
+        );
+    }
+
+    #[test]
+    fn an_out_ends_that_batting_order_slot_and_removes_the_runner() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::Delivery(RoundersDelivery {
+                movements: vec![RoundersRunnerMovement {
+                    player_id: "sharma".into(),
+                    post_reached: None,
+                    out: Some(RoundersOut {
+                        kind: RoundersOutKind::Caught,
+                        fielder_player_id: Some("khan".into()),
+                    }),
+                }],
+                ..delivery("patel", "sharma", vec![])
+            }),
+        ];
+
+        let d = score(&events);
+        assert_eq!(d.innings[0].outs, 1);
+        assert_eq!(d.innings[0].fall_of_outs.as_ref().unwrap().len(), 1);
+        let sharma = d.innings[0]
+            .batting
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|b| b.player_id == "sharma")
+            .unwrap();
+        assert!(matches!(
+            sharma.out.as_ref().map(|o| o.kind),
+            Some(RoundersOutKind::Caught)
+        ));
+        let patel = d.innings[0]
+            .bowling
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|b| b.player_id == "patel")
+            .unwrap();
+        assert_eq!(patel.outs, 1);
+    }
+
+    #[test]
+    fn the_batting_order_can_lap_the_same_player_faces_more_than_one_turn() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::Delivery(delivery(
+                "patel",
+                "sharma",
+                vec![moved("sharma", RoundersPost::First)],
+            )),
+            RoundersLiveEvent::Delivery(delivery("patel", "verma", vec![])),
+            // Sharma comes around again for a second turn while still on base.
+            RoundersLiveEvent::Delivery(delivery(
+                "patel",
+                "sharma",
+                vec![moved("sharma", RoundersPost::Fourth)],
+            )),
+        ];
+
+        let d = score(&events);
+        let sharma = d.innings[0]
+            .batting
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|b| b.player_id == "sharma")
+            .unwrap();
+        assert_eq!(sharma.balls_faced, 2, "faced two separate turns");
+        assert_eq!(
+            sharma.half_rounders, 2,
+            "the second turn's hit is the striker's own single hit home, so it's still full"
+        );
+    }
+
+    #[test]
+    fn no_ball_does_not_count_toward_good_balls_bowled() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::Delivery(RoundersDelivery {
+                no_ball: true,
+                ..delivery("patel", "sharma", vec![])
+            }),
+        ];
+
+        let d = score(&events);
+        assert_eq!(d.innings[0].good_balls_bowled, 0);
+        let patel = d.innings[0]
+            .bowling
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|b| b.player_id == "patel")
+            .unwrap();
+        assert_eq!(patel.no_balls, 1);
+        assert_eq!(patel.balls_bowled, 0);
+    }
+
+    #[test]
+    fn bowling_spell_resets_when_the_bowler_changes() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::Delivery(delivery("patel", "sharma", vec![])),
+            RoundersLiveEvent::Delivery(delivery("patel", "verma", vec![])),
+            RoundersLiveEvent::Delivery(delivery("khan", "cole", vec![])),
+        ];
+
+        let d = score(&events);
+        let ctx = d.next_ball_context.unwrap();
+        assert_eq!(ctx.bowler_player_id.as_deref(), Some("khan"));
+        assert_eq!(ctx.balls_in_spell, 1);
+    }
+
+    #[test]
+    fn innings_end_clears_live_context_and_awaits_the_next_innings() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::Delivery(delivery("patel", "sharma", vec![])),
+            RoundersLiveEvent::InningsEnd(RoundersInningsEndEvent {
+                reason: RoundersInningsEndReason::AllBattersOut,
+            }),
+        ];
+
+        let d = score(&events);
+        assert!(d.recent_deliveries.is_none());
+        assert!(d.next_ball_context.is_none());
+        assert_eq!(d.awaiting_next_innings, Some(true));
+    }
+
+    #[test]
+    fn incremental_and_full_fold_agree() {
+        let events = vec![
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::Delivery(delivery(
+                "patel",
+                "sharma",
+                vec![moved("sharma", RoundersPost::Second)],
+            )),
+            RoundersLiveEvent::Delivery(delivery(
+                "patel",
+                "verma",
+                vec![moved("sharma", RoundersPost::Fourth)],
+            )),
+        ];
+
+        let full = crate::RoundersScore::from_events(&events);
+
+        let mut incremental = crate::RoundersScore {
+            innings: Vec::new(),
+            recent_deliveries: None,
+            next_ball_context: None,
+            awaiting_next_innings: Some(true),
+            players: std::collections::HashMap::new(),
+        };
+        for event in &events {
+            incremental.apply_event(event);
+        }
+
+        assert_eq!(incremental.innings.len(), full.innings.len());
+        assert_eq!(
+            incremental.innings[0].half_rounders,
+            full.innings[0].half_rounders
+        );
+        assert_eq!(
+            incremental.innings[0].batting.as_ref().unwrap().len(),
+            full.innings[0].batting.as_ref().unwrap().len()
+        );
+    }
+}

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -66,6 +66,10 @@ use detailed_score::{
         FootballCardEvent, FootballGoalEvent, FootballPenaltyShootoutKick, FootballPeriod,
         FootballSubstitutionEvent,
     },
+    rounders::{
+        RoundersDelivery, RoundersNextBallContext, RoundersOut, RoundersOutKind,
+        RoundersRunnerMovement,
+    },
 };
 
 mod live_score;
@@ -350,6 +354,10 @@ enum Score {
     /// completed football match — live-scored or manually entered. Carries
     /// enough to render the feed/detail goal ticker without a separate fetch.
     Football(FootballScore),
+    /// Per-innings (half-)rounders/outs (plus optional per-player detail),
+    /// the result of a completed rounders match — live-scored or manually
+    /// entered.
+    Rounders(RoundersScore),
 }
 
 #[derive(Object)]
@@ -495,6 +503,121 @@ struct FootballScore {
     players: HashMap<String, RosterPreviewPlayer>,
 }
 
+/// A rounders match's result: per-innings totals, plus optional richer
+/// detail — same three-role shape as `CricketScore`/`FootballScore` (see
+/// `Score`'s doc comment).
+#[derive(Object)]
+struct RoundersScore {
+    /// One entry per innings played, in the order they were played.
+    innings: Vec<RoundersScoreInnings>,
+    /// The current/most recent innings' recent-ball window. `None` once
+    /// there isn't a current innings (between innings, match over) or for a
+    /// result with no ball-by-ball detail behind it.
+    recent_deliveries: Option<Vec<RoundersDelivery>>,
+    /// Who's where right now — who's on which post, who's bowling. `None`
+    /// once there isn't a next delivery to give context for.
+    next_ball_context: Option<RoundersNextBallContext>,
+    /// True once the log's last innings has ended and no following one has
+    /// started yet. `None` for a result with no live log behind it.
+    awaiting_next_innings: Option<bool>,
+    /// Live name/avatar for every player id referenced anywhere else in this
+    /// score, keyed by that same (match-scoped) player id. Same mechanism
+    /// and rationale as `CricketScore.players`.
+    players: HashMap<String, RosterPreviewPlayer>,
+}
+
+/// One innings' totals, plus optional per-player detail — the rounders
+/// analogue of `CricketScoreInnings`. Every field beyond `batting_side_id`/
+/// `fielding_side_id` is either a running total folded from the delivery
+/// log (`half_rounders`, `outs`, `good_balls_bowled`, `byes`) or optional
+/// per-player detail (`None` for a manually-entered result with no card
+/// behind it, populated for a live-scored or backfilled one) — nothing here
+/// is ever asserted directly by a client, only derived while folding (see
+/// `live_score::rounders::apply_delivery`).
+#[derive(Object)]
+struct RoundersScoreInnings {
+    /// The batting side for this innings (references MatchSide.id).
+    batting_side_id: String,
+    /// The fielding side for this innings.
+    fielding_side_id: String,
+    /// Half-rounder units — a full rounder is 2. Kept as an integer, same
+    /// reasoning as `Overs` splitting overs/balls instead of a float: exact
+    /// arithmetic, no rounding surprises. Render as `half_rounders / 2` +
+    /// ".5" when odd.
+    half_rounders: u32,
+    /// Batting-order slots marked out so far (max = the order's length,
+    /// usually 9 — the "Batters out" grid on the standard scoresheet).
+    outs: u32,
+    /// Good (fair) balls bowled so far this innings — no-balls excluded.
+    /// Compared against `match_format::RoundersFormat::good_balls_per_innings`
+    /// to drive `live_score::rounders::RoundersInningsEndReason::GoodBallsComplete`.
+    good_balls_bowled: u32,
+    /// Byes conceded this innings — not attributed to a specific bowler
+    /// (it's the backstop's doing, not theirs), same convention as cricket
+    /// crediting byes to `CricketExtras` rather than any bowler.
+    byes: u32,
+    batting: Option<Vec<RoundersBattingEntry>>,
+    bowling: Option<Vec<RoundersBowlingEntry>>,
+    fall_of_outs: Option<Vec<RoundersFallOfOut>>,
+}
+
+impl RoundersScoreInnings {
+    /// The state before any delivery has been recorded in this innings —
+    /// only ever constructed on a live-scoring path (`InningsStart`), same
+    /// convention as `CricketScoreInnings::opening`.
+    fn opening(batting_side_id: String, fielding_side_id: String) -> Self {
+        RoundersScoreInnings {
+            batting_side_id,
+            fielding_side_id,
+            half_rounders: 0,
+            outs: 0,
+            good_balls_bowled: 0,
+            byes: 0,
+            batting: Some(Vec::new()),
+            bowling: Some(Vec::new()),
+            fall_of_outs: Some(Vec::new()),
+        }
+    }
+}
+
+#[derive(Object)]
+struct RoundersBattingEntry {
+    player_id: String,
+    half_rounders: u32,
+    /// Faced across every turn at the square this innings — the batting
+    /// order can lap back around for anyone not yet out, so this can
+    /// accumulate over more than one turn (see
+    /// `detailed_score::rounders::RoundersDelivery::striker_player_id`'s
+    /// doc comment). Excludes no-balls, same convention as cricket's
+    /// `balls_faced`.
+    balls_faced: u32,
+    /// Set once — a batting-order slot is out at most once per innings,
+    /// even though the same player may have faced several separate turns
+    /// before that happened.
+    out: Option<RoundersOut>,
+    /// Position in the batting order (typically 1-9).
+    batting_position: Option<u32>,
+}
+
+#[derive(Object)]
+struct RoundersBowlingEntry {
+    player_id: String,
+    /// Good (fair) balls bowled — no-balls tracked separately.
+    balls_bowled: u32,
+    no_balls: u32,
+    outs: u32,
+    half_rounders_conceded: u32,
+}
+
+#[derive(Object)]
+struct RoundersFallOfOut {
+    out_number: u32,
+    /// The innings' `half_rounders` total at the moment of this out.
+    half_rounders: u32,
+    player_id: String,
+    kind: RoundersOutKind,
+}
+
 /// The sport a match was played in. Determines the expected `Score` shape
 /// (e.g. racket sports use `Score::Sets`, football uses `Score::Football`,
 /// and cricket uses `Score::Cricket`). Extend as more sports are supported.
@@ -507,6 +630,7 @@ pub enum MatchType {
     TableTennis,
     Football,
     Cricket,
+    Rounders,
     /// Fallback for sports not yet modelled explicitly.
     Other,
 }
@@ -2613,6 +2737,11 @@ impl Api {
                     .flat_map(|i| [i.batting_side_id.as_str(), i.bowling_side_id.as_str()])
                     .collect(),
                 Score::Football(s) => s.score.keys().map(|k| k.as_str()).collect(),
+                Score::Rounders(s) => s
+                    .innings
+                    .iter()
+                    .flat_map(|i| [i.batting_side_id.as_str(), i.fielding_side_id.as_str()])
+                    .collect(),
             };
             if score_sides.iter().any(|sid| !valid_sides.contains(sid)) {
                 return Ok(UpdateMatchResponse::ValidationError(PlainText(
@@ -3173,8 +3302,17 @@ impl Api {
                     s.apply_event(e.occurred_at, event);
                 }
             }
-            // Live scoring only ever creates a `Cricket`/`Football` record
-            // for this match_id/sport pair — unreachable in practice.
+            Score::Rounders(s) => {
+                for e in new_events {
+                    let LiveEventInput::Rounders(event) = &e.event else {
+                        return Ok(None);
+                    };
+                    s.apply_event(event);
+                }
+            }
+            // Live scoring only ever creates a `Cricket`/`Football`/
+            // `Rounders` record for this match_id/sport pair — unreachable
+            // in practice.
             Score::Simple(_) | Score::Sets(_) => return Ok(None),
         }
 
@@ -5286,6 +5424,123 @@ fn resolve_score_ids(
                 players: HashMap::new(),
             }))
         }
+        Score::Rounders(s) => {
+            let remap_out = |out: &Option<RoundersOut>| -> Option<Option<RoundersOut>> {
+                match out {
+                    Some(o) => Some(Some(RoundersOut {
+                        kind: o.kind,
+                        fielder_player_id: pmap_opt(&o.fielder_player_id)?,
+                    })),
+                    None => Some(None),
+                }
+            };
+            let mut innings = Vec::with_capacity(s.innings.len());
+            for i in &s.innings {
+                let batting = match &i.batting {
+                    Some(bs) => {
+                        let mut out = Vec::with_capacity(bs.len());
+                        for b in bs {
+                            out.push(RoundersBattingEntry {
+                                player_id: pmap(&b.player_id)?,
+                                half_rounders: b.half_rounders,
+                                balls_faced: b.balls_faced,
+                                out: remap_out(&b.out)?,
+                                batting_position: b.batting_position,
+                            });
+                        }
+                        Some(out)
+                    }
+                    None => None,
+                };
+                let bowling = match &i.bowling {
+                    Some(bs) => {
+                        let mut out = Vec::with_capacity(bs.len());
+                        for b in bs {
+                            out.push(RoundersBowlingEntry {
+                                player_id: pmap(&b.player_id)?,
+                                balls_bowled: b.balls_bowled,
+                                no_balls: b.no_balls,
+                                outs: b.outs,
+                                half_rounders_conceded: b.half_rounders_conceded,
+                            });
+                        }
+                        Some(out)
+                    }
+                    None => None,
+                };
+                let fall_of_outs = match &i.fall_of_outs {
+                    Some(fs) => {
+                        let mut out = Vec::with_capacity(fs.len());
+                        for f in fs {
+                            out.push(RoundersFallOfOut {
+                                out_number: f.out_number,
+                                half_rounders: f.half_rounders,
+                                player_id: pmap(&f.player_id)?,
+                                kind: f.kind,
+                            });
+                        }
+                        Some(out)
+                    }
+                    None => None,
+                };
+                innings.push(RoundersScoreInnings {
+                    batting_side_id: map(&i.batting_side_id)?,
+                    fielding_side_id: map(&i.fielding_side_id)?,
+                    half_rounders: i.half_rounders,
+                    outs: i.outs,
+                    good_balls_bowled: i.good_balls_bowled,
+                    byes: i.byes,
+                    batting,
+                    bowling,
+                    fall_of_outs,
+                });
+            }
+            let recent_deliveries = match &s.recent_deliveries {
+                Some(ds) => {
+                    let mut out = Vec::with_capacity(ds.len());
+                    for d in ds {
+                        let mut movements = Vec::with_capacity(d.movements.len());
+                        for m in &d.movements {
+                            movements.push(RoundersRunnerMovement {
+                                player_id: pmap(&m.player_id)?,
+                                post_reached: m.post_reached,
+                                out: remap_out(&m.out)?,
+                            });
+                        }
+                        out.push(RoundersDelivery {
+                            bowler_player_id: pmap(&d.bowler_player_id)?,
+                            striker_player_id: pmap(&d.striker_player_id)?,
+                            no_ball: d.no_ball,
+                            byes: d.byes,
+                            movements,
+                        });
+                    }
+                    Some(out)
+                }
+                None => None,
+            };
+            let next_ball_context = match &s.next_ball_context {
+                Some(ctx) => {
+                    let mut runners_on_base = HashMap::with_capacity(ctx.runners_on_base.len());
+                    for (player_id, post) in &ctx.runners_on_base {
+                        runners_on_base.insert(pmap(player_id)?, *post);
+                    }
+                    Some(RoundersNextBallContext {
+                        runners_on_base,
+                        bowler_player_id: pmap_opt(&ctx.bowler_player_id)?,
+                        balls_in_spell: ctx.balls_in_spell,
+                    })
+                }
+                None => None,
+            };
+            Some(Score::Rounders(RoundersScore {
+                innings,
+                recent_deliveries,
+                next_ball_context,
+                awaiting_next_innings: s.awaiting_next_innings,
+                players: HashMap::new(),
+            }))
+        }
     }
 }
 
@@ -5296,6 +5551,7 @@ fn set_score_players(score: &mut Score, resolved: HashMap<String, RosterPreviewP
     match score {
         Score::Cricket(s) => s.players = resolved,
         Score::Football(s) => s.players = resolved,
+        Score::Rounders(s) => s.players = resolved,
         Score::Simple(_) | Score::Sets(_) => {}
     }
 }
@@ -5336,6 +5592,7 @@ fn score_player_ids(score: &Score) -> Vec<String> {
     match score {
         Score::Cricket(s) => cricket_score_player_ids(s),
         Score::Football(s) => football_score_player_ids(s),
+        Score::Rounders(s) => rounders_score_player_ids(s),
         Score::Simple(_) | Score::Sets(_) => Vec::new(),
     }
 }
@@ -5401,6 +5658,45 @@ fn football_score_player_ids(score: &FootballScore) -> Vec<String> {
     ids
 }
 
+/// Every player id referenced in a `RoundersScore`: `next_ball_context`'s
+/// runners-on-base and bowler, each innings' batting/bowling/fall-of-out
+/// entries (plus a batting entry's dismissal fielder), and
+/// `recent_deliveries` (plus each delivery's runner movements and their
+/// dismissal fielders). Same "may repeat, deduped downstream" contract as
+/// [`cricket_score_player_ids`].
+fn rounders_score_player_ids(score: &RoundersScore) -> Vec<String> {
+    let mut ids = Vec::new();
+    if let Some(ctx) = &score.next_ball_context {
+        ids.extend(ctx.runners_on_base.keys().cloned());
+        ids.extend(ctx.bowler_player_id.clone());
+    }
+    for innings in &score.innings {
+        for entry in innings.batting.iter().flatten() {
+            ids.push(entry.player_id.clone());
+            if let Some(out) = &entry.out {
+                ids.extend(out.fielder_player_id.clone());
+            }
+        }
+        for entry in innings.bowling.iter().flatten() {
+            ids.push(entry.player_id.clone());
+        }
+        for fall in innings.fall_of_outs.iter().flatten() {
+            ids.push(fall.player_id.clone());
+        }
+    }
+    for delivery in score.recent_deliveries.iter().flatten() {
+        ids.push(delivery.bowler_player_id.clone());
+        ids.push(delivery.striker_player_id.clone());
+        for m in &delivery.movements {
+            ids.push(m.player_id.clone());
+            if let Some(out) = &m.out {
+                ids.extend(out.fielder_player_id.clone());
+            }
+        }
+    }
+    ids
+}
+
 /// Derives the winner (when decidable) from a live-scored match's persisted
 /// score — used by `update_match` to finish a live-scored match without the
 /// client having to work out and resubmit a margin the server already has
@@ -5434,6 +5730,15 @@ fn winner_from_score(score: &Score, side_ids: &[String]) -> Option<String> {
             let mut totals: HashMap<&str, u32> = HashMap::new();
             for i in &s.innings {
                 *totals.entry(i.batting_side_id.as_str()).or_insert(0) += i.runs;
+            }
+            two_side_winner(side_ids, |sid| *totals.get(sid).unwrap_or(&0) as i64)
+        }
+        Score::Rounders(s) => {
+            // The winner is the summed half-rounders across innings, same
+            // reasoning as cricket's summed runs.
+            let mut totals: HashMap<&str, u32> = HashMap::new();
+            for i in &s.innings {
+                *totals.entry(i.batting_side_id.as_str()).or_insert(0) += i.half_rounders;
             }
             two_side_winner(side_ids, |sid| *totals.get(sid).unwrap_or(&0) as i64)
         }

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -16,6 +16,10 @@ use crate::detailed_score::football::{
     FootballCardColor, FootballCardEvent, FootballGoalEvent, FootballPenaltyShootoutKick,
     FootballPeriod, FootballSubstitutionEvent,
 };
+use crate::detailed_score::rounders::{
+    RoundersDelivery, RoundersNextBallContext, RoundersOut, RoundersOutKind, RoundersPost,
+    RoundersRunnerMovement,
+};
 use crate::live_score::{
     LiveEvent, LiveEventInput, NewLiveEventInput,
     cricket::{
@@ -23,8 +27,12 @@ use crate::live_score::{
         InningsEndReason,
     },
     football::{FootballLiveEvent, FootballPeriodEvent},
+    rounders::{
+        RoundersInningsEndEvent, RoundersInningsEndReason, RoundersInningsStartEvent,
+        RoundersLiveEvent,
+    },
 };
-use crate::match_format::{CricketFormat, FootballFormat, MatchFormat};
+use crate::match_format::{CricketFormat, FootballFormat, MatchFormat, RoundersFormat};
 use crate::membership::{
     ExternalMember, Invitation, InvitationContext, InvitationKind, InvitationMatchContext,
     InvitationStatus, InvitationTeamContext, Member, TokenInvitation, UserInvitation, UserMember,
@@ -38,9 +46,10 @@ use crate::team::{Team, TeamListItem, TeamMember, TeamRole};
 use crate::{
     Comment, ConfirmedScore, CricketScore, CricketScoreInnings, FeedMatch, FootballScore, Location,
     Match, MatchOutcome, MatchPlayer, MatchSide, MatchSocial, MatchStatus, MatchType, PendingScore,
-    Photo, RosterPreviewPlayer, Score, ScoreConfirmation, ScoreResponseKind, ScoreSubmission,
-    ScoreSubmissionResponse, ScoreSubmissionStatus, SearchMatch, SetsScore, SimpleScore,
-    UserProfile, UserSportStats,
+    Photo, RosterPreviewPlayer, RoundersBattingEntry, RoundersBowlingEntry, RoundersFallOfOut,
+    RoundersScore, RoundersScoreInnings, Score, ScoreConfirmation, ScoreResponseKind,
+    ScoreSubmission, ScoreSubmissionResponse, ScoreSubmissionStatus, SearchMatch, SetsScore,
+    SimpleScore, UserProfile, UserSportStats,
 };
 use agon_core::dao::error::DaoError;
 use agon_core::dao::live_score_ops::NewLiveEvent;
@@ -57,9 +66,13 @@ use agon_core::dao::records::{
     InningsEndReasonRecord, InvitationContextRecord, InvitationKindRecord, InvitationRecord,
     LiveEventPayloadRecord, LiveEventRecord, MatchFormatRecord, MatchLikeRecord, MatchPlayerRecord,
     MatchRecord, MatchScoreRecord, MatchSideRecord, NextBallContextRecord, NotificationKindRecord,
-    NotificationRecord, OversRecord, PendingScoreRecord, ScoreConfirmationRecord, ScoreRecord,
-    ScoreResponseRecord, ScoreSubmissionRecord, TeamMemberRecord, TeamRecord, UserRecord,
-    UserSportStatsRecord,
+    NotificationRecord, OversRecord, PendingScoreRecord, RoundersBattingEntryRecord,
+    RoundersBowlingEntryRecord, RoundersDeliveryRecord, RoundersFallOfOutRecord,
+    RoundersFormatRecord, RoundersInningsEndEventRecord, RoundersInningsEndReasonRecord,
+    RoundersInningsStartEventRecord, RoundersLiveEventRecord, RoundersNextBallContextRecord,
+    RoundersOutKindRecord, RoundersOutRecord, RoundersPostRecord, RoundersRunnerMovementRecord,
+    RoundersScoreInningsRecord, ScoreConfirmationRecord, ScoreRecord, ScoreResponseRecord,
+    ScoreSubmissionRecord, TeamMemberRecord, TeamRecord, UserRecord, UserSportStatsRecord,
 };
 
 /// Parse an RFC-3339 timestamp string stored by the DAO into a UTC datetime,
@@ -94,6 +107,7 @@ pub fn match_type_from_tag(tag: &str) -> MatchType {
         "table_tennis" => MatchType::TableTennis,
         "football" => MatchType::Football,
         "cricket" => MatchType::Cricket,
+        "rounders" => MatchType::Rounders,
         _ => MatchType::Other,
     }
 }
@@ -107,6 +121,7 @@ pub fn match_type_tag(mt: &MatchType) -> &'static str {
         MatchType::TableTennis => "table_tennis",
         MatchType::Football => "football",
         MatchType::Cricket => "cricket",
+        MatchType::Rounders => "rounders",
         MatchType::Other => "other",
     }
 }
@@ -243,6 +258,26 @@ pub fn score_from_record(rec: &ScoreRecord) -> Score {
                     .collect()
             }),
             penalty_shootout_score: penalty_shootout_score.clone(),
+            // Not stored — `Api::hydrate_score_players` fills this afterward.
+            players: std::collections::HashMap::new(),
+        }),
+        ScoreRecord::Rounders {
+            innings,
+            recent_deliveries,
+            next_ball_context,
+            awaiting_next_innings,
+        } => Score::Rounders(RoundersScore {
+            innings: innings
+                .iter()
+                .map(rounders_score_innings_from_record)
+                .collect(),
+            recent_deliveries: recent_deliveries
+                .as_ref()
+                .map(|ds| ds.iter().map(rounders_delivery_from_record).collect()),
+            next_ball_context: next_ball_context
+                .as_ref()
+                .map(rounders_next_ball_context_from_record),
+            awaiting_next_innings: *awaiting_next_innings,
             // Not stored — `Api::hydrate_score_players` fills this afterward.
             players: std::collections::HashMap::new(),
         }),
@@ -413,6 +448,238 @@ fn cricket_score_innings_from_record(rec: &CricketScoreInningsRecord) -> Cricket
     }
 }
 
+// ---- Rounders score -----------------------------------------------------
+
+fn rounders_out_kind_to_record(kind: &RoundersOutKind) -> RoundersOutKindRecord {
+    match kind {
+        RoundersOutKind::Caught => RoundersOutKindRecord::Caught,
+        RoundersOutKind::StumpedAtPost => RoundersOutKindRecord::StumpedAtPost,
+        RoundersOutKind::OvertookRunner => RoundersOutKindRecord::OvertookRunner,
+        RoundersOutKind::Obstruction => RoundersOutKindRecord::Obstruction,
+        RoundersOutKind::FailedToRun => RoundersOutKindRecord::FailedToRun,
+    }
+}
+
+fn rounders_out_kind_from_record(rec: &RoundersOutKindRecord) -> RoundersOutKind {
+    match rec {
+        RoundersOutKindRecord::Caught => RoundersOutKind::Caught,
+        RoundersOutKindRecord::StumpedAtPost => RoundersOutKind::StumpedAtPost,
+        RoundersOutKindRecord::OvertookRunner => RoundersOutKind::OvertookRunner,
+        RoundersOutKindRecord::Obstruction => RoundersOutKind::Obstruction,
+        RoundersOutKindRecord::FailedToRun => RoundersOutKind::FailedToRun,
+    }
+}
+
+fn rounders_out_to_record(out: &RoundersOut) -> RoundersOutRecord {
+    RoundersOutRecord {
+        kind: rounders_out_kind_to_record(&out.kind),
+        fielder_player_id: out.fielder_player_id.clone(),
+    }
+}
+
+fn rounders_out_from_record(rec: &RoundersOutRecord) -> RoundersOut {
+    RoundersOut {
+        kind: rounders_out_kind_from_record(&rec.kind),
+        fielder_player_id: rec.fielder_player_id.clone(),
+    }
+}
+
+fn rounders_post_to_record(post: &RoundersPost) -> RoundersPostRecord {
+    match post {
+        RoundersPost::First => RoundersPostRecord::First,
+        RoundersPost::Second => RoundersPostRecord::Second,
+        RoundersPost::Third => RoundersPostRecord::Third,
+        RoundersPost::Fourth => RoundersPostRecord::Fourth,
+    }
+}
+
+fn rounders_post_from_record(rec: &RoundersPostRecord) -> RoundersPost {
+    match rec {
+        RoundersPostRecord::First => RoundersPost::First,
+        RoundersPostRecord::Second => RoundersPost::Second,
+        RoundersPostRecord::Third => RoundersPost::Third,
+        RoundersPostRecord::Fourth => RoundersPost::Fourth,
+    }
+}
+
+fn rounders_runner_movement_to_record(m: &RoundersRunnerMovement) -> RoundersRunnerMovementRecord {
+    RoundersRunnerMovementRecord {
+        player_id: m.player_id.clone(),
+        post_reached: m.post_reached.as_ref().map(rounders_post_to_record),
+        out: m.out.as_ref().map(rounders_out_to_record),
+    }
+}
+
+fn rounders_runner_movement_from_record(
+    rec: &RoundersRunnerMovementRecord,
+) -> RoundersRunnerMovement {
+    RoundersRunnerMovement {
+        player_id: rec.player_id.clone(),
+        post_reached: rec.post_reached.as_ref().map(rounders_post_from_record),
+        out: rec.out.as_ref().map(rounders_out_from_record),
+    }
+}
+
+fn rounders_delivery_to_record(d: &RoundersDelivery) -> RoundersDeliveryRecord {
+    RoundersDeliveryRecord {
+        bowler_player_id: d.bowler_player_id.clone(),
+        striker_player_id: d.striker_player_id.clone(),
+        no_ball: d.no_ball,
+        byes: d.byes,
+        movements: d
+            .movements
+            .iter()
+            .map(rounders_runner_movement_to_record)
+            .collect(),
+    }
+}
+
+fn rounders_delivery_from_record(rec: &RoundersDeliveryRecord) -> RoundersDelivery {
+    RoundersDelivery {
+        bowler_player_id: rec.bowler_player_id.clone(),
+        striker_player_id: rec.striker_player_id.clone(),
+        no_ball: rec.no_ball,
+        byes: rec.byes,
+        movements: rec
+            .movements
+            .iter()
+            .map(rounders_runner_movement_from_record)
+            .collect(),
+    }
+}
+
+fn rounders_next_ball_context_to_record(
+    ctx: &RoundersNextBallContext,
+) -> RoundersNextBallContextRecord {
+    RoundersNextBallContextRecord {
+        runners_on_base: ctx
+            .runners_on_base
+            .iter()
+            .map(|(id, post)| (id.clone(), rounders_post_to_record(post)))
+            .collect(),
+        bowler_player_id: ctx.bowler_player_id.clone(),
+        balls_in_spell: ctx.balls_in_spell,
+    }
+}
+
+fn rounders_next_ball_context_from_record(
+    rec: &RoundersNextBallContextRecord,
+) -> RoundersNextBallContext {
+    RoundersNextBallContext {
+        runners_on_base: rec
+            .runners_on_base
+            .iter()
+            .map(|(id, post)| (id.clone(), rounders_post_from_record(post)))
+            .collect(),
+        bowler_player_id: rec.bowler_player_id.clone(),
+        balls_in_spell: rec.balls_in_spell,
+    }
+}
+
+fn rounders_batting_entry_to_record(b: &RoundersBattingEntry) -> RoundersBattingEntryRecord {
+    RoundersBattingEntryRecord {
+        player_id: b.player_id.clone(),
+        half_rounders: b.half_rounders,
+        balls_faced: b.balls_faced,
+        out: b.out.as_ref().map(rounders_out_to_record),
+        batting_position: b.batting_position,
+    }
+}
+
+fn rounders_batting_entry_from_record(rec: &RoundersBattingEntryRecord) -> RoundersBattingEntry {
+    RoundersBattingEntry {
+        player_id: rec.player_id.clone(),
+        half_rounders: rec.half_rounders,
+        balls_faced: rec.balls_faced,
+        out: rec.out.as_ref().map(rounders_out_from_record),
+        batting_position: rec.batting_position,
+    }
+}
+
+fn rounders_bowling_entry_to_record(b: &RoundersBowlingEntry) -> RoundersBowlingEntryRecord {
+    RoundersBowlingEntryRecord {
+        player_id: b.player_id.clone(),
+        balls_bowled: b.balls_bowled,
+        no_balls: b.no_balls,
+        outs: b.outs,
+        half_rounders_conceded: b.half_rounders_conceded,
+    }
+}
+
+fn rounders_bowling_entry_from_record(rec: &RoundersBowlingEntryRecord) -> RoundersBowlingEntry {
+    RoundersBowlingEntry {
+        player_id: rec.player_id.clone(),
+        balls_bowled: rec.balls_bowled,
+        no_balls: rec.no_balls,
+        outs: rec.outs,
+        half_rounders_conceded: rec.half_rounders_conceded,
+    }
+}
+
+fn rounders_fall_of_out_to_record(f: &RoundersFallOfOut) -> RoundersFallOfOutRecord {
+    RoundersFallOfOutRecord {
+        out_number: f.out_number,
+        half_rounders: f.half_rounders,
+        player_id: f.player_id.clone(),
+        kind: rounders_out_kind_to_record(&f.kind),
+    }
+}
+
+fn rounders_fall_of_out_from_record(rec: &RoundersFallOfOutRecord) -> RoundersFallOfOut {
+    RoundersFallOfOut {
+        out_number: rec.out_number,
+        half_rounders: rec.half_rounders,
+        player_id: rec.player_id.clone(),
+        kind: rounders_out_kind_from_record(&rec.kind),
+    }
+}
+
+fn rounders_score_innings_to_record(i: &RoundersScoreInnings) -> RoundersScoreInningsRecord {
+    RoundersScoreInningsRecord {
+        batting_side_id: i.batting_side_id.clone(),
+        fielding_side_id: i.fielding_side_id.clone(),
+        half_rounders: i.half_rounders,
+        outs: i.outs,
+        good_balls_bowled: i.good_balls_bowled,
+        byes: i.byes,
+        batting: i
+            .batting
+            .as_ref()
+            .map(|bs| bs.iter().map(rounders_batting_entry_to_record).collect()),
+        bowling: i
+            .bowling
+            .as_ref()
+            .map(|bs| bs.iter().map(rounders_bowling_entry_to_record).collect()),
+        fall_of_outs: i
+            .fall_of_outs
+            .as_ref()
+            .map(|fs| fs.iter().map(rounders_fall_of_out_to_record).collect()),
+    }
+}
+
+fn rounders_score_innings_from_record(rec: &RoundersScoreInningsRecord) -> RoundersScoreInnings {
+    RoundersScoreInnings {
+        batting_side_id: rec.batting_side_id.clone(),
+        fielding_side_id: rec.fielding_side_id.clone(),
+        half_rounders: rec.half_rounders,
+        outs: rec.outs,
+        good_balls_bowled: rec.good_balls_bowled,
+        byes: rec.byes,
+        batting: rec
+            .batting
+            .as_ref()
+            .map(|bs| bs.iter().map(rounders_batting_entry_from_record).collect()),
+        bowling: rec
+            .bowling
+            .as_ref()
+            .map(|bs| bs.iter().map(rounders_bowling_entry_from_record).collect()),
+        fall_of_outs: rec
+            .fall_of_outs
+            .as_ref()
+            .map(|fs| fs.iter().map(rounders_fall_of_out_from_record).collect()),
+    }
+}
+
 pub fn score_to_record(score: &Score) -> ScoreRecord {
     match score {
         Score::Simple(s) => ScoreRecord::Simple {
@@ -472,6 +739,22 @@ pub fn score_to_record(score: &Score) -> ScoreRecord {
                     .collect()
             }),
             penalty_shootout_score: s.penalty_shootout_score.clone(),
+        },
+        Score::Rounders(s) => ScoreRecord::Rounders {
+            innings: s
+                .innings
+                .iter()
+                .map(rounders_score_innings_to_record)
+                .collect(),
+            recent_deliveries: s
+                .recent_deliveries
+                .as_ref()
+                .map(|ds| ds.iter().map(rounders_delivery_to_record).collect()),
+            next_ball_context: s
+                .next_ball_context
+                .as_ref()
+                .map(rounders_next_ball_context_to_record),
+            awaiting_next_innings: s.awaiting_next_innings,
         },
     }
 }
@@ -1026,6 +1309,7 @@ pub fn match_score_to_record(score: &Score, last_seq: Option<u32>) -> MatchScore
     let sport = match score {
         Score::Football(_) => "football",
         Score::Cricket(_) => "cricket",
+        Score::Rounders(_) => "rounders",
         Score::Simple(_) => "simple",
         Score::Sets(_) => "sets",
     }
@@ -1068,6 +1352,15 @@ pub fn match_format_to_record(fmt: &MatchFormat) -> MatchFormatRecord {
             no_ball_is_extra_ball: f.no_ball_is_extra_ball,
             free_hit_after_no_ball: f.free_hit_after_no_ball,
         }),
+        MatchFormat::Rounders(f) => MatchFormatRecord::Rounders(RoundersFormatRecord {
+            innings_per_side: f.innings_per_side,
+            good_balls_per_innings: f.good_balls_per_innings,
+            innings_length_minutes: f.innings_length_minutes,
+            last_batter_bonus_balls: f.last_batter_bonus_balls,
+            balls_per_bowling_spell: f.balls_per_bowling_spell,
+            half_rounders_count: f.half_rounders_count,
+            no_ball_penalty_threshold: f.no_ball_penalty_threshold,
+        }),
     }
 }
 
@@ -1092,6 +1385,15 @@ pub fn match_format_from_record(rec: &MatchFormatRecord) -> MatchFormat {
             no_ball_is_extra_ball: f.no_ball_is_extra_ball,
             free_hit_after_no_ball: f.free_hit_after_no_ball,
         }),
+        MatchFormatRecord::Rounders(f) => MatchFormat::Rounders(RoundersFormat {
+            innings_per_side: f.innings_per_side,
+            good_balls_per_innings: f.good_balls_per_innings,
+            innings_length_minutes: f.innings_length_minutes,
+            last_batter_bonus_balls: f.last_batter_bonus_balls,
+            balls_per_bowling_spell: f.balls_per_bowling_spell,
+            half_rounders_count: f.half_rounders_count,
+            no_ball_penalty_threshold: f.no_ball_penalty_threshold,
+        }),
     }
 }
 
@@ -1102,6 +1404,7 @@ pub fn match_format_sport_tag(fmt: &MatchFormat) -> &'static str {
     match fmt {
         MatchFormat::Football(_) => "football",
         MatchFormat::Cricket(_) => "cricket",
+        MatchFormat::Rounders(_) => "rounders",
     }
 }
 
@@ -1120,6 +1423,7 @@ pub fn live_event_sport_tag(event: &LiveEventInput) -> &'static str {
     match event {
         LiveEventInput::Football(_) => "football",
         LiveEventInput::Cricket(_) => "cricket",
+        LiveEventInput::Rounders(_) => "rounders",
     }
 }
 
@@ -1131,6 +1435,9 @@ pub fn live_event_input_to_record(event: &LiveEventInput) -> LiveEventPayloadRec
         LiveEventInput::Cricket(c) => {
             LiveEventPayloadRecord::Cricket(cricket_live_event_to_record(c))
         }
+        LiveEventInput::Rounders(r) => {
+            LiveEventPayloadRecord::Rounders(rounders_live_event_to_record(r))
+        }
     }
 }
 
@@ -1141,6 +1448,9 @@ pub fn live_event_payload_from_record(rec: &LiveEventPayloadRecord) -> LiveEvent
         }
         LiveEventPayloadRecord::Cricket(c) => {
             LiveEventInput::Cricket(cricket_live_event_from_record(c))
+        }
+        LiveEventPayloadRecord::Rounders(r) => {
+            LiveEventInput::Rounders(rounders_live_event_from_record(r))
         }
     }
 }
@@ -1497,6 +1807,70 @@ fn cricket_dismissal_kind_from_record(rec: &CricketDismissalKindRecord) -> Crick
     }
 }
 
+// ---- Rounders live events -------------------------------------------------
+
+fn rounders_live_event_to_record(event: &RoundersLiveEvent) -> RoundersLiveEventRecord {
+    match event {
+        RoundersLiveEvent::Delivery(d) => {
+            RoundersLiveEventRecord::Delivery(rounders_delivery_to_record(d))
+        }
+        RoundersLiveEvent::InningsStart(s) => {
+            RoundersLiveEventRecord::InningsStart(RoundersInningsStartEventRecord {
+                batting_side_id: s.batting_side_id.clone(),
+                fielding_side_id: s.fielding_side_id.clone(),
+            })
+        }
+        RoundersLiveEvent::InningsEnd(e) => {
+            RoundersLiveEventRecord::InningsEnd(RoundersInningsEndEventRecord {
+                reason: rounders_innings_end_reason_to_record(&e.reason),
+            })
+        }
+    }
+}
+
+pub fn rounders_live_event_from_record(rec: &RoundersLiveEventRecord) -> RoundersLiveEvent {
+    match rec {
+        RoundersLiveEventRecord::Delivery(d) => {
+            RoundersLiveEvent::Delivery(rounders_delivery_from_record(d))
+        }
+        RoundersLiveEventRecord::InningsStart(s) => {
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: s.batting_side_id.clone(),
+                fielding_side_id: s.fielding_side_id.clone(),
+            })
+        }
+        RoundersLiveEventRecord::InningsEnd(e) => {
+            RoundersLiveEvent::InningsEnd(RoundersInningsEndEvent {
+                reason: rounders_innings_end_reason_from_record(&e.reason),
+            })
+        }
+    }
+}
+
+fn rounders_innings_end_reason_to_record(
+    reason: &RoundersInningsEndReason,
+) -> RoundersInningsEndReasonRecord {
+    match reason {
+        RoundersInningsEndReason::AllBattersOut => RoundersInningsEndReasonRecord::AllBattersOut,
+        RoundersInningsEndReason::GoodBallsComplete => {
+            RoundersInningsEndReasonRecord::GoodBallsComplete
+        }
+        RoundersInningsEndReason::TimeUp => RoundersInningsEndReasonRecord::TimeUp,
+    }
+}
+
+fn rounders_innings_end_reason_from_record(
+    rec: &RoundersInningsEndReasonRecord,
+) -> RoundersInningsEndReason {
+    match rec {
+        RoundersInningsEndReasonRecord::AllBattersOut => RoundersInningsEndReason::AllBattersOut,
+        RoundersInningsEndReasonRecord::GoodBallsComplete => {
+            RoundersInningsEndReason::GoodBallsComplete
+        }
+        RoundersInningsEndReasonRecord::TimeUp => RoundersInningsEndReason::TimeUp,
+    }
+}
+
 // ---- Batch append / read / derive ---------------------------------------
 
 /// Build the DAO-layer append input from one API-level new-event input.
@@ -1550,7 +1924,9 @@ pub fn derive_live_score(
                     LiveEventPayloadRecord::Football(f) => {
                         Some((parse_ts(&r.occurred_at), football_live_event_from_record(f)))
                     }
-                    LiveEventPayloadRecord::Cricket(_) => None,
+                    LiveEventPayloadRecord::Cricket(_) | LiveEventPayloadRecord::Rounders(_) => {
+                        None
+                    }
                 })
                 .collect();
             Some(Score::Football(FootballScore::from_events(&events)))
@@ -1560,7 +1936,9 @@ pub fn derive_live_score(
                 .iter()
                 .filter_map(|r| match &r.payload {
                     LiveEventPayloadRecord::Cricket(c) => Some(cricket_live_event_from_record(c)),
-                    LiveEventPayloadRecord::Football(_) => None,
+                    LiveEventPayloadRecord::Football(_) | LiveEventPayloadRecord::Rounders(_) => {
+                        None
+                    }
                 })
                 .collect();
             let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
@@ -1571,6 +1949,18 @@ pub fn derive_live_score(
                 wide_is_extra_ball,
                 no_ball_is_extra_ball,
             )))
+        }
+        "rounders" => {
+            let events: Vec<RoundersLiveEvent> = records
+                .iter()
+                .filter_map(|r| match &r.payload {
+                    LiveEventPayloadRecord::Rounders(r) => Some(rounders_live_event_from_record(r)),
+                    LiveEventPayloadRecord::Football(_) | LiveEventPayloadRecord::Cricket(_) => {
+                        None
+                    }
+                })
+                .collect();
+            Some(Score::Rounders(RoundersScore::from_events(&events)))
         }
         _ => None,
     }
@@ -1818,6 +2208,52 @@ mod tests {
     }
 
     #[test]
+    fn rounders_live_event_round_trips_through_dao_mirror() {
+        let events = vec![
+            RoundersLiveEvent::Delivery(RoundersDelivery {
+                bowler_player_id: "patel".into(),
+                striker_player_id: "sharma".into(),
+                no_ball: false,
+                byes: false,
+                movements: vec![
+                    RoundersRunnerMovement {
+                        player_id: "sharma".into(),
+                        post_reached: Some(RoundersPost::Second),
+                        out: None,
+                    },
+                    RoundersRunnerMovement {
+                        player_id: "verma".into(),
+                        post_reached: Some(RoundersPost::Fourth),
+                        out: None,
+                    },
+                    RoundersRunnerMovement {
+                        player_id: "khan".into(),
+                        post_reached: None,
+                        out: Some(RoundersOut {
+                            kind: RoundersOutKind::Caught,
+                            fielder_player_id: Some("cole".into()),
+                        }),
+                    },
+                ],
+            }),
+            RoundersLiveEvent::InningsStart(RoundersInningsStartEvent {
+                batting_side_id: "warriors".into(),
+                fielding_side_id: "mill_lane".into(),
+            }),
+            RoundersLiveEvent::InningsEnd(RoundersInningsEndEvent {
+                reason: RoundersInningsEndReason::GoodBallsComplete,
+            }),
+        ];
+
+        for event in events {
+            let input = LiveEventInput::Rounders(event);
+            let original_json = input.to_json();
+            let round_tripped = live_event_payload_from_record(&live_event_input_to_record(&input));
+            assert_eq!(original_json, round_tripped.to_json());
+        }
+    }
+
+    #[test]
     fn match_format_round_trips_through_dao_mirror() {
         let formats = vec![
             MatchFormat::Football(FootballFormat {
@@ -1836,6 +2272,15 @@ mod tests {
                 wide_is_extra_ball: true,
                 no_ball_is_extra_ball: false,
                 free_hit_after_no_ball: false,
+            }),
+            MatchFormat::Rounders(RoundersFormat {
+                innings_per_side: 2,
+                good_balls_per_innings: Some(30),
+                innings_length_minutes: None,
+                last_batter_bonus_balls: Some(3),
+                balls_per_bowling_spell: Some(8),
+                half_rounders_count: true,
+                no_ball_penalty_threshold: Some(2),
             }),
         ];
 
@@ -2025,6 +2470,99 @@ mod tests {
                     scored: true,
                 }]),
                 penalty_shootout_score: Some(HashMap::from([("side_red".to_string(), 1)])),
+                players: HashMap::new(),
+            }),
+            // A manually-entered rounders result: totals only, no per-player detail.
+            Score::Rounders(RoundersScore {
+                innings: vec![
+                    RoundersScoreInnings {
+                        batting_side_id: "warriors".into(),
+                        fielding_side_id: "mill_lane".into(),
+                        half_rounders: 9,
+                        outs: 7,
+                        good_balls_bowled: 28,
+                        byes: 1,
+                        batting: None,
+                        bowling: None,
+                        fall_of_outs: None,
+                    },
+                    RoundersScoreInnings {
+                        batting_side_id: "mill_lane".into(),
+                        fielding_side_id: "warriors".into(),
+                        half_rounders: 6,
+                        outs: 9,
+                        good_balls_bowled: 24,
+                        byes: 0,
+                        batting: None,
+                        bowling: None,
+                        fall_of_outs: None,
+                    },
+                ],
+                recent_deliveries: None,
+                next_ball_context: None,
+                awaiting_next_innings: None,
+                players: HashMap::new(),
+            }),
+            // A live-scored rounders result: full per-player detail, a runner
+            // still out on the track, and one batter already out.
+            Score::Rounders(RoundersScore {
+                innings: vec![RoundersScoreInnings {
+                    batting_side_id: "warriors".into(),
+                    fielding_side_id: "mill_lane".into(),
+                    half_rounders: 3,
+                    outs: 1,
+                    good_balls_bowled: 5,
+                    byes: 1,
+                    batting: Some(vec![
+                        RoundersBattingEntry {
+                            player_id: "player_1".into(),
+                            half_rounders: 2,
+                            balls_faced: 1,
+                            out: None,
+                            batting_position: Some(1),
+                        },
+                        RoundersBattingEntry {
+                            player_id: "player_2".into(),
+                            half_rounders: 0,
+                            balls_faced: 1,
+                            out: Some(RoundersOut {
+                                kind: RoundersOutKind::StumpedAtPost,
+                                fielder_player_id: Some("player_6".into()),
+                            }),
+                            batting_position: Some(2),
+                        },
+                    ]),
+                    bowling: Some(vec![RoundersBowlingEntry {
+                        player_id: "player_5".into(),
+                        balls_bowled: 4,
+                        no_balls: 1,
+                        outs: 1,
+                        half_rounders_conceded: 2,
+                    }]),
+                    fall_of_outs: Some(vec![RoundersFallOfOut {
+                        out_number: 1,
+                        half_rounders: 2,
+                        player_id: "player_2".into(),
+                        kind: RoundersOutKind::StumpedAtPost,
+                    }]),
+                }],
+                recent_deliveries: Some(vec![RoundersDelivery {
+                    bowler_player_id: "player_5".into(),
+                    striker_player_id: "player_3".into(),
+                    no_ball: false,
+                    byes: true,
+                    movements: vec![RoundersRunnerMovement {
+                        player_id: "player_1".into(),
+                        post_reached: Some(RoundersPost::First),
+                        out: None,
+                    }],
+                }]),
+                next_ball_context: Some(RoundersNextBallContext {
+                    runners_on_base: HashMap::from([("player_1".to_string(), RoundersPost::First)]),
+                    bowler_player_id: Some("player_5".into()),
+                    balls_in_spell: 5,
+                }),
+                awaiting_next_innings: Some(false),
                 players: HashMap::new(),
             }),
         ];

--- a/agon_service/src/match_format.rs
+++ b/agon_service/src/match_format.rs
@@ -23,6 +23,7 @@ use poem_openapi::{Object, Union};
 pub enum MatchFormat {
     Football(FootballFormat),
     Cricket(CricketFormat),
+    Rounders(RoundersFormat),
 }
 
 #[derive(Object, Clone)]
@@ -69,4 +70,37 @@ pub struct CricketFormat {
     pub no_ball_is_extra_ball: bool,
     /// Whether the delivery after a no-ball is a free hit.
     pub free_hit_after_no_ball: bool,
+}
+
+#[derive(Object, Clone)]
+pub struct RoundersFormat {
+    /// Innings per side — almost always 2.
+    pub innings_per_side: u32,
+    /// The "Good balls" cap per innings (30 on the standard Rounders
+    /// England scoresheet; other leagues play 18 or 20). Fair deliveries
+    /// only — a no-ball doesn't count against it, mirroring
+    /// `RoundersDelivery::no_ball` being excluded from
+    /// `RoundersScoreInnings::good_balls_bowled`. `None` = uncapped
+    /// (time-limited instead — see `innings_length_minutes`).
+    pub good_balls_per_innings: Option<u32>,
+    /// Minutes per innings, if time-limited instead of/alongside a
+    /// good-ball cap.
+    pub innings_length_minutes: Option<u32>,
+    /// Extra balls the last remaining batter gets once nobody's left behind
+    /// them in the order (commonly 3, vs. one ball for everyone else).
+    /// `None` = no bonus, they get one like everyone else.
+    pub last_batter_bonus_balls: Option<u32>,
+    /// Balls a single bowler may bowl before a mandatory change.
+    pub balls_per_bowling_spell: Option<u32>,
+    /// Whether completing the circuit over multiple stops counts as a half
+    /// rounder (the standard rule) as opposed to only single-hit circuits
+    /// scoring at all.
+    pub half_rounders_count: bool,
+    /// Consecutive no-balls to the same batter that award a penalty
+    /// (typically half a rounder plus a free run) — leagues vary on both
+    /// the threshold and the reward, so this is descriptive only for now,
+    /// same as `CricketFormat::free_hit_after_no_ball`: not automatically
+    /// applied by the live-scoring fold, just recorded as configuration.
+    /// `None` = this league doesn't play a no-ball penalty.
+    pub no_ball_penalty_threshold: Option<u32>,
 }

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -15,7 +15,9 @@ import { MatchHeaderCarousel } from './MatchHeaderCarousel'
 import { InvitationResponseDialog } from './InvitationResponseDialog'
 import { LiveMatchBlock } from './live/LiveMatchBlock'
 import { CricketMatchBlock } from './live/CricketMatchBlock'
+import { RoundersMatchBlock } from './live/RoundersMatchBlock'
 import { CricketScoreBlock } from './CricketScoreBlock'
+import { RoundersScoreBlock } from './RoundersScoreBlock'
 import { KnownPlayersRow } from './KnownPlayersRow'
 import { useMatchScore } from '@/hooks/useMatchScore'
 import { describeEvent, eventEmoji, footballScoreFrom, recentGoalEvents } from '@/lib/liveScore'
@@ -24,7 +26,12 @@ import {
   cricketScoreFrom,
   cricketStateDescription,
 } from '@/lib/cricketScore'
-import { cricketFormat } from '@/lib/matchFormat'
+import {
+  roundersProgressFromScore,
+  roundersScoreFrom,
+  roundersStateDescription,
+} from '@/lib/roundersScore'
+import { cricketFormat, roundersFormat } from '@/lib/matchFormat'
 import {
   displayScore,
   footballGoalsFromScore,
@@ -209,7 +216,8 @@ export function MatchCard({
   const aWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideA?.id
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
 
-  const isLiveSport = match.match_type === 'football' || match.match_type === 'cricket'
+  const isLiveSport =
+    match.match_type === 'football' || match.match_type === 'cricket' || match.match_type === 'rounders'
   const isCurrentlyLive = isLiveSport && match.status === 'in_progress'
   // Only fetched while live — a finished match doesn't need it. Football's
   // confirmed/pending `Score.Football` already embeds its goals (see
@@ -232,6 +240,7 @@ export function MatchCard({
   // live block/badge for a match that finished after the card last mounted.
   const footballState = isCurrentlyLive ? footballScoreFrom(scoreQuery.data) : null
   const cricketState = isCurrentlyLive ? cricketScoreFrom(scoreQuery.data) : null
+  const roundersState = isCurrentlyLive ? roundersScoreFrom(scoreQuery.data) : null
   // Recent goals for a finished football match, read straight off the
   // confirmed/pending score (no fetch) — shown under the plain score box
   // below (the live ticker in `LiveMatchBlock` only renders while
@@ -266,6 +275,19 @@ export function MatchCard({
       ? cricketStateDescription(match, cricketProgressFromScore(cricketScore), cricketFmt)
       : null
 
+  // Same role as `cricketScore`/`cricketDescription` above, for rounders.
+  const roundersScore = scoreInfo ? roundersScoreFrom(scoreInfo.score) : null
+  const roundersFmt = roundersFormat(match.format)
+  const roundersDescription = roundersState
+    ? roundersStateDescription(
+        match,
+        { innings: roundersState.innings, awaiting_next_innings: roundersState.awaiting_next_innings ?? true },
+        roundersFmt,
+      )
+    : roundersScore
+      ? roundersStateDescription(match, roundersProgressFromScore(roundersScore), roundersFmt)
+      : null
+
   const { like_count, comment_count, i_liked } = match.social
   const toggleLike = useToggleLike(match)
 
@@ -285,14 +307,16 @@ export function MatchCard({
         className="flex w-full items-start justify-between gap-3 p-3.5 text-left"
       >
         <p className="text-sm leading-snug">
-          {cricketDescription ? (
-            <span>{cricketDescription}</span>
+          {cricketDescription || roundersDescription ? (
+            <span>{cricketDescription || roundersDescription}</span>
           ) : (
             <>
               <span className={cn(aWon && 'font-medium')}>{nameA}</span>
               <span className="text-primary">
                 {' '}
-                {match.match_type !== 'cricket' && scoreInfo?.winnerSideId ? 'beat' : 'vs'}{' '}
+                {match.match_type !== 'cricket' && match.match_type !== 'rounders' && scoreInfo?.winnerSideId
+                  ? 'beat'
+                  : 'vs'}{' '}
               </span>
               <span className={cn(bWon && 'font-medium')}>{nameB}</span>
             </>
@@ -330,6 +354,14 @@ export function MatchCard({
       ) : cricketScore ? (
         <div className="mx-3.5 mb-3">
           <CricketScoreBlock match={match} score={cricketScore} showDescription={false} />
+        </div>
+      ) : roundersState ? (
+        <div className="mx-3.5 mb-3">
+          <RoundersMatchBlock match={match} state={roundersState} showDescription={false} />
+        </div>
+      ) : roundersScore ? (
+        <div className="mx-3.5 mb-3">
+          <RoundersScoreBlock match={match} score={roundersScore} showDescription={false} />
         </div>
       ) : (
         scoreInfo && (

--- a/agon_ui/src/components/agon/MatchFormatCard.tsx
+++ b/agon_ui/src/components/agon/MatchFormatCard.tsx
@@ -4,13 +4,16 @@ import { Pencil } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
-import { CricketFields, FootballFields } from './MatchFormatEditor'
+import { CricketFields, FootballFields, RoundersFields } from './MatchFormatEditor'
 import {
   cricketFormat,
   footballFormat,
+  goodBallsLimitLabel,
   oversLimitLabel,
+  roundersFormat,
   type CricketFormat,
   type FootballFormat,
+  type RoundersFormat,
 } from '@/lib/matchFormat'
 
 type Match = components['schemas']['Match']
@@ -38,6 +41,15 @@ function FormatSummary({ match }: { match: Match }) {
         {fmt.num_halves} × {fmt.half_length_minutes}min
         {fmt.extra_time && ' · extra time'}
         {fmt.penalties && ' · penalties'}
+      </p>
+    )
+  }
+  if (match.match_type === 'rounders') {
+    const fmt = roundersFormat(match.format)
+    return (
+      <p className="text-xs text-muted-foreground">
+        {goodBallsLimitLabel(fmt)} · {fmt.innings_per_side === 1 ? 'single' : 'two'} innings
+        {fmt.last_batter_bonus_balls && ` · last batter gets ${fmt.last_batter_bonus_balls} balls`}
       </p>
     )
   }
@@ -71,6 +83,9 @@ export function MatchFormatCard({
   const [cricketDraft, setCricketDraft] = useState<CricketFormat>(() =>
     cricketFormat(match.format),
   )
+  const [roundersDraft, setRoundersDraft] = useState<RoundersFormat>(() =>
+    roundersFormat(match.format),
+  )
 
   const save = useMutation({
     mutationFn: async () => {
@@ -80,7 +95,9 @@ export function MatchFormatCard({
           format:
             match.match_type === 'cricket'
               ? { sport: 'Cricket', ...cricketDraft }
-              : { sport: 'Football', ...footballDraft },
+              : match.match_type === 'rounders'
+                ? { sport: 'Rounders', ...roundersDraft }
+                : { sport: 'Football', ...footballDraft },
         },
       })
       if (error) throw new Error('Failed to save the match format')
@@ -91,7 +108,8 @@ export function MatchFormatCard({
     },
   })
 
-  if (match.match_type !== 'football' && match.match_type !== 'cricket') return null
+  if (match.match_type !== 'football' && match.match_type !== 'cricket' && match.match_type !== 'rounders')
+    return null
 
   if (!editing) {
     return (
@@ -108,6 +126,7 @@ export function MatchFormatCard({
             onClick={() => {
               setFootballDraft(footballFormat(match.format))
               setCricketDraft(cricketFormat(match.format))
+              setRoundersDraft(roundersFormat(match.format))
               setEditing(true)
             }}
           >
@@ -123,6 +142,8 @@ export function MatchFormatCard({
       <p className="mb-3 text-sm font-medium">Format</p>
       {match.match_type === 'cricket' ? (
         <CricketFields value={cricketDraft} onChange={setCricketDraft} />
+      ) : match.match_type === 'rounders' ? (
+        <RoundersFields value={roundersDraft} onChange={setRoundersDraft} />
       ) : (
         <FootballFields value={footballDraft} onChange={setFootballDraft} />
       )}

--- a/agon_ui/src/components/agon/MatchFormatEditor.tsx
+++ b/agon_ui/src/components/agon/MatchFormatEditor.tsx
@@ -6,9 +6,11 @@ import type { MatchType } from '@/lib/sports'
 import {
   DEFAULT_CRICKET_FORMAT,
   DEFAULT_FOOTBALL_FORMAT,
+  DEFAULT_ROUNDERS_FORMAT,
   type CricketFormat,
   type FootballFormat,
   type MatchFormat,
+  type RoundersFormat,
 } from '@/lib/matchFormat'
 
 /**
@@ -185,6 +187,64 @@ export function CricketFields({
   )
 }
 
+export function RoundersFields({
+  value,
+  onChange,
+}: {
+  value: RoundersFormat
+  onChange: (value: RoundersFormat) => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-2">
+        <NumberField
+          label="Innings per side"
+          value={value.innings_per_side}
+          min={1}
+          onChange={(v) => onChange({ ...value, innings_per_side: v ?? 1 })}
+        />
+        <NumberField
+          label="Good balls per innings"
+          value={value.good_balls_per_innings ?? undefined}
+          placeholder="Unlimited"
+          onChange={(v) => onChange({ ...value, good_balls_per_innings: v })}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <NumberField
+          label="Innings length (min)"
+          value={value.innings_length_minutes ?? undefined}
+          placeholder="Untimed"
+          onChange={(v) => onChange({ ...value, innings_length_minutes: v })}
+        />
+        <NumberField
+          label="Last batter's bonus balls"
+          value={value.last_batter_bonus_balls ?? undefined}
+          placeholder="None"
+          onChange={(v) => onChange({ ...value, last_batter_bonus_balls: v })}
+        />
+      </div>
+      <NumberField
+        label="Balls per bowling spell"
+        value={value.balls_per_bowling_spell ?? undefined}
+        placeholder="Unlimited"
+        onChange={(v) => onChange({ ...value, balls_per_bowling_spell: v })}
+      />
+      <ToggleRow
+        label="Reaching home over multiple balls counts as a half rounder"
+        checked={value.half_rounders_count}
+        onChange={(half_rounders_count) => onChange({ ...value, half_rounders_count })}
+      />
+      <NumberField
+        label="No-ball penalty after (consecutive)"
+        value={value.no_ball_penalty_threshold ?? undefined}
+        placeholder="No penalty"
+        onChange={(v) => onChange({ ...value, no_ball_penalty_threshold: v })}
+      />
+    </div>
+  )
+}
+
 /**
  * Sport-specific match format settings (half length, overs limit, penalty
  * runs, ...) — `null` while unset, in which case the app just falls back to
@@ -208,7 +268,7 @@ export function MatchFormatEditor({
   value: MatchFormat | null
   onChange: (value: MatchFormat | null) => void
 }) {
-  if (sport !== 'football' && sport !== 'cricket') return null
+  if (sport !== 'football' && sport !== 'cricket' && sport !== 'rounders') return null
 
   const enabled = value !== null
 
@@ -225,7 +285,9 @@ export function MatchFormatEditor({
           onChange(
             sport === 'cricket'
               ? { sport: 'Cricket', ...DEFAULT_CRICKET_FORMAT }
-              : { sport: 'Football', ...DEFAULT_FOOTBALL_FORMAT },
+              : sport === 'rounders'
+                ? { sport: 'Rounders', ...DEFAULT_ROUNDERS_FORMAT }
+                : { sport: 'Football', ...DEFAULT_FOOTBALL_FORMAT },
           )
         }}
       />
@@ -235,6 +297,11 @@ export function MatchFormatEditor({
             <CricketFields
               value={value}
               onChange={(v) => onChange({ sport: 'Cricket', ...v })}
+            />
+          ) : value.sport === 'Rounders' ? (
+            <RoundersFields
+              value={value}
+              onChange={(v) => onChange({ sport: 'Rounders', ...v })}
             />
           ) : (
             <FootballFields

--- a/agon_ui/src/components/agon/MatchResultEditor.tsx
+++ b/agon_ui/src/components/agon/MatchResultEditor.tsx
@@ -7,8 +7,10 @@ import { Input } from '@/components/ui/input'
 import { isSetsSport } from '@/lib/sports'
 import { FootballScoreFields } from '@/components/agon/FootballScoreFields'
 import { CricketScoreFields } from '@/components/agon/CricketScoreFields'
+import { RoundersScoreFields } from '@/components/agon/RoundersScoreFields'
 import { displayScore, headlineBySide } from '@/lib/score'
 import { cricketProgressFromScore, matchTotalsBySide } from '@/lib/cricketScore'
+import { roundersMatchTotalsBySide, roundersProgressFromScore } from '@/lib/roundersScore'
 
 type Match = components['schemas']['Match']
 type UpdateMatchInput = components['schemas']['UpdateMatchInput']
@@ -20,7 +22,11 @@ type Score = components['schemas']['Score']
  *  so it sums each side's runs across every innings played so far instead. */
 function scoreSummary(score: Score, aId: string, bId: string): string {
   const totals =
-    score.type === 'Cricket' ? matchTotalsBySide(cricketProgressFromScore(score)) : headlineBySide(score)
+    score.type === 'Cricket'
+      ? matchTotalsBySide(cricketProgressFromScore(score))
+      : score.type === 'Rounders'
+        ? roundersMatchTotalsBySide(roundersProgressFromScore(score))
+        : headlineBySide(score)
   return `${totals[aId] ?? 0}–${totals[bId] ?? 0}`
 }
 
@@ -104,6 +110,7 @@ export function MatchResultEditor({
 
   const isFootball = match.match_type === 'football'
   const isCricket = match.match_type === 'cricket'
+  const isRounders = match.match_type === 'rounders'
   const setsMode = isSetsSport(match.match_type)
   // The result to prepopulate the form with: confirmed if there is one, else
   // a still-pending submission awaiting the other side's confirmation.
@@ -115,7 +122,7 @@ export function MatchResultEditor({
 
   /** Build the score payload + derived winner, or null when incomplete. */
   const build = (): { score: Score; winner?: string } | null => {
-    if (isFootball || isCricket) {
+    if (isFootball || isCricket || isRounders) {
       return detailBuilt ? { score: detailBuilt.score, winner: detailBuilt.winnerSideId } : null
     }
 
@@ -223,6 +230,14 @@ export function MatchResultEditor({
         />
       ) : isCricket && sideA && sideB ? (
         <CricketScoreFields
+          sideA={sideA}
+          sideB={sideB}
+          players={match.players}
+          initial={currentScore}
+          onChange={setDetailBuilt}
+        />
+      ) : isRounders && sideA && sideB ? (
+        <RoundersScoreFields
           sideA={sideA}
           sideB={sideB}
           players={match.players}

--- a/agon_ui/src/components/agon/RoundersScoreBlock.tsx
+++ b/agon_ui/src/components/agon/RoundersScoreBlock.tsx
@@ -1,0 +1,59 @@
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import {
+  formatHalfRounders,
+  roundersProgressFromScore,
+  roundersStateDescription,
+  sideNameFor,
+  type RoundersScore,
+} from '@/lib/roundersScore'
+import { roundersFormat } from '@/lib/matchFormat'
+
+type Match = components['schemas']['Match']
+type FeedMatch = components['schemas']['FeedMatch']
+type SearchMatch = components['schemas']['SearchMatch']
+
+/**
+ * The rounders score tile for a match that's been fully scored and
+ * confirmed — sourced entirely from the confirmed score's per-innings
+ * totals, no live event log fetch involved. Mirrors `CricketScoreBlock`.
+ */
+export function RoundersScoreBlock({
+  match,
+  score,
+  showDescription = true,
+}: {
+  match: Match | FeedMatch | SearchMatch
+  score: RoundersScore
+  /** Whether to show the result line here. Callers that already surface it
+   *  elsewhere (the feed card's header) pass `false` so it isn't said twice. */
+  showDescription?: boolean
+}) {
+  const format = roundersFormat(match.format)
+  const description = roundersStateDescription(match, roundersProgressFromScore(score), format)
+
+  return (
+    <div className="rounded-lg bg-muted/50 px-3.5 py-3">
+      <p
+        className={cn(
+          'text-sm font-medium',
+          showDescription && description ? 'text-primary' : 'text-muted-foreground',
+        )}
+      >
+        {showDescription ? description || 'Result' : 'Result'}
+      </p>
+      {score.innings.length > 0 && (
+        <div className="mt-1 space-y-0.5">
+          {score.innings.map((inn, i) => (
+            <p key={i} className="text-lg font-medium leading-tight tracking-tight">
+              {sideNameFor(match, inn.batting_side_id)} {formatHalfRounders(inn.half_rounders)}
+              <span className="ml-1.5 text-sm font-normal text-muted-foreground">
+                ({inn.outs} out)
+              </span>
+            </p>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/RoundersScoreFields.tsx
+++ b/agon_ui/src/components/agon/RoundersScoreFields.tsx
@@ -1,0 +1,458 @@
+import { useEffect, useState } from 'react'
+import { Plus } from 'lucide-react'
+import type { components } from '@/types/api'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { SidePicker, PlayerPicker } from '@/components/agon/live/Pickers'
+import { playersOnSide } from '@/lib/members'
+import { outKindLabel, type RoundersOutKind } from '@/lib/roundersScore'
+
+type MatchSide = components['schemas']['MatchSide']
+type MatchPlayer = components['schemas']['MatchPlayer']
+type Score = components['schemas']['Score']
+type RoundersScoreInnings = components['schemas']['RoundersScoreInnings']
+type RoundersBattingEntry = components['schemas']['RoundersBattingEntry']
+type RoundersBowlingEntry = components['schemas']['RoundersBowlingEntry']
+
+const OUT_KINDS: RoundersOutKind[] = [
+  'caught',
+  'stumped_at_post',
+  'overtook_runner',
+  'obstruction',
+  'failed_to_run',
+]
+
+interface BattingRowDraft {
+  playerId: string
+  halfRounders: string
+  balls: string
+  out: boolean
+  outKind: RoundersOutKind
+  fielderId: string
+}
+
+interface BowlingRowDraft {
+  playerId: string
+  ballsBowled: string
+  noBalls: string
+  outs: string
+  halfRoundersConceded: string
+}
+
+interface InningsDraft {
+  battingSideId: string
+  fieldingSideId: string
+  halfRounders: string
+  outs: string
+  goodBalls: string
+  byes: string
+  detailOpen: boolean
+  batting: BattingRowDraft[]
+  bowling: BowlingRowDraft[]
+}
+
+function newInnings(battingSideId: string, fieldingSideId: string): InningsDraft {
+  return {
+    battingSideId,
+    fieldingSideId,
+    halfRounders: '',
+    outs: '',
+    goodBalls: '',
+    byes: '',
+    detailOpen: false,
+    batting: [],
+    bowling: [],
+  }
+}
+
+function seedInnings(initial: Score | undefined, aId: string, bId: string): InningsDraft[] {
+  if (initial?.type !== 'Rounders' || initial.innings.length === 0) {
+    return [newInnings(aId, bId)]
+  }
+  return initial.innings.map((inn) => ({
+    battingSideId: inn.batting_side_id,
+    fieldingSideId: inn.fielding_side_id,
+    halfRounders: String(inn.half_rounders),
+    outs: String(inn.outs),
+    goodBalls: String(inn.good_balls_bowled),
+    byes: String(inn.byes),
+    detailOpen: !!inn.batting?.length || !!inn.bowling?.length,
+    batting: (inn.batting ?? []).map((b) => ({
+      playerId: b.player_id,
+      halfRounders: String(b.half_rounders),
+      balls: String(b.balls_faced),
+      out: !!b.out,
+      outKind: b.out?.kind ?? 'caught',
+      fielderId: b.out?.fielder_player_id ?? '',
+    })),
+    bowling: (inn.bowling ?? []).map((b) => ({
+      playerId: b.player_id,
+      ballsBowled: String(b.balls_bowled),
+      noBalls: String(b.no_balls),
+      outs: String(b.outs),
+      halfRoundersConceded: String(b.half_rounders_conceded),
+    })),
+  }))
+}
+
+function num(v: string): number {
+  const n = Number(v)
+  return v !== '' && Number.isFinite(n) && n >= 0 ? n : 0
+}
+
+function buildInnings(draft: InningsDraft): RoundersScoreInnings | null {
+  if (draft.halfRounders === '' && draft.outs === '' && draft.goodBalls === '') return null
+  const batting: RoundersBattingEntry[] | undefined =
+    draft.detailOpen && draft.batting.length > 0
+      ? draft.batting
+          .filter((b) => b.playerId)
+          .map((b) => ({
+            player_id: b.playerId,
+            half_rounders: num(b.halfRounders),
+            balls_faced: num(b.balls),
+            out: b.out
+              ? { kind: b.outKind, fielder_player_id: b.fielderId || undefined }
+              : undefined,
+          }))
+      : undefined
+  const bowling: RoundersBowlingEntry[] | undefined =
+    draft.detailOpen && draft.bowling.length > 0
+      ? draft.bowling
+          .filter((b) => b.playerId)
+          .map((b) => ({
+            player_id: b.playerId,
+            balls_bowled: num(b.ballsBowled),
+            no_balls: num(b.noBalls),
+            outs: num(b.outs),
+            half_rounders_conceded: num(b.halfRoundersConceded),
+          }))
+      : undefined
+  return {
+    batting_side_id: draft.battingSideId,
+    fielding_side_id: draft.fieldingSideId,
+    half_rounders: num(draft.halfRounders),
+    outs: num(draft.outs),
+    good_balls_bowled: num(draft.goodBalls),
+    byes: num(draft.byes),
+    batting,
+    bowling,
+  }
+}
+
+/**
+ * Rounders' result entry — per-innings totals (half-rounders/outs/good
+ * balls/byes), plus an optional batting/bowling card per innings. Mirrors
+ * `CricketScoreFields`' shape closely (same innings-based sport), with
+ * `fall_of_outs` left uncollected here for the same reason cricket omits
+ * `fall_of_wickets`: ordering outs against a running score is real extra UI
+ * for the lowest-value field.
+ */
+export function RoundersScoreFields({
+  sideA,
+  sideB,
+  players,
+  initial,
+  onChange,
+}: {
+  sideA: MatchSide
+  sideB: MatchSide
+  players: MatchPlayer[]
+  initial?: Score
+  onChange: (built: { score: Score; winnerSideId?: string } | null) => void
+}) {
+  const [innings, setInnings] = useState<InningsDraft[]>(() => seedInnings(initial, sideA.id, sideB.id))
+
+  useEffect(() => {
+    const built = innings.map(buildInnings).filter((i): i is RoundersScoreInnings => i !== null)
+    if (built.length === 0) {
+      onChange(null)
+      return
+    }
+    const totals: Record<string, number> = {}
+    for (const inn of built)
+      totals[inn.batting_side_id] = (totals[inn.batting_side_id] ?? 0) + inn.half_rounders
+    const a = totals[sideA.id] ?? 0
+    const b = totals[sideB.id] ?? 0
+    const winnerSideId = a === b ? undefined : a > b ? sideA.id : sideB.id
+    // `players` (the score's resolved-name map) is server-only — a manually
+    // built score has nothing to put here, same as cricket/football.
+    onChange({ score: { type: 'Rounders', innings: built, players: {} }, winnerSideId })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [innings, sideA.id, sideB.id])
+
+  const update = (i: number, patch: Partial<InningsDraft>) =>
+    setInnings((rows) => rows.map((r, j) => (j === i ? { ...r, ...patch } : r)))
+
+  return (
+    <div className="flex flex-col gap-3">
+      {innings.map((inn, i) => (
+        <InningsRow
+          key={i}
+          index={i}
+          draft={inn}
+          sideA={sideA}
+          sideB={sideB}
+          players={players}
+          onChange={(patch) => update(i, patch)}
+          onRemove={innings.length > 1 ? () => setInnings((rows) => rows.filter((_, j) => j !== i)) : undefined}
+        />
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="self-start"
+        onClick={() => setInnings((rows) => [...rows, newInnings(sideB.id, sideA.id)])}
+      >
+        <Plus className="size-3.5" /> Add innings
+      </Button>
+    </div>
+  )
+}
+
+function InningsRow({
+  index,
+  draft,
+  sideA,
+  sideB,
+  players,
+  onChange,
+  onRemove,
+}: {
+  index: number
+  draft: InningsDraft
+  sideA: MatchSide
+  sideB: MatchSide
+  players: MatchPlayer[]
+  onChange: (patch: Partial<InningsDraft>) => void
+  onRemove?: () => void
+}) {
+  const battingSide = [sideA, sideB].find((s) => s.id === draft.battingSideId)
+  const fieldingSide = [sideA, sideB].find((s) => s.id === draft.fieldingSideId)
+  const battingRoster = battingSide ? playersOnSide(players, battingSide) : []
+  const fieldingRoster = fieldingSide ? playersOnSide(players, fieldingSide) : []
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Innings {index + 1}
+        </p>
+        {onRemove && (
+          <Button type="button" variant="ghost" size="sm" className="h-6 px-1.5 text-xs" onClick={onRemove}>
+            Remove
+          </Button>
+        )}
+      </div>
+
+      <p className="mb-1.5 text-xs text-muted-foreground">Batting side</p>
+      <SidePicker
+        sides={[sideA, sideB]}
+        value={draft.battingSideId}
+        onChange={(sideId) =>
+          onChange({
+            battingSideId: sideId,
+            fieldingSideId: sideId === sideA.id ? sideB.id : sideA.id,
+          })
+        }
+      />
+
+      <div className="mt-3 grid grid-cols-4 gap-2">
+        <Field label="½ rounders" value={draft.halfRounders} onChange={(v) => onChange({ halfRounders: v })} />
+        <Field label="Outs" value={draft.outs} onChange={(v) => onChange({ outs: v })} />
+        <Field label="Good balls" value={draft.goodBalls} onChange={(v) => onChange({ goodBalls: v })} />
+        <Field label="Byes" value={draft.byes} onChange={(v) => onChange({ byes: v })} />
+      </div>
+
+      {!draft.detailOpen ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="mt-2"
+          onClick={() => onChange({ detailOpen: true })}
+        >
+          <Plus className="size-3.5" /> Add batting/bowling card
+        </Button>
+      ) : (
+        <div className="mt-3 flex flex-col gap-3 border-t pt-3">
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Batting
+            </p>
+            {draft.batting.map((b, i) => (
+              <BattingRow
+                key={i}
+                draft={b}
+                roster={battingRoster}
+                fieldingRoster={fieldingRoster}
+                onChange={(patch) =>
+                  onChange({ batting: draft.batting.map((r, j) => (j === i ? { ...r, ...patch } : r)) })
+                }
+                onRemove={() => onChange({ batting: draft.batting.filter((_, j) => j !== i) })}
+              />
+            ))}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                onChange({
+                  batting: [
+                    ...draft.batting,
+                    {
+                      playerId: '',
+                      halfRounders: '',
+                      balls: '',
+                      out: false,
+                      outKind: 'caught',
+                      fielderId: '',
+                    },
+                  ],
+                })
+              }
+            >
+              <Plus className="size-3.5" /> Add batter
+            </Button>
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Bowling
+            </p>
+            {draft.bowling.map((b, i) => (
+              <BowlingRow
+                key={i}
+                draft={b}
+                roster={fieldingRoster}
+                onChange={(patch) =>
+                  onChange({ bowling: draft.bowling.map((r, j) => (j === i ? { ...r, ...patch } : r)) })
+                }
+                onRemove={() => onChange({ bowling: draft.bowling.filter((_, j) => j !== i) })}
+              />
+            ))}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                onChange({
+                  bowling: [
+                    ...draft.bowling,
+                    { playerId: '', ballsBowled: '', noBalls: '', outs: '', halfRoundersConceded: '' },
+                  ],
+                })
+              }
+            >
+              <Plus className="size-3.5" /> Add bowler
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Field({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-center text-[10px] uppercase text-muted-foreground">{label}</span>
+      <Input
+        type="number"
+        min={0}
+        inputMode="numeric"
+        className="h-8"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="0"
+      />
+    </div>
+  )
+}
+
+function BattingRow({
+  draft,
+  roster,
+  fieldingRoster,
+  onChange,
+  onRemove,
+}: {
+  draft: BattingRowDraft
+  roster: MatchPlayer[]
+  fieldingRoster: MatchPlayer[]
+  onChange: (patch: Partial<BattingRowDraft>) => void
+  onRemove: () => void
+}) {
+  return (
+    <div className="mb-2 rounded-md border p-2">
+      <div className="mb-1.5 flex items-center justify-between">
+        <PlayerPicker players={roster} value={draft.playerId || undefined} onChange={(id) => onChange({ playerId: id })} />
+        <Button type="button" variant="ghost" size="sm" className="h-6 px-1.5 text-xs" onClick={onRemove}>
+          Remove
+        </Button>
+      </div>
+      <div className="grid grid-cols-2 gap-1.5">
+        <Field label="½ rounders" value={draft.halfRounders} onChange={(v) => onChange({ halfRounders: v })} />
+        <Field label="Balls faced" value={draft.balls} onChange={(v) => onChange({ balls: v })} />
+      </div>
+      <label className="mt-1.5 flex items-center gap-1.5 text-xs">
+        <input type="checkbox" checked={draft.out} onChange={(e) => onChange({ out: e.target.checked })} />
+        Out
+      </label>
+      {draft.out && (
+        <div className="mt-1.5 flex flex-col gap-1.5">
+          <div className="grid grid-cols-2 gap-1">
+            {OUT_KINDS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                aria-pressed={draft.outKind === k}
+                onClick={() => onChange({ outKind: k })}
+                className={`rounded border px-1.5 py-1 text-[10px] ${draft.outKind === k ? 'border-primary bg-accent' : 'text-muted-foreground'}`}
+              >
+                {outKindLabel(k)}
+              </button>
+            ))}
+          </div>
+          <PlayerPicker
+            players={fieldingRoster}
+            value={draft.fielderId || undefined}
+            emptyLabel="Fielder (optional)"
+            onChange={(id) => onChange({ fielderId: draft.fielderId === id ? '' : id })}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function BowlingRow({
+  draft,
+  roster,
+  onChange,
+  onRemove,
+}: {
+  draft: BowlingRowDraft
+  roster: MatchPlayer[]
+  onChange: (patch: Partial<BowlingRowDraft>) => void
+  onRemove: () => void
+}) {
+  return (
+    <div className="mb-2 rounded-md border p-2">
+      <div className="mb-1.5 flex items-center justify-between">
+        <PlayerPicker players={roster} value={draft.playerId || undefined} onChange={(id) => onChange({ playerId: id })} />
+        <Button type="button" variant="ghost" size="sm" className="h-6 px-1.5 text-xs" onClick={onRemove}>
+          Remove
+        </Button>
+      </div>
+      <div className="grid grid-cols-2 gap-1.5">
+        <Field label="Balls" value={draft.ballsBowled} onChange={(v) => onChange({ ballsBowled: v })} />
+        <Field label="No balls" value={draft.noBalls} onChange={(v) => onChange({ noBalls: v })} />
+      </div>
+      <div className="mt-1.5 grid grid-cols-2 gap-1.5">
+        <Field label="Outs" value={draft.outs} onChange={(v) => onChange({ outs: v })} />
+        <Field label="½ rounders conceded" value={draft.halfRoundersConceded} onChange={(v) => onChange({ halfRoundersConceded: v })} />
+      </div>
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/RoundersScorecard.tsx
+++ b/agon_ui/src/components/agon/RoundersScorecard.tsx
@@ -1,0 +1,129 @@
+import type { components } from '@/types/api'
+import { formatHalfRounders, outKindLabel, playerNameFor } from '@/lib/roundersScore'
+import type { ScorePlayers } from '@/lib/members'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+
+type Match = components['schemas']['Match']
+type RoundersScoreInnings = components['schemas']['RoundersScoreInnings']
+type RoundersBattingEntry = components['schemas']['RoundersBattingEntry']
+type RoundersBowlingEntry = components['schemas']['RoundersBowlingEntry']
+
+function sideNameFor(match: Match, sideId: string): string {
+  return match.sides.find((s) => s.id === sideId)?.name?.trim() || 'This side'
+}
+
+/**
+ * A match's full rounders scorecard: each innings' batting/bowling cards.
+ * Mirrors `CricketScorecard`, minus the run-progression graph — rounders has
+ * no equivalent continuous metric (a batter's turn is one or a few balls,
+ * not an over-by-over rate) to plot one against. Renders nothing if there's
+ * no per-innings detail to show (e.g. only a headline score was recorded).
+ *
+ * `match` is always the full detail-page `Match` here (own roster included),
+ * so `players` (the score's resolved-name map) is a redundant-but-cheap
+ * first lookup rather than the only source a feed card relies on — see
+ * `playerNameFor`.
+ */
+export function RoundersScorecard({
+  match,
+  innings,
+  players,
+}: {
+  match: Match
+  innings: RoundersScoreInnings[]
+  players?: ScorePlayers
+}) {
+  if (innings.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-4">
+      {innings.map((inn, i) => (
+        <InningsCard key={`${inn.batting_side_id}-${i}`} match={match} innings={inn} players={players} />
+      ))}
+    </div>
+  )
+}
+
+function InningsCard({
+  match,
+  innings,
+  players,
+}: {
+  match: Match
+  innings: RoundersScoreInnings
+  players?: ScorePlayers
+}) {
+  const batting = innings.batting ?? []
+  const bowling = innings.bowling ?? []
+  if (batting.length === 0 && bowling.length === 0) return null
+
+  const battingName = sideNameFor(match, innings.batting_side_id)
+  const fieldingName = sideNameFor(match, innings.fielding_side_id)
+
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card">
+      <div className="border-b px-4 py-3">
+        <p className="text-sm font-medium">{battingName}</p>
+        <p className="text-xs text-muted-foreground">
+          {formatHalfRounders(innings.half_rounders)} rounders, {innings.outs} out (
+          {innings.good_balls_bowled} good balls) vs {fieldingName}
+        </p>
+      </div>
+
+      {batting.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Batter</TableHead>
+              <TableHead className="w-16 text-right">½R</TableHead>
+              <TableHead className="w-12 text-right">B</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {batting.map((b: RoundersBattingEntry) => (
+              <TableRow key={b.player_id}>
+                <TableCell>
+                  <p className="font-medium">{playerNameFor(match, b.player_id, players) ?? '—'}</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {b.out ? outKindLabel(b.out.kind) : 'not out'}
+                  </p>
+                </TableCell>
+                <TableCell className="w-16 text-right tabular-nums">
+                  {formatHalfRounders(b.half_rounders)}
+                </TableCell>
+                <TableCell className="w-12 text-right tabular-nums">{b.balls_faced}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {bowling.length > 0 && (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Bowler</TableHead>
+              <TableHead className="w-12 text-right">B</TableHead>
+              <TableHead className="w-12 text-right">NB</TableHead>
+              <TableHead className="w-16 text-right">½R</TableHead>
+              <TableHead className="w-12 text-right">O</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bowling.map((bw: RoundersBowlingEntry) => (
+              <TableRow key={bw.player_id}>
+                <TableCell className="font-medium">{playerNameFor(match, bw.player_id, players) ?? '—'}</TableCell>
+                <TableCell className="w-12 text-right tabular-nums">{bw.balls_bowled}</TableCell>
+                <TableCell className="w-12 text-right tabular-nums">{bw.no_balls}</TableCell>
+                <TableCell className="w-16 text-right tabular-nums">
+                  {formatHalfRounders(bw.half_rounders_conceded)}
+                </TableCell>
+                <TableCell className="w-12 text-right tabular-nums">{bw.outs}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/SportPicker.tsx
+++ b/agon_ui/src/components/agon/SportPicker.tsx
@@ -9,6 +9,7 @@ const SPORTS: MatchType[] = [
   'table_tennis',
   'football',
   'cricket',
+  'rounders',
   'other',
 ]
 

--- a/agon_ui/src/components/agon/live/RoundersInningsCompleteDialog.tsx
+++ b/agon_ui/src/components/agon/live/RoundersInningsCompleteDialog.tsx
@@ -1,0 +1,56 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Pops up once the innings looks over by one of its two ending conditions —
+ * every batting-order slot out, or the good-ball cap reached (see
+ * `allBattersOut`/`goodBallsComplete` in `lib/roundersScore`) — same
+ * shape and reasoning as cricket's `AllOutDialog`/`OversCompleteDialog`:
+ * nothing on the backend blocks further deliveries (the format's caps are
+ * descriptive, not enforced — see `RoundersFormat`'s doc comment), so this
+ * surfaces the choice rather than forcing it. "End innings" is the primary
+ * action; "Continue" just dismisses the popup and lets scoring carry on.
+ */
+export function RoundersInningsCompleteDialog({
+  open,
+  battingSideName,
+  reason,
+  submitting,
+  onEnd,
+  onContinue,
+}: {
+  open: boolean
+  battingSideName: string
+  reason: 'all_batters_out' | 'good_balls_complete'
+  submitting: boolean
+  /** Ends the innings now, with the matching reason. */
+  onEnd: () => void
+  /** Dismisses the popup without ending the innings. */
+  onContinue: () => void
+}) {
+  const title =
+    reason === 'all_batters_out' ? `${battingSideName} are all out!` : `${battingSideName}'s good balls are used up`
+  const body =
+    reason === 'all_batters_out'
+      ? 'No batters left to come in — end the innings, or bring someone back in to keep going.'
+      : "This innings' good-ball cap has been reached — end it here, or play on past the quota."
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onContinue()}>
+      <DialogContent className="max-w-sm text-center sm:text-center">
+        <DialogHeader className="text-center sm:text-center">
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-muted-foreground">{body}</p>
+        <div className="mt-2 flex flex-col gap-2">
+          <Button disabled={submitting} onClick={onEnd}>
+            {submitting ? 'Ending…' : 'End innings'}
+          </Button>
+          <Button variant="outline" disabled={submitting} onClick={onContinue}>
+            Continue
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/agon_ui/src/components/agon/live/RoundersMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/RoundersMatchBlock.tsx
@@ -1,0 +1,125 @@
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { LiveIndicator } from './LiveIndicator'
+import {
+  currentRoundersInnings,
+  formatHalfRounders,
+  playerNameFor,
+  postLabel,
+  roundersStateDescription,
+  sideNameFor,
+  type RoundersScore,
+} from '@/lib/roundersScore'
+import { roundersFormat } from '@/lib/matchFormat'
+
+type Match = components['schemas']['Match']
+type FeedMatch = components['schemas']['FeedMatch']
+type SearchMatch = components['schemas']['SearchMatch']
+
+/**
+ * The score block + "who's on base" row for a rounders match being scored
+ * live (mirrors `CricketMatchBlock`'s role, adapted for rounders' concurrent
+ * runners instead of a striker/non-striker pair). Presentational: the caller
+ * fetches the live score (`useMatchScore`) and passes the derived rounders
+ * score down.
+ */
+export function RoundersMatchBlock({
+  match,
+  state,
+  showDescription = true,
+}: {
+  match: Match | FeedMatch | SearchMatch
+  state: RoundersScore
+  /** Whether to show the state-of-game line (leading/result) here. Callers
+   *  that already surface it elsewhere (the feed card's header) pass
+   *  `false` so it isn't said twice — the innings-break heading then falls
+   *  back to a neutral "Innings break"/"Match complete" instead. */
+  showDescription?: boolean
+}) {
+  const innings = currentRoundersInnings(state)
+  const format = roundersFormat(match.format)
+  const description = roundersStateDescription(
+    match,
+    { innings: state.innings, awaiting_next_innings: state.awaiting_next_innings ?? true },
+    format,
+  )
+
+  if (!innings) {
+    // Between innings, or nothing bowled yet. Every innings played so far is
+    // still worth showing rather than discarding. `description` is only
+    // ever non-null here once the match is complete, so its presence
+    // doubles as that signal — same convention as `CricketMatchBlock`.
+    const heading = showDescription
+      ? description || 'Innings break'
+      : description
+        ? 'Match complete'
+        : 'Innings break'
+    return (
+      <div className="rounded-lg bg-muted/50 px-3.5 py-3">
+        <div className="flex items-center justify-between">
+          <p
+            className={cn(
+              'text-sm font-medium',
+              showDescription && description ? 'text-primary' : 'text-muted-foreground',
+            )}
+          >
+            {heading}
+          </p>
+          <LiveIndicator />
+        </div>
+        {state.innings.length > 0 && (
+          <div className="mt-1 space-y-0.5">
+            {state.innings.map((inn, i) => (
+              <p key={i} className="text-lg font-medium leading-tight tracking-tight">
+                {sideNameFor(match, inn.batting_side_id)} {formatHalfRounders(inn.half_rounders)}
+                <span className="ml-1.5 text-sm font-normal text-muted-foreground">
+                  ({inn.outs} out)
+                </span>
+              </p>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const battingName = sideNameFor(match, innings.batting_side_id)
+  const fieldingName = sideNameFor(match, innings.fielding_side_id)
+  const runners = Object.entries(state.next_ball_context?.runners_on_base ?? {})
+  const goodBallsLabel = format.good_balls_per_innings
+    ? `${innings.good_balls_bowled}/${format.good_balls_per_innings}`
+    : `${innings.good_balls_bowled}`
+
+  return (
+    <div className="rounded-lg bg-muted/50 px-3.5 py-3">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-xs font-medium text-muted-foreground">{battingName} batting</p>
+          <p className="text-2xl font-medium leading-tight tracking-tight">
+            {formatHalfRounders(innings.half_rounders)}
+            <span className="ml-1.5 text-sm font-normal text-muted-foreground">
+              ({innings.outs} out · {goodBallsLabel} balls)
+            </span>
+          </p>
+          {runners.length > 0 && (
+            <p className="mt-0.5 truncate text-xs text-muted-foreground">
+              {runners
+                .map(([playerId, post]) => {
+                  const name = playerNameFor(match, playerId, state.players)
+                  return name ? `${name} (${postLabel(post)})` : null
+                })
+                .filter(Boolean)
+                .join(' · ')}
+            </p>
+          )}
+          {showDescription && description && (
+            <p className="mt-0.5 text-xs font-medium text-primary">{description}</p>
+          )}
+        </div>
+        <LiveIndicator />
+      </div>
+
+      <p className="mt-1.5 text-[11px] text-muted-foreground">vs {fieldingName}</p>
+    </div>
+  )
+}

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -7,6 +7,7 @@ type LiveEvent = components['schemas']['LiveEvent']
 type NewLiveEventInput = components['schemas']['NewLiveEventInput']
 type FootballLiveEvent = components['schemas']['FootballLiveEvent']
 type CricketLiveEvent = components['schemas']['CricketLiveEvent']
+type RoundersLiveEvent = components['schemas']['RoundersLiveEvent']
 
 /** Drains every page of a match's raw live event log, oldest first. */
 async function drainLiveEvents(matchId: string): Promise<LiveEvent[]> {
@@ -121,6 +122,10 @@ export function useAppendFootballEvent(matchId: string) {
 
 export function useAppendCricketEvent(matchId: string) {
   return useAppendLiveEvent<CricketLiveEvent>(matchId, 'Cricket')
+}
+
+export function useAppendRoundersEvent(matchId: string) {
+  return useAppendLiveEvent<RoundersLiveEvent>(matchId, 'Rounders')
 }
 
 /**

--- a/agon_ui/src/lib/matchFormat.ts
+++ b/agon_ui/src/lib/matchFormat.ts
@@ -3,6 +3,7 @@ import type { components } from '@/types/api'
 export type MatchFormat = components['schemas']['MatchFormat']
 export type FootballFormat = components['schemas']['FootballFormat']
 export type CricketFormat = components['schemas']['CricketFormat']
+export type RoundersFormat = components['schemas']['RoundersFormat']
 
 /**
  * App-side defaults for an unconfigured match — the backend stores `format`
@@ -30,6 +31,18 @@ export const DEFAULT_CRICKET_FORMAT: CricketFormat = {
   free_hit_after_no_ball: true,
 }
 
+/** The standard Rounders England scoresheet's numbers — 2 innings, a 30
+ *  good-ball cap, 3 bonus balls for the last remaining batter. */
+export const DEFAULT_ROUNDERS_FORMAT: RoundersFormat = {
+  innings_per_side: 2,
+  good_balls_per_innings: 30,
+  innings_length_minutes: undefined,
+  last_batter_bonus_balls: 3,
+  balls_per_bowling_spell: undefined,
+  half_rounders_count: true,
+  no_ball_penalty_threshold: undefined,
+}
+
 // `Match.format`'s generated type erases the union discriminant (same quirk
 // as `Invitation.kind` in `lib/members.ts` — openapi-typescript widens a
 // union nested inside an object to `Omit<Union, "sport"> & unknown`, so
@@ -55,4 +68,19 @@ export function cricketFormat(format: unknown): CricketFormat {
 /** "20 overs" / "Unlimited overs" for a cricket format summary. */
 export function oversLimitLabel(fmt: CricketFormat): string {
   return fmt.overs_per_innings ? `${fmt.overs_per_innings} overs` : 'Unlimited overs'
+}
+
+/** The rounders format to use — the match's own if set for rounders, else
+ *  the app default. */
+export function roundersFormat(format: unknown): RoundersFormat {
+  const fmt = format as MatchFormat | null | undefined
+  if (fmt && fmt.sport === 'Rounders') return fmt
+  return DEFAULT_ROUNDERS_FORMAT
+}
+
+/** "30 good balls" / "Unlimited good balls" for a rounders format summary. */
+export function goodBallsLimitLabel(fmt: RoundersFormat): string {
+  return fmt.good_balls_per_innings
+    ? `${fmt.good_balls_per_innings} good balls`
+    : 'Unlimited good balls'
 }

--- a/agon_ui/src/lib/roundersScore.ts
+++ b/agon_ui/src/lib/roundersScore.ts
@@ -1,0 +1,211 @@
+import type { components } from '@/types/api'
+import { memberName, type ScorePlayers } from './members'
+import type { RoundersFormat } from './matchFormat'
+
+export type RoundersPost = components['schemas']['RoundersPost']
+export type RoundersOutKind = components['schemas']['RoundersOutKind']
+export type RoundersOut = components['schemas']['RoundersOut']
+export type RoundersRunnerMovement = components['schemas']['RoundersRunnerMovement']
+export type RoundersDelivery = components['schemas']['RoundersDelivery']
+export type RoundersNextBallContext = components['schemas']['RoundersNextBallContext']
+export type RoundersBattingEntry = components['schemas']['RoundersBattingEntry']
+export type RoundersBowlingEntry = components['schemas']['RoundersBowlingEntry']
+export type RoundersFallOfOut = components['schemas']['RoundersFallOfOut']
+export type RoundersScore = components['schemas']['RoundersScore']
+export type RoundersScoreInnings = components['schemas']['RoundersScoreInnings']
+export type RoundersLiveEvent = components['schemas']['RoundersLiveEvent']
+type Score = components['schemas']['Score']
+type Match = components['schemas']['Match']
+type MatchPlayer = components['schemas']['MatchPlayer']
+type FeedMatch = components['schemas']['FeedMatch']
+type SearchMatch = components['schemas']['SearchMatch']
+/** Anything with an optional `players` list — see `members.ts`'s `MatchLike`
+ *  for why `FeedMatch`/`SearchMatch` need their own explicit branches. */
+type MatchLike = { players?: MatchPlayer[] } | FeedMatch | SearchMatch
+
+/** Narrows a match's score to its rounders variant — same role as
+ *  `cricketScoreFrom` in `lib/cricketScore.ts`. `null` when there's no score
+ *  yet or it's the plain totals-only shape a manually-logged (not
+ *  live-scored) rounders result degrades to. */
+export function roundersScoreFrom(score: Score | null | undefined): RoundersScore | null {
+  if (!score || score.type !== 'Rounders') return null
+  return score
+}
+
+/** A match's per-innings totals (plus whatever per-player detail they carry)
+ *  straight off its score — `null` if there's no score yet or it's not
+ *  `Rounders`. Mirrors `cricketInningsFor` in `lib/cricketScore.ts`. */
+export function roundersInningsFor(score: Score | null | undefined): RoundersScoreInnings[] | null {
+  return roundersScoreFrom(score)?.innings ?? null
+}
+
+/** The minimal per-innings shape match-aggregate math needs — a live
+ *  `RoundersScore.innings` and a confirmed one satisfy this structurally
+ *  either way. */
+interface RoundersInningsTotal {
+  batting_side_id: string
+  fielding_side_id: string
+  half_rounders: number
+  outs: number
+}
+
+/** Ditto, for the match-level progress shape — mirrors
+ *  `CricketMatchProgress`. */
+export interface RoundersMatchProgress {
+  innings: RoundersInningsTotal[]
+  awaiting_next_innings: boolean
+}
+
+/** Reframes a completed match's `RoundersScore` as a `RoundersMatchProgress`
+ *  — there's no currently-open innings once the score is confirmed. */
+export function roundersProgressFromScore(score: RoundersScore): RoundersMatchProgress {
+  return { innings: score.innings, awaiting_next_innings: true }
+}
+
+/** The innings currently being played, or `null` when the match hasn't
+ *  started its first innings yet, or is between innings. */
+export function currentRoundersInnings(score: RoundersScore): RoundersScoreInnings | null {
+  if (score.awaiting_next_innings ?? true) return null
+  return score.innings[score.innings.length - 1] ?? null
+}
+
+/** "4½" / "4" — half-rounder units rendered as the conventional fractional
+ *  score (a full rounder is 2 units). */
+export function formatHalfRounders(units: number): string {
+  const whole = Math.floor(units / 2)
+  return units % 2 === 1 ? `${whole}½` : `${whole}`
+}
+
+const POST_LABEL: Record<RoundersPost, string> = {
+  first: '1st post',
+  second: '2nd post',
+  third: '3rd post',
+  fourth: 'Home',
+}
+
+export function postLabel(post: RoundersPost): string {
+  return POST_LABEL[post]
+}
+
+const OUT_KIND_LABEL: Record<RoundersOutKind, string> = {
+  caught: 'Caught',
+  stumped_at_post: 'Stumped at post',
+  overtook_runner: 'Overtook runner',
+  obstruction: 'Obstruction',
+  failed_to_run: 'Failed to run',
+}
+
+export function outKindLabel(kind: RoundersOutKind): string {
+  return OUT_KIND_LABEL[kind]
+}
+
+/** Total half-rounders scored by each side across every completed innings so
+ *  far — mirrors `matchTotalsBySide` in `lib/cricketScore.ts`. */
+export function roundersMatchTotalsBySide(state: RoundersMatchProgress): Record<string, number> {
+  const totals: Record<string, number> = {}
+  for (const innings of state.innings) {
+    totals[innings.batting_side_id] = (totals[innings.batting_side_id] ?? 0) + innings.half_rounders
+  }
+  return totals
+}
+
+/** The batting order's size for a side — the roster registered on it, or the
+ *  standard 9 if the roster looks too small to make sense of (e.g. not fully
+ *  set up) — same fallback reasoning as cricket's `wicketsInHand`. */
+export function battingOrderSize(
+  match: Pick<Match, 'sides'> & Partial<Pick<Match, 'players'>>,
+  sideId: string,
+): number {
+  const rosterSize = (match.players ?? []).filter((p) => p.side_id === sideId).length
+  return rosterSize > 0 ? rosterSize : 9
+}
+
+/** Whether every batting-order slot is out — the "Batters out" grid full,
+ *  same signal as cricket's `wicketsInHand` reaching zero. */
+export function allBattersOut(
+  match: Pick<Match, 'sides'> & Partial<Pick<Match, 'players'>>,
+  innings: Pick<RoundersScoreInnings, 'batting_side_id' | 'outs'>,
+): boolean {
+  return innings.outs >= battingOrderSize(match, innings.batting_side_id)
+}
+
+/** Whether the innings' good-ball cap (if the format sets one) has been
+ *  reached — the "Good balls" grid full. */
+export function goodBallsComplete(
+  innings: Pick<RoundersScoreInnings, 'good_balls_bowled'>,
+  format: Pick<RoundersFormat, 'good_balls_per_innings'>,
+): boolean {
+  return (
+    format.good_balls_per_innings != null &&
+    innings.good_balls_bowled >= format.good_balls_per_innings
+  )
+}
+
+/**
+ * A one-line summary of where the match stands — mirrors
+ * `cricketStateDescription`'s three phases (leading, chasing, result), using
+ * half-rounders as the unit instead of runs. `null` when none apply yet
+ * (the match's very first innings, with nothing yet to lead or chase).
+ */
+export function roundersStateDescription(
+  match: Pick<Match, 'sides'> & Partial<Pick<Match, 'players'>>,
+  state: RoundersMatchProgress,
+  format: Pick<RoundersFormat, 'innings_per_side'>,
+): string | null {
+  if (state.innings.length === 0) return null
+  const quota = match.sides.length * format.innings_per_side
+  const totals = roundersMatchTotalsBySide(state)
+
+  const open = state.awaiting_next_innings ? null : state.innings[state.innings.length - 1]
+  if (open) {
+    const battingTotal = totals[open.batting_side_id] ?? 0
+    const fieldingTotal = totals[open.fielding_side_id] ?? 0
+
+    if (state.innings.length === quota) {
+      const needed = fieldingTotal + 1 - battingTotal
+      if (needed <= 0) return null
+      return `${sideNameFor(match, open.batting_side_id)} need ${formatHalfRounders(needed)} to win`
+    }
+
+    const fieldingHasBatted = state.innings
+      .slice(0, -1)
+      .some((i) => i.batting_side_id === open.fielding_side_id)
+    if (!fieldingHasBatted) return null
+    const diff = battingTotal - fieldingTotal
+    if (diff === 0) return 'Scores level'
+    const leadingSideId = diff > 0 ? open.batting_side_id : open.fielding_side_id
+    return `${sideNameFor(match, leadingSideId)} lead by ${formatHalfRounders(Math.abs(diff))}`
+  }
+
+  if (!state.awaiting_next_innings || state.innings.length < quota) return null
+  const last = state.innings[state.innings.length - 1]
+  const battingTotal = totals[last.batting_side_id] ?? 0
+  const fieldingTotal = totals[last.fielding_side_id] ?? 0
+  if (battingTotal === fieldingTotal) return 'Match tied'
+
+  const winnerSideId = battingTotal > fieldingTotal ? last.batting_side_id : last.fielding_side_id
+  const margin = Math.abs(battingTotal - fieldingTotal)
+  return `${sideNameFor(match, winnerSideId)} won by ${formatHalfRounders(margin)}`
+}
+
+/** Display name for a side id: its name, or a neutral fallback. */
+export function sideNameFor(match: Pick<Match, 'sides'>, sideId: string): string {
+  return match.sides.find((s) => s.id === sideId)?.name?.trim() || 'This side'
+}
+
+/** Player display name for a match-scoped player id — same contract as
+ *  cricket's `playerNameFor` in `lib/cricketScore.ts`: checks the score's
+ *  own resolved-name map first (the only source a feed/search card's
+ *  trimmed match type carries), falling back to the match's own roster. */
+export function playerNameFor(
+  match: MatchLike,
+  playerId: string | undefined | null,
+  scorePlayers?: ScorePlayers,
+): string | null {
+  if (!playerId) return null
+  const resolved = scorePlayers?.[playerId]
+  if (resolved) return resolved.name
+  const players = ('players' in match && match.players) || []
+  const player = players.find((p) => p.member.id === playerId)
+  return player ? memberName(player.member) : null
+}

--- a/agon_ui/src/lib/score.ts
+++ b/agon_ui/src/lib/score.ts
@@ -41,14 +41,15 @@ export function displayScore(
  * (across index-aligned entries); for a Simple score it's the points; for a
  * Football score it's the goal tally (`score.score`, keyed by side id —
  * already correct including own goals, which credit the benefiting side).
- * Returns a map of side id → headline value. A `Cricket` score has no single
- * headline number to show here — `CricketMatchBlock`/`CricketScoreBlock`
- * render it their own way — so it's an empty map, same as "no score yet".
+ * Returns a map of side id → headline value. A `Cricket`/`Rounders` score has
+ * no single headline number to show here — `CricketMatchBlock`/
+ * `CricketScoreBlock` and `RoundersMatchBlock`/`RoundersScoreBlock` render
+ * them their own way — so it's an empty map, same as "no score yet".
  */
 export function headlineBySide(score: Score): Record<string, number> {
   if (score.type === 'Simple') return { ...score.entries }
   if (score.type === 'Football') return { ...score.score }
-  if (score.type === 'Cricket') return {}
+  if (score.type === 'Cricket' || score.type === 'Rounders') return {}
   // Sets: a side wins a set at index i if its games exceed every other side's.
   const out: Record<string, number> = {}
   const entries = Object.entries(score.entries)

--- a/agon_ui/src/lib/sports.ts
+++ b/agon_ui/src/lib/sports.ts
@@ -4,6 +4,7 @@ import {
   Target,
   CircleDot,
   Circle,
+  Diamond,
   type LucideIcon,
 } from 'lucide-react'
 import type { components } from '@/types/api'
@@ -18,6 +19,7 @@ const SPORT_LABELS: Record<MatchType, string> = {
   table_tennis: 'Table Tennis',
   football: 'Football',
   cricket: 'Cricket',
+  rounders: 'Rounders',
   other: 'Other',
 }
 
@@ -34,6 +36,8 @@ const SPORT_ICONS: Record<MatchType, LucideIcon> = {
   table_tennis: CircleDot,
   football: Volleyball,
   cricket: Target,
+  // The four-post circuit reads closest to a diamond of any glyph on hand.
+  rounders: Diamond,
   other: Dumbbell,
 }
 
@@ -53,6 +57,7 @@ const SPORT_EMOJI: Record<MatchType, string> = {
   table_tennis: '🏓',
   football: '⚽',
   cricket: '🏏',
+  rounders: '🥎',
   other: '🏅',
 }
 

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -11,6 +11,7 @@ import { RecordEventDialog, type EventKind } from '@/components/agon/live/Record
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { UndoLastEventButton } from '@/components/agon/live/UndoLastEventButton'
 import { CricketLiveScoringPage } from './CricketLiveScoringPage'
+import { RoundersLiveScoringPage } from './RoundersLiveScoringPage'
 import { footballFormat } from '@/lib/matchFormat'
 import {
   currentMinute,
@@ -39,9 +40,10 @@ function sideName(match: Match, index: number, fallback: string): string {
 
 /**
  * Route entry for `/matches/:matchId/live`: fetches the match once and
- * dispatches to the sport-specific scoring screen. Football and cricket have
- * different live-scoring shapes entirely (a running clock vs. overs/wickets),
- * so past the match fetch they don't share a component.
+ * dispatches to the sport-specific scoring screen. Football, cricket, and
+ * rounders have different live-scoring shapes entirely (a running clock vs.
+ * overs/wickets vs. good balls/concurrent runners), so past the match fetch
+ * they don't share a component.
  */
 export function LiveScoringPage() {
   const { matchId } = useParams()
@@ -80,6 +82,9 @@ export function LiveScoringPage() {
   const match = matchQuery.data
   if (match.match_type === 'cricket') {
     return <CricketLiveScoringPage match={match} />
+  }
+  if (match.match_type === 'rounders') {
+    return <RoundersLiveScoringPage match={match} />
   }
   return <FootballLiveScoringPage match={match} />
 }

--- a/agon_ui/src/pages/LogMatchPage.tsx
+++ b/agon_ui/src/pages/LogMatchPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/agon/PlayerSideEditor'
 import { FootballScoreFields } from '@/components/agon/FootballScoreFields'
 import { CricketScoreFields } from '@/components/agon/CricketScoreFields'
+import { RoundersScoreFields } from '@/components/agon/RoundersScoreFields'
 import { cn } from '@/lib/utils'
 import { toDateTimeLocal } from '@/lib/datetime'
 import { addPendingMatch } from '@/hooks/usePendingMatches'
@@ -178,6 +179,7 @@ export function LogMatchPage() {
   const setsPlayable = isSetsSport(sport ?? 'other')
   const isFootball = sport === 'football'
   const isCricket = sport === 'cricket'
+  const isRounders = sport === 'rounders'
 
   // Is the picked time valid for the chosen mode? Completed matches must be in
   // the past, scheduled ones in the future (matches the server's rule). Empty or
@@ -199,7 +201,7 @@ export function LogMatchPage() {
   // inline hint), or null when the score state is acceptable for the mode.
   const scoreError = useMemo((): string | null => {
     if (mode !== 'completed') return null
-    if (isFootball || isCricket) {
+    if (isFootball || isCricket || isRounders) {
       return detailBuilt ? null : 'Enter the score'
     }
     if (setsPlayable) {
@@ -222,7 +224,7 @@ export function LogMatchPage() {
     if (pointsA === '' || pointsB === '' || !Number.isFinite(a) || !Number.isFinite(b))
       return 'Enter the score for both sides'
     return null
-  }, [mode, isFootball, isCricket, detailBuilt, setsPlayable, sets, pointsA, pointsB])
+  }, [mode, isFootball, isCricket, isRounders, detailBuilt, setsPlayable, sets, pointsA, pointsB])
 
   // Validation: a sport, a match name, at least one player on each side (so the
   // match is meaningful), at least one opponent on side B, a time valid for the
@@ -298,7 +300,7 @@ export function LogMatchPage() {
     | null => {
     if (!recordResult || !sport) return null
 
-    if (isFootball || isCricket) {
+    if (isFootball || isCricket || isRounders) {
       if (!detailBuilt) return null
       return {
         score: detailBuilt.score as unknown as CreateMatchInput['score'],
@@ -509,7 +511,7 @@ export function LogMatchPage() {
       {mode === 'completed' &&
         (playersSet ? (
           <Section num={5} title="Score">
-          {(isFootball || isCricket) && (() => {
+          {(isFootball || isCricket || isRounders) && (() => {
             const sideAObj: MatchSide = { id: SIDE_A, name: sideAName.trim() || undefined }
             const sideBObj: MatchSide = { id: SIDE_B, name: sideBName.trim() || undefined }
             const players = [...toMatchPlayers(sideA, SIDE_A), ...toMatchPlayers(sideB, SIDE_B)]
@@ -520,8 +522,15 @@ export function LogMatchPage() {
                 players={players}
                 onChange={setDetailBuilt}
               />
-            ) : (
+            ) : isCricket ? (
               <CricketScoreFields
+                sideA={sideAObj}
+                sideB={sideBObj}
+                players={players}
+                onChange={setDetailBuilt}
+              />
+            ) : (
+              <RoundersScoreFields
                 sideA={sideAObj}
                 sideB={sideBObj}
                 players={players}
@@ -594,7 +603,7 @@ export function LogMatchPage() {
             </div>
           )}
 
-          {!isFootball && !isCricket && !setsPlayable && (
+          {!isFootball && !isCricket && !isRounders && !setsPlayable && (
             <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
               <div className="flex flex-col gap-1">
                 <span className="truncate text-center text-xs text-muted-foreground">

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -13,13 +13,17 @@ import { StatusBadge, matchBadgeStatus } from '@/components/agon/StatusBadge'
 import { ScoreConfirmationBar } from '@/components/agon/ScoreConfirmationBar'
 import { LiveMatchBlock } from '@/components/agon/live/LiveMatchBlock'
 import { CricketMatchBlock } from '@/components/agon/live/CricketMatchBlock'
+import { RoundersMatchBlock } from '@/components/agon/live/RoundersMatchBlock'
 import { CricketScoreBlock } from '@/components/agon/CricketScoreBlock'
+import { RoundersScoreBlock } from '@/components/agon/RoundersScoreBlock'
 import { CricketScorecard } from '@/components/agon/CricketScorecard'
+import { RoundersScorecard } from '@/components/agon/RoundersScorecard'
 import { FootballScorecard } from '@/components/agon/FootballScorecard'
 import { useLiveEvents } from '@/hooks/useLiveScore'
 import { useMatchScore } from '@/hooks/useMatchScore'
 import { footballScoreFrom, footballEventSourceFromScore } from '@/lib/liveScore'
 import { cricketInningsFor, cricketScoreFrom, inningsDeliveriesFromEvents } from '@/lib/cricketScore'
+import { roundersInningsFor, roundersScoreFrom } from '@/lib/roundersScore'
 import { useCurrentUserId } from '@/hooks/useCurrentUserId'
 import { displayScore, headlineBySide, headlineLabel, setLine } from '@/lib/score'
 import {
@@ -115,7 +119,8 @@ function MatchDetail({
 
   const canEdit = isParticipant(match, currentUserId)
   const cancelled = match.status === 'cancelled'
-  const isLiveSport = match.match_type === 'football' || match.match_type === 'cricket'
+  const isLiveSport =
+    match.match_type === 'football' || match.match_type === 'cricket' || match.match_type === 'rounders'
 
   const [sideA, sideB] = match.sides
   const nameA = sideName(sideA, 'Side A')
@@ -142,21 +147,27 @@ function MatchDetail({
   const isCurrentlyLive = isLiveSport && match.status === 'in_progress'
   const footballState = isCurrentlyLive ? footballScoreFrom(scoreQuery.data) : null
   const cricketState = isCurrentlyLive ? cricketScoreFrom(scoreQuery.data) : null
-  const hasLiveState = !!footballState || !!cricketState
+  const roundersState = isCurrentlyLive ? roundersScoreFrom(scoreQuery.data) : null
+  const hasLiveState = !!footballState || !!cricketState || !!roundersState
   // Same "live while in progress, else confirmed/pending" source as
   // `cricketScoreInnings` below — needed here just for `.players` (the
   // score's resolved-name map), passed to `CricketScorecard`.
   const cricketScore = cricketScoreFrom(isCurrentlyLive ? scoreQuery.data : scoreInfo?.score)
+  // Ditto for rounders — passed to `RoundersScorecard`.
+  const roundersScore = roundersScoreFrom(isCurrentlyLive ? scoreQuery.data : scoreInfo?.score)
   // `FootballScorecard`'s event timeline: the live running score while the
   // match is in progress, else straight off the confirmed/pending score —
   // stays visible once the match is completed, unlike `footballState` above.
   const footballEventSource = footballEventSourceFromScore(
     isCurrentlyLive ? scoreQuery.data : scoreInfo?.score,
   )
-  // Football's setup screen also gates starting the clock; cricket has no
-  // equivalent preferences step, so it goes straight into scoring.
+  // Football's setup screen also gates starting the clock; cricket and
+  // rounders have no equivalent preferences step (no clock), so they go
+  // straight into scoring.
   const liveEntryPath =
-    match.match_type === 'cricket' ? `/matches/${match.id}/live` : `/matches/${match.id}/live/setup`
+    match.match_type === 'cricket' || match.match_type === 'rounders'
+      ? `/matches/${match.id}/live`
+      : `/matches/${match.id}/live/setup`
 
   // Each cricket innings' deliveries, folded in from the raw live event log
   // by matching innings order, for the run-rate graph — the score's own
@@ -171,6 +182,10 @@ function MatchDetail({
     ...inn,
     deliveries: liveInningsDeliveries?.[i]?.deliveries ?? [],
   }))
+  // Rounders' scorecard reads each innings' batting/bowling cards straight
+  // off the score (no run-rate graph, so no need for the raw event log the
+  // way cricket's does — see `RoundersScorecard`'s doc comment).
+  const roundersInnings = roundersInningsFor(isCurrentlyLive ? scoreQuery.data : scoreInfo?.score)
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-4">
@@ -220,6 +235,14 @@ function MatchDetail({
           ) : cricketScore ? (
             <div className="mt-3">
               <CricketScoreBlock match={match} score={cricketScore} />
+            </div>
+          ) : roundersState ? (
+            <div className="mt-3">
+              <RoundersMatchBlock match={match} state={roundersState} />
+            </div>
+          ) : roundersScore ? (
+            <div className="mt-3">
+              <RoundersScoreBlock match={match} score={roundersScore} />
             </div>
           ) : scoreInfo ? (
             <div className="mt-3 flex items-center justify-between">
@@ -346,6 +369,12 @@ function MatchDetail({
           directly). */}
       {cricketInnings && cricketInnings.length > 0 && (
         <CricketScorecard match={match} innings={cricketInnings} players={cricketScore?.players} />
+      )}
+
+      {/* Rounders scorecard: per-innings batting/bowling, once there's
+          per-innings detail recorded (live-scored or entered directly). */}
+      {roundersInnings && roundersInnings.length > 0 && (
+        <RoundersScorecard match={match} innings={roundersInnings} players={roundersScore?.players} />
       )}
 
       {/* Football event timeline: goals/cards/subs, once there's detail

--- a/agon_ui/src/pages/RoundersLiveScoringPage.tsx
+++ b/agon_ui/src/pages/RoundersLiveScoringPage.tsx
@@ -1,0 +1,547 @@
+import { useEffect, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
+import { ChevronLeft } from 'lucide-react'
+import { fetchClient } from '@/lib/api-client'
+import type { components } from '@/types/api'
+import { Button } from '@/components/ui/button'
+import { useAppendRoundersEvent, useLiveSeq } from '@/hooks/useLiveScore'
+import { matchScoreQueryKey, useMatchScore } from '@/hooks/useMatchScore'
+import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
+import { UndoLastEventButton } from '@/components/agon/live/UndoLastEventButton'
+import { SidePicker, PlayerPicker, sideName } from '@/components/agon/live/Pickers'
+import { RoundersInningsCompleteDialog } from '@/components/agon/live/RoundersInningsCompleteDialog'
+import { playersOnSide } from '@/lib/members'
+import { roundersFormat } from '@/lib/matchFormat'
+import {
+  allBattersOut,
+  currentRoundersInnings,
+  formatHalfRounders,
+  goodBallsComplete,
+  outKindLabel,
+  playerNameFor,
+  postLabel,
+  roundersScoreFrom,
+  sideNameFor,
+  type RoundersOutKind,
+  type RoundersPost,
+  type RoundersRunnerMovement,
+} from '@/lib/roundersScore'
+
+type Match = components['schemas']['Match']
+type RoundersDelivery = components['schemas']['RoundersDelivery']
+type RoundersInningsEndReason = components['schemas']['RoundersInningsEndReason']
+type UpdateMatchInput = components['schemas']['UpdateMatchInput']
+type Score = components['schemas']['Score']
+
+const END_REASONS: { value: RoundersInningsEndReason; label: string }[] = [
+  { value: 'all_batters_out', label: 'All batters out' },
+  { value: 'good_balls_complete', label: 'Good balls complete' },
+  { value: 'time_up', label: "Time's up" },
+]
+
+const POSTS: RoundersPost[] = ['first', 'second', 'third', 'fourth']
+const OUT_KINDS: RoundersOutKind[] = [
+  'caught',
+  'stumped_at_post',
+  'overtook_runner',
+  'obstruction',
+  'failed_to_run',
+]
+
+/** A movement being drafted for one candidate (the picked striker, or a
+ *  runner already on base) before it's submitted with the delivery. */
+interface MovementDraft {
+  post?: RoundersPost
+  out?: { kind: RoundersOutKind; fielderId?: string }
+}
+
+/**
+ * The live rounders scoring screen: pick a bowler and the batter facing this
+ * ball, then record what every runner on the track (including the new
+ * striker) did on it — mirrors `CricketLiveScoringPage`'s shape, adapted for
+ * rounders' concurrent runners instead of a fixed striker/non-striker pair
+ * (see `RoundersDelivery`'s doc comment on the backend). No clock, same as
+ * cricket — progress is good balls/outs, derivable from the event log
+ * itself.
+ */
+export function RoundersLiveScoringPage({ match }: { match: Match }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+
+  const scoreQuery = useMatchScore(match.id, { refetchInterval: 8000 })
+  const seq = useLiveSeq(match.id)
+  const appendEvent = useAppendRoundersEvent(match.id)
+  const state = roundersScoreFrom(scoreQuery.data)
+  const innings = state ? currentRoundersInnings(state) : null
+  const format = roundersFormat(match.format)
+  const next = state?.next_ball_context ?? null
+
+  const [startBattingSide, setStartBattingSide] = useState<string | undefined>(undefined)
+  const [pickedBowler, setPickedBowler] = useState<string | null>(null)
+  const [pickedStriker, setPickedStriker] = useState<string | null>(null)
+  const [noBall, setNoBall] = useState(false)
+  const [byes, setByes] = useState(false)
+  const [outcomes, setOutcomes] = useState<Record<string, MovementDraft>>({})
+  const [endInningsOpen, setEndInningsOpen] = useState(false)
+
+  // The bowler persists server-side across balls (`next_ball_context.
+  // bowler_player_id`) — once it's confirmed there, drop the local pick so
+  // the picker reflects the server's view, same pattern as cricket's opener
+  // picks.
+  useEffect(() => {
+    if (next?.bowler_player_id) setPickedBowler(null)
+  }, [next?.bowler_player_id])
+
+  const outBatters = (innings?.batting ?? []).filter((b) => b.out).map((b) => b.player_id)
+  const runnersOnBase = next?.runners_on_base ?? {}
+
+  const allOut = !!innings && allBattersOut(match, innings)
+  const ballsComplete = !!innings && goodBallsComplete(innings, format)
+  const [allOutContinued, setAllOutContinued] = useState(false)
+  const [ballsContinued, setBallsContinued] = useState(false)
+  useEffect(() => {
+    if (!allOut) setAllOutContinued(false)
+  }, [allOut])
+  useEffect(() => {
+    if (!ballsComplete) setBallsContinued(false)
+  }, [ballsComplete])
+
+  // Concludes the match — same conflict-handling shape as
+  // `CricketLiveScoringPage.finishMatch`: the server independently derives
+  // the score from the persisted live detail and 409s if this device's view
+  // has fallen behind, surfaced rather than silently resolved.
+  const finishMatch = useMutation({
+    mutationFn: async () => {
+      if (!state) throw new Error('No score recorded yet')
+      const fresh = roundersScoreFrom(
+        queryClient.getQueryData<Score | null>(matchScoreQueryKey(match.id)),
+      )
+      const body: UpdateMatchInput = {
+        status: 'completed',
+        score: fresh ?? undefined,
+      }
+      const { error, response } = await fetchClient.PATCH('/matches/{match_id}', {
+        params: { path: { match_id: match.id } },
+        body,
+      })
+      if (response.status === 409) {
+        await queryClient.refetchQueries({ queryKey: matchScoreQueryKey(match.id) })
+        throw new Error('The live score just changed — check the updated score above, then finish again')
+      }
+      if (error) throw new Error('Failed to finish the match')
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['match', match.id] })
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
+      navigate(`/matches/${match.id}`)
+    },
+  })
+
+  if (scoreQuery.isLoading || seq.isLoading) {
+    return (
+      <div className="mx-auto max-w-xl">
+        <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
+      </div>
+    )
+  }
+
+  const header = (
+    <div className="flex items-center justify-between">
+      <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${match.id}`)}>
+        <ChevronLeft className="size-4" /> Back
+      </Button>
+      <div className="flex items-center gap-1">
+        <UndoLastEventButton matchId={match.id} seq={seq.data} />
+        <LiveIndicator />
+      </div>
+    </div>
+  )
+
+  // No innings open — either the match hasn't started, or we're between
+  // innings. Pick who's batting (the other side fields).
+  if (!innings) {
+    const inningsQuota = match.sides.length * format.innings_per_side
+    const allInningsComplete = !!state && state.innings.length >= inningsQuota
+
+    return (
+      <div className="mx-auto flex max-w-xl flex-col gap-4">
+        {header}
+        <div>
+          <h1 className="text-lg font-semibold">
+            {match.sides[0]?.name?.trim() || 'Side A'} vs {match.sides[1]?.name?.trim() || 'Side B'}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            {allInningsComplete
+              ? 'All innings complete'
+              : state && state.innings.length > 0
+                ? 'Start the next innings'
+                : "You're scoring this match"}
+          </p>
+        </div>
+        {state && state.innings.length > 0 && (
+          <div className="rounded-xl border bg-card p-4">
+            <div className="space-y-3">
+              {state.innings.map((inn, i) => (
+                <div key={i}>
+                  <p className="mb-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    {sideNameFor(match, inn.batting_side_id)}
+                  </p>
+                  <p className="text-2xl font-medium tracking-tight">
+                    {formatHalfRounders(inn.half_rounders)}
+                    <span className="ml-2 text-sm font-normal text-muted-foreground">
+                      ({inn.outs} out · {inn.good_balls_bowled} balls)
+                    </span>
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {!allInningsComplete && (
+          <>
+            <div className="rounded-xl border bg-card p-4">
+              <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Who's batting?
+              </p>
+              <SidePicker sides={match.sides} value={startBattingSide} onChange={setStartBattingSide} />
+            </div>
+            <Button
+              size="lg"
+              disabled={!startBattingSide || appendEvent.isPending}
+              onClick={() => {
+                const fieldingSideId = match.sides.find((s) => s.id !== startBattingSide)?.id
+                if (!startBattingSide || !fieldingSideId) return
+                appendEvent.mutate(
+                  {
+                    kind: 'InningsStart',
+                    batting_side_id: startBattingSide,
+                    fielding_side_id: fieldingSideId,
+                  },
+                  { onSuccess: () => setStartBattingSide(undefined) },
+                )
+              }}
+            >
+              {appendEvent.isPending ? 'Starting…' : 'Start innings'}
+            </Button>
+          </>
+        )}
+
+        {state && state.innings.length > 0 && (
+          <>
+            {!allInningsComplete && <p className="text-center text-xs text-muted-foreground">or</p>}
+            {finishMatch.isError && (
+              <p className="text-center text-xs text-destructive">
+                {(finishMatch.error as Error).message}
+              </p>
+            )}
+            <Button
+              variant={allInningsComplete ? 'default' : 'outline'}
+              size="lg"
+              disabled={finishMatch.isPending}
+              onClick={() => finishMatch.mutate()}
+            >
+              {finishMatch.isPending ? 'Finishing…' : 'Finish match'}
+            </Button>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  const battingSide = match.sides.find((s) => s.id === innings.batting_side_id)
+  const fieldingSide = match.sides.find((s) => s.id === innings.fielding_side_id)
+  const effectiveBowler = next?.bowler_player_id ?? pickedBowler
+  // A candidate for a movement this ball: the newly picked striker, plus
+  // every runner already on base — deduplicated in case a runner and the
+  // striker pick somehow coincide.
+  const candidates = Array.from(
+    new Set([...(pickedStriker ? [pickedStriker] : []), ...Object.keys(runnersOnBase)]),
+  )
+
+  const setOutcome = (playerId: string, patch: MovementDraft | undefined) =>
+    setOutcomes((o) => {
+      if (!patch) {
+        const rest = { ...o }
+        delete rest[playerId]
+        return rest
+      }
+      return { ...o, [playerId]: patch }
+    })
+
+  const resetBall = () => {
+    setPickedStriker(null)
+    setOutcomes({})
+    setNoBall(false)
+    setByes(false)
+  }
+
+  const recordDelivery = () => {
+    if (!effectiveBowler || !pickedStriker) return
+    const movements: RoundersRunnerMovement[] = candidates.flatMap((playerId): RoundersRunnerMovement[] => {
+      const o = outcomes[playerId]
+      if (!o) return []
+      if (o.out) {
+        return [{ player_id: playerId, out: { kind: o.out.kind, fielder_player_id: o.out.fielderId } }]
+      }
+      if (o.post) return [{ player_id: playerId, post_reached: o.post }]
+      return []
+    })
+    const delivery: RoundersDelivery = {
+      bowler_player_id: effectiveBowler,
+      striker_player_id: pickedStriker,
+      no_ball: noBall,
+      byes,
+      movements,
+    }
+    appendEvent.mutate({ kind: 'Delivery', ...delivery }, { onSuccess: resetBall })
+  }
+
+  const endInnings = (reason: RoundersInningsEndReason) => {
+    appendEvent.mutate(
+      { kind: 'InningsEnd', reason },
+      { onSuccess: () => setEndInningsOpen(false) },
+    )
+  }
+
+  const goodBallsLabel = format.good_balls_per_innings
+    ? `${innings.good_balls_bowled}/${format.good_balls_per_innings}`
+    : `${innings.good_balls_bowled}`
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4">
+      {header}
+
+      <div>
+        <h1 className="text-lg font-semibold">
+          {sideName(battingSide!, 'Side A')} vs {sideName(fieldingSide!, 'Side B')}
+        </h1>
+        <p className="text-sm text-muted-foreground">You're scoring this match</p>
+      </div>
+
+      <div className="rounded-xl border bg-card p-4">
+        <p className="text-sm font-medium">{sideName(battingSide!, 'Side A')} batting</p>
+        <p className="mt-0.5 text-3xl font-medium tracking-tight">
+          {formatHalfRounders(innings.half_rounders)}
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            ({innings.outs} out · {goodBallsLabel} balls)
+          </span>
+        </p>
+
+        {Object.keys(runnersOnBase).length > 0 && (
+          <div className="mt-3 space-y-1 border-t pt-3 text-sm">
+            {Object.entries(runnersOnBase).map(([playerId, post]) => (
+              <div key={playerId} className="flex items-center justify-between">
+                <span>{playerNameFor(match, playerId, state?.players) ?? '—'}</span>
+                <span className="text-xs text-muted-foreground">{postLabel(post)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {effectiveBowler && (
+          <div className="mt-1.5 flex items-center justify-between border-t pt-1.5 text-xs">
+            <span className="text-muted-foreground">
+              Bowling:{' '}
+              <span className="font-medium text-foreground">
+                {playerNameFor(match, effectiveBowler, state?.players) ?? '—'}
+              </span>
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-xl border bg-card p-4">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">Bowler</p>
+        <PlayerPicker
+          players={playersOnSide(match.players, fieldingSide!)}
+          value={effectiveBowler ?? undefined}
+          onChange={setPickedBowler}
+        />
+      </div>
+
+      <div className="rounded-xl border bg-card p-4">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Who's facing this ball?
+        </p>
+        <PlayerPicker
+          players={playersOnSide(match.players, battingSide!)}
+          value={pickedStriker ?? undefined}
+          exclude={[...Object.keys(runnersOnBase), ...outBatters]}
+          onChange={setPickedStriker}
+        />
+      </div>
+
+      <div className="flex gap-4">
+        <label className="flex items-center gap-1.5 text-sm">
+          <input type="checkbox" checked={noBall} onChange={(e) => setNoBall(e.target.checked)} />
+          No ball
+        </label>
+        <label className="flex items-center gap-1.5 text-sm">
+          <input type="checkbox" checked={byes} onChange={(e) => setByes(e.target.checked)} />
+          Byes
+        </label>
+      </div>
+
+      {candidates.length > 0 && (
+        <div className="flex flex-col gap-3">
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            What happened
+          </p>
+          {candidates.map((playerId) => (
+            <MovementRow
+              key={playerId}
+              name={playerNameFor(match, playerId, state?.players) ?? '—'}
+              fieldingRoster={playersOnSide(match.players, fieldingSide!)}
+              value={outcomes[playerId]}
+              onChange={(v) => setOutcome(playerId, v)}
+            />
+          ))}
+        </div>
+      )}
+
+      <Button
+        size="lg"
+        disabled={!effectiveBowler || !pickedStriker || appendEvent.isPending}
+        onClick={recordDelivery}
+      >
+        {appendEvent.isPending ? 'Recording…' : 'Record ball'}
+      </Button>
+
+      {appendEvent.isError && (
+        <p className="text-center text-xs text-destructive">
+          Failed to record that ball — try again.
+        </p>
+      )}
+
+      {endInningsOpen ? (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4">
+          <p className="mb-2 text-sm font-medium">End this innings — why?</p>
+          <div className="grid grid-cols-2 gap-2">
+            {END_REASONS.map((r) => (
+              <Button
+                key={r.value}
+                variant="outline"
+                size="sm"
+                disabled={appendEvent.isPending}
+                onClick={() => endInnings(r.value)}
+              >
+                {r.label}
+              </Button>
+            ))}
+          </div>
+          <Button variant="ghost" size="sm" className="mt-2" onClick={() => setEndInningsOpen(false)}>
+            Cancel
+          </Button>
+        </div>
+      ) : (
+        <Button variant="outline" onClick={() => setEndInningsOpen(true)}>
+          End innings
+        </Button>
+      )}
+
+      {allOut && (
+        <RoundersInningsCompleteDialog
+          open={!allOutContinued}
+          battingSideName={sideName(battingSide!, 'Side A')}
+          reason="all_batters_out"
+          submitting={appendEvent.isPending}
+          onEnd={() => endInnings('all_batters_out')}
+          onContinue={() => setAllOutContinued(true)}
+        />
+      )}
+
+      {ballsComplete && !allOut && (
+        <RoundersInningsCompleteDialog
+          open={!ballsContinued}
+          battingSideName={sideName(battingSide!, 'Side A')}
+          reason="good_balls_complete"
+          submitting={appendEvent.isPending}
+          onEnd={() => endInnings('good_balls_complete')}
+          onContinue={() => setBallsContinued(true)}
+        />
+      )}
+    </div>
+  )
+}
+
+/** One candidate's outcome picker for the current ball: stayed (default,
+ *  nothing picked), a post they reached, or out (with a kind and optional
+ *  fielder). */
+function MovementRow({
+  name,
+  fieldingRoster,
+  value,
+  onChange,
+}: {
+  name: string
+  fieldingRoster: components['schemas']['MatchPlayer'][]
+  value: MovementDraft | undefined
+  onChange: (v: MovementDraft | undefined) => void
+}) {
+  const isOut = !!value?.out
+
+  return (
+    <div className="rounded-lg border p-3">
+      <p className="mb-2 text-sm font-medium">{name}</p>
+      <div className="grid grid-cols-3 gap-1.5">
+        <button
+          type="button"
+          aria-pressed={!value}
+          onClick={() => onChange(undefined)}
+          className={`rounded border px-2 py-1.5 text-xs font-medium ${!value ? 'border-primary bg-accent' : 'text-muted-foreground'}`}
+        >
+          Stayed
+        </button>
+        {POSTS.map((post) => (
+          <button
+            key={post}
+            type="button"
+            aria-pressed={value?.post === post}
+            onClick={() => onChange({ post })}
+            className={`rounded border px-2 py-1.5 text-xs font-medium ${value?.post === post ? 'border-primary bg-accent' : 'text-muted-foreground'}`}
+          >
+            {postLabel(post)}
+          </button>
+        ))}
+        <button
+          type="button"
+          aria-pressed={isOut}
+          onClick={() => onChange({ out: { kind: value?.out?.kind ?? 'caught', fielderId: value?.out?.fielderId } })}
+          className={`rounded border px-2 py-1.5 text-xs font-medium ${isOut ? 'border-destructive bg-destructive/10 text-destructive' : 'text-muted-foreground'}`}
+        >
+          Out
+        </button>
+      </div>
+
+      {isOut && (
+        <div className="mt-2 flex flex-col gap-1.5 border-t pt-2">
+          <div className="grid grid-cols-2 gap-1">
+            {OUT_KINDS.map((k) => (
+              <button
+                key={k}
+                type="button"
+                aria-pressed={value?.out?.kind === k}
+                onClick={() => onChange({ out: { kind: k, fielderId: value?.out?.fielderId } })}
+                className={`rounded border px-1.5 py-1 text-[10px] ${value?.out?.kind === k ? 'border-primary bg-accent' : 'text-muted-foreground'}`}
+              >
+                {outKindLabel(k)}
+              </button>
+            ))}
+          </div>
+          <PlayerPicker
+            players={fieldingRoster}
+            value={value?.out?.fielderId}
+            emptyLabel="Fielder (optional)"
+            onChange={(id) =>
+              onChange({
+                out: { kind: value?.out?.kind ?? 'caught', fielderId: value?.out?.fielderId === id ? undefined : id },
+              })
+            }
+          />
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Adds Score::Rounders/LiveEventInput::Rounders/MatchFormat::Rounders end
to end: API types, the DAO record mirrors, mapping.rs conversions, and
the live-scoring fold (apply_delivery/RoundersScore::from_events).

Score model follows the cricket/football conventions already in the
codebase: innings-based totals with optional per-player detail, a
delivery-log event vocabulary reused verbatim from detailed_score, and
a next-ball context folded incrementally as events are recorded.

Rounders-specific pieces, informed by the official Rounders England
scoresheet and rules:
- Concurrent base runners (RoundersNextBallContext.runners_on_base)
  rather than cricket's fixed striker/non-striker pair, since several
  batters' hits can have runners on different posts at once.
- Full vs. half rounder is derived while folding (striker reaching the
  4th post in one hit vs. a runner who took more than one delivery to
  get there), not asserted by the client — same reasoning that keeps
  cricket's fours/sixes/maidens derived rather than stored as flags.
- good_balls_bowled/outs on the innings track the two ending
  conditions from the scoresheet's own tally grids ("Good balls",
  "Batters out"), surfaced via RoundersInningsEndReason.
- RoundersOut deliberately carries no player_id (always nested where
  the player is already known), mirroring CricketDismissal.

Includes unit tests for the fold (full/half rounder scoring, outs,
bowling spells, batting-order laps) and mapping round-trip tests for
the live event, match format, and score DAO mirrors.