### PR TITLE
Add netball as a supported sport with two live-scoring methods

### DIFF
--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -82,6 +82,27 @@ pub enum ScoreRecord {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         penalty_shootout_score: Option<HashMap<String, u32>>,
     },
+    Netball {
+        /// Goal tally, keyed by side id.
+        #[serde(default)]
+        score: HashMap<String, u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        goals: Option<Vec<NetballGoalEventRecord>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        fouls: Option<Vec<NetballFoulEventRecord>>,
+        /// The most recent period marker seen, if any.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        period: Option<NetballPeriodRecord>,
+        /// When each period marker was recorded, keyed by kind.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        period_times: Option<HashMap<NetballPeriodRecord, String>>,
+        /// The score as of each quarter-end marker, keyed by kind — the
+        /// *only* source of the score for a quarter-only-scored match. See
+        /// `agon_service::live_score::netball::NetballPeriodEvent::score`'s
+        /// doc comment.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        period_scores: Option<HashMap<NetballPeriodRecord, HashMap<String, u32>>>,
+    },
 }
 
 /// One innings' final totals, as stored on a match's confirmed/pending
@@ -429,6 +450,7 @@ pub struct MatchRecord {
 pub enum MatchFormatRecord {
     Football(FootballFormatRecord),
     Cricket(CricketFormatRecord),
+    Netball(NetballFormatRecord),
 }
 
 /// Mirrors `agon_service::match_format::FootballFormat`.
@@ -463,6 +485,15 @@ pub struct CricketFormatRecord {
 
 fn default_true() -> bool {
     true
+}
+
+/// Mirrors `agon_service::match_format::NetballFormat`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NetballFormatRecord {
+    pub num_quarters: u32,
+    pub quarter_length_minutes: u32,
+    pub two_point_zone: bool,
+    pub extra_time: bool,
 }
 
 /// `MATCH#<matchId>` / `SIDE#<sideId>` — one side of a match.
@@ -576,6 +607,7 @@ pub struct LiveEventRecord {
 pub enum LiveEventPayloadRecord {
     Football(FootballLiveEventRecord),
     Cricket(CricketLiveEventRecord),
+    Netball(NetballLiveEventRecord),
 }
 
 // ---- Football live events --------------------------------------------------
@@ -761,6 +793,86 @@ pub enum InningsEndReasonRecord {
     OversComplete,
     Declared,
     TargetReached,
+}
+
+// ---- Netball live events ----------------------------------------------------
+
+/// Mirrors `agon_service::live_score::netball::NetballLiveEvent`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum NetballLiveEventRecord {
+    Goal(NetballGoalEventRecord),
+    Foul(NetballFoulEventRecord),
+    Period(NetballPeriodEventRecord),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NetballGoalEventRecord {
+    pub side_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scorer_player_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scorer_position: Option<NetballPositionRecord>,
+    pub two_points: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minute: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum NetballPositionRecord {
+    GoalShooter,
+    GoalAttack,
+    WingAttack,
+    Centre,
+    WingDefence,
+    GoalDefence,
+    GoalKeeper,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NetballFoulEventRecord {
+    pub side_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub player_id: Option<String>,
+    /// Named `foul_kind`, not `kind` — same collision-avoidance as the API's
+    /// `NetballFoulEvent::foul_kind` (`NetballLiveEventRecord`'s own
+    /// `#[serde(tag = "kind")]` would otherwise fight this field over the
+    /// same wire key once serde flattens the variant's fields in).
+    pub foul_kind: NetballFoulKindRecord,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minute: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum NetballFoulKindRecord {
+    Contact,
+    Obstruction,
+    Footwork,
+    Offside,
+    HeldBall,
+    Other,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NetballPeriodEventRecord {
+    pub period: NetballPeriodRecord,
+    /// Cumulative score per side as of this marker — always present, same
+    /// reasoning as `agon_service::live_score::netball::NetballPeriodEvent`.
+    pub score: HashMap<String, u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum NetballPeriodRecord {
+    Start,
+    QuarterOneEnd,
+    QuarterTwoEnd,
+    QuarterThreeEnd,
+    FullTime,
+    ExtraTimeStart,
+    ExtraTimeEnd,
 }
 
 /// `MATCH#<matchId>` / `SCORESUB#<ts>#<subId>` — a score submission and its

--- a/agon_service/src/detailed_score/mod.rs
+++ b/agon_service/src/detailed_score/mod.rs
@@ -1,10 +1,11 @@
-//! Shared per-event/per-entry types used by `Score::Football`/`Score::Cricket`'s
-//! optional rich-detail fields (goals/cards/substitutions; batting/bowling
-//! cards, extras, fall-of-wickets) — reused verbatim by both the live-scoring
-//! event vocabulary (`live_score`) and the confirmable `Score` (`main.rs`).
-//! There's no separate "detailed score" type anymore: `Score` itself carries
-//! everything, live or finished, confirmed or not (see `Score`'s doc comment
-//! on `main.rs`).
+//! Shared per-event/per-entry types used by `Score::Football`/`Score::Cricket`/
+//! `Score::Netball`'s optional rich-detail fields (goals/cards/substitutions;
+//! batting/bowling cards, extras, fall-of-wickets; netball goals/fouls) —
+//! reused verbatim by both the live-scoring event vocabulary (`live_score`)
+//! and the confirmable `Score` (`main.rs`). There's no separate "detailed
+//! score" type anymore: `Score` itself carries everything, live or finished,
+//! confirmed or not (see `Score`'s doc comment on `main.rs`).
 
 pub mod cricket;
 pub mod football;
+pub mod netball;

--- a/agon_service/src/detailed_score/netball.rs
+++ b/agon_service/src/detailed_score/netball.rs
@@ -1,0 +1,112 @@
+use poem_openapi::{Enum, Object};
+
+/// GS/GA are the only positions that can legally shoot, but (same stance as
+/// `match_format::CricketFormat`'s doc comment) that isn't enforced here —
+/// purely descriptive, for stat display.
+#[derive(Enum, Debug, Clone, Copy, PartialEq, Eq)]
+#[oai(rename_all = "snake_case")]
+pub enum NetballPosition {
+    GoalShooter,
+    GoalAttack,
+    WingAttack,
+    Centre,
+    WingDefence,
+    GoalDefence,
+    GoalKeeper,
+}
+
+#[derive(Object, Clone)]
+pub struct NetballGoalEvent {
+    /// The side this goal counts for.
+    pub side_id: String,
+    pub scorer_player_id: Option<String>,
+    pub scorer_position: Option<NetballPosition>,
+    /// Fast5/Power-Play-style two-point zone. `false` for standard scoring,
+    /// where every goal is worth one.
+    pub two_points: bool,
+    /// Minutes elapsed in the *current quarter*, not match-wide — netball's
+    /// clock resets each quarter, unlike football's continuous minute.
+    pub minute: Option<u32>,
+}
+
+#[derive(Enum, Debug, Clone, Copy, PartialEq, Eq)]
+#[oai(rename_all = "snake_case")]
+pub enum NetballFoulKind {
+    Contact,
+    Obstruction,
+    Footwork,
+    Offside,
+    HeldBall,
+    Other,
+}
+
+/// A non-scoring infringement — recorded for stats only, same role as
+/// `FootballCardEvent`. Doesn't touch `score`.
+#[derive(Object, Clone)]
+pub struct NetballFoulEvent {
+    /// The side penalised (the conceding side, not the side benefiting).
+    pub side_id: String,
+    /// The offending player, when tracked — a casual scorer may log fouls
+    /// against the side only.
+    pub player_id: Option<String>,
+    /// Named `foul_kind`, not `kind` — `NetballLiveEvent`'s own
+    /// discriminator (`Goal`/`Foul`/`Period`) is itself called `kind`, and
+    /// nesting a *second*, differently-typed `kind` field inside the `Foul`
+    /// variant would collide with it once flattened onto the same JSON
+    /// object (the two would fight over one wire key). `NetballGoalEvent`
+    /// has no such field, so it doesn't need the same care.
+    pub foul_kind: NetballFoulKind,
+    pub minute: Option<u32>,
+}
+
+/// A netball match's quarters, plus an optional golden-goal-style decider if
+/// still level after full time — same shape/role as `FootballPeriod`.
+#[derive(Enum, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[oai(rename_all = "snake_case")]
+pub enum NetballPeriod {
+    /// First centre pass — the moment the match clock actually starts.
+    Start,
+    QuarterOneEnd,
+    /// = half time.
+    QuarterTwoEnd,
+    QuarterThreeEnd,
+    FullTime,
+    ExtraTimeStart,
+    ExtraTimeEnd,
+}
+
+/// `ToString`/`FromStr` (via `Display`) mirroring the `#[oai(rename_all =
+/// "snake_case")]` wire form above — needed so `NetballPeriod` can be used as
+/// a `HashMap` key (`period_times`/`period_scores`), which poem-openapi
+/// represents as a plain JSON object keyed by this string form. Same
+/// convention as `FootballPeriod`.
+impl std::fmt::Display for NetballPeriod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            NetballPeriod::Start => "start",
+            NetballPeriod::QuarterOneEnd => "quarter_one_end",
+            NetballPeriod::QuarterTwoEnd => "quarter_two_end",
+            NetballPeriod::QuarterThreeEnd => "quarter_three_end",
+            NetballPeriod::FullTime => "full_time",
+            NetballPeriod::ExtraTimeStart => "extra_time_start",
+            NetballPeriod::ExtraTimeEnd => "extra_time_end",
+        })
+    }
+}
+
+impl std::str::FromStr for NetballPeriod {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "start" => Ok(NetballPeriod::Start),
+            "quarter_one_end" => Ok(NetballPeriod::QuarterOneEnd),
+            "quarter_two_end" => Ok(NetballPeriod::QuarterTwoEnd),
+            "quarter_three_end" => Ok(NetballPeriod::QuarterThreeEnd),
+            "full_time" => Ok(NetballPeriod::FullTime),
+            "extra_time_start" => Ok(NetballPeriod::ExtraTimeStart),
+            "extra_time_end" => Ok(NetballPeriod::ExtraTimeEnd),
+            other => Err(format!("unknown netball period: {other}")),
+        }
+    }
+}

--- a/agon_service/src/live_score/mod.rs
+++ b/agon_service/src/live_score/mod.rs
@@ -20,9 +20,11 @@ use poem_openapi::{Object, Union};
 
 pub mod cricket;
 pub mod football;
+pub mod netball;
 
 pub use cricket::CricketLiveEvent;
 pub use football::FootballLiveEvent;
+pub use netball::NetballLiveEvent;
 
 /// A single live-scoring event, sport-first discriminated so a new sport is a
 /// new variant without touching existing ones — same pattern as `Score`.
@@ -33,6 +35,7 @@ pub use football::FootballLiveEvent;
 pub enum LiveEventInput {
     Football(FootballLiveEvent),
     Cricket(CricketLiveEvent),
+    Netball(NetballLiveEvent),
 }
 
 /// One event to append, before the server has assigned it a `seq`.
@@ -118,6 +121,49 @@ mod tests {
             LiveEventInput::Football(FootballLiveEvent::Card(c)) => {
                 assert_eq!(c.player_id, "p1");
                 assert_eq!(c.minute, Some(58));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    /// `NetballFoulEvent::foul_kind` must survive serialization distinctly
+    /// from `NetballLiveEvent`'s own `kind` discriminator (`Goal`/`Foul`/
+    /// `Period`) once the two are flattened onto the same JSON object —
+    /// regression test for exactly this collision, which previously silently
+    /// dropped the foul's own kind (a naming clash, `NetballFoulEvent` field
+    /// also called `kind`, that `NetballGoalEvent`/`NetballPeriodEvent` don't
+    /// have — see `NetballFoulEvent::foul_kind`'s doc comment).
+    #[test]
+    fn netball_foul_kind_does_not_collide_with_the_outer_discriminator() {
+        use crate::detailed_score::netball::{NetballFoulEvent, NetballFoulKind};
+        use crate::live_score::netball::NetballLiveEvent;
+
+        let event = LiveEventInput::Netball(NetballLiveEvent::Foul(NetballFoulEvent {
+            side_id: "side_a".into(),
+            player_id: Some("p1".into()),
+            foul_kind: NetballFoulKind::Contact,
+            minute: Some(10),
+        }));
+
+        let json = event.to_json().expect("serializes");
+        let obj = json.as_object().expect("flat object, not a wrapper");
+        assert_eq!(obj.get("sport").and_then(|v| v.as_str()), Some("Netball"));
+        // The outer union's own discriminator.
+        assert_eq!(obj.get("kind").and_then(|v| v.as_str()), Some("Foul"));
+        // The foul's own kind, under its own (non-colliding) key.
+        assert_eq!(
+            obj.get("foul_kind").and_then(|v| v.as_str()),
+            Some("contact")
+        );
+
+        let parsed = match LiveEventInput::parse_from_json(Some(json)) {
+            Ok(v) => v,
+            Err(_) => panic!("failed to parse back"),
+        };
+        match parsed {
+            LiveEventInput::Netball(NetballLiveEvent::Foul(fo)) => {
+                assert!(matches!(fo.foul_kind, NetballFoulKind::Contact));
+                assert_eq!(fo.player_id.as_deref(), Some("p1"));
             }
             _ => panic!("wrong variant"),
         }

--- a/agon_service/src/live_score/netball.rs
+++ b/agon_service/src/live_score/netball.rs
@@ -1,0 +1,284 @@
+use std::collections::HashMap;
+
+use poem_openapi::{Object, Union};
+
+use crate::NetballScore;
+use crate::detailed_score::netball::{NetballFoulEvent, NetballGoalEvent, NetballPeriod};
+
+/// Netball live-scoring events, nested under the outer sport union
+/// (`LiveEventInput::Netball`), discriminated by `kind`. Corrections are
+/// handled by directly deleting or amending the stored event (see
+/// `DELETE`/`PATCH /matches/:id/live/events/:seq`), not a variant here.
+///
+/// The same three variants serve both of netball's live-scoring methods —
+/// there's no separate vocabulary per method:
+///
+/// - **Event-by-event**: `Goal`/`Foul` as they happen, plus a `Period`
+///   marker at each quarter's end for time-tracking. `NetballScore::score`
+///   is folded from `Goal` events; the `Period` marker's own `score` should
+///   just agree with that running total (see `NetballPeriodEvent::score`'s
+///   doc comment for what happens if it doesn't).
+/// - **Quarter-only**: no `Goal`/`Foul` events at all — just a `Period`
+///   marker at each quarter's end, each one carrying the score directly.
+///   `NetballScore::score` comes *only* from these markers.
+#[derive(Union, Clone)]
+#[oai(one_of, discriminator_name = "kind")]
+pub enum NetballLiveEvent {
+    Goal(NetballGoalEvent),
+    Foul(NetballFoulEvent),
+    Period(NetballPeriodEvent),
+}
+
+#[derive(Object, Clone)]
+pub struct NetballPeriodEvent {
+    pub period: NetballPeriod,
+    /// Cumulative score per side as of this marker — always present, not
+    /// `Option`, unlike `FootballPeriodEvent` (which carries no score at
+    /// all, since football's score is always derivable from `Goal` events
+    /// alone). This is what lets both of netball's live-scoring methods
+    /// share one event vocabulary: for event-by-event scoring this is a
+    /// checkpoint that should already agree with the total folded from
+    /// `Goal` events; for quarter-only scoring it's the *only* place the
+    /// score ever comes from. Either way, `NetballScore::apply_event`
+    /// simply overwrites `score` with this value — it doesn't need to know
+    /// which method a given match is using.
+    pub score: HashMap<String, u32>,
+}
+
+impl NetballScore {
+    /// Folds the whole event log into a `NetballScore` from scratch — the
+    /// slow path, used to bootstrap a match's first score or recover from a
+    /// missing/unparseable persisted record. Just `apply_event` run once per
+    /// event in order; the fast (single-event) and slow (whole-log) paths
+    /// share the exact same fold, so they can't disagree — same pattern as
+    /// `FootballScore::from_events`.
+    pub fn from_events(events: &[(chrono::DateTime<chrono::Utc>, NetballLiveEvent)]) -> Self {
+        let mut score = NetballScore {
+            score: HashMap::new(),
+            goals: Some(Vec::new()),
+            fouls: Some(Vec::new()),
+            period: None,
+            period_times: Some(HashMap::new()),
+            period_scores: Some(HashMap::new()),
+            players: HashMap::new(),
+        };
+        for (occurred_at, event) in events {
+            score.apply_event(*occurred_at, event);
+        }
+        score
+    }
+
+    /// Folds one new event into this score in place — the fast path, run on
+    /// every append. `occurred_at` (not `recorded_at`) is threaded through
+    /// separately from `event`, same reasoning as `FootballScore::apply_event`.
+    pub fn apply_event(
+        &mut self,
+        occurred_at: chrono::DateTime<chrono::Utc>,
+        event: &NetballLiveEvent,
+    ) {
+        match event {
+            NetballLiveEvent::Goal(g) => {
+                *self.score.entry(g.side_id.clone()).or_insert(0) +=
+                    if g.two_points { 2 } else { 1 };
+                self.goals.get_or_insert_with(Vec::new).push(g.clone());
+            }
+            NetballLiveEvent::Foul(fo) => {
+                self.fouls.get_or_insert_with(Vec::new).push(fo.clone());
+            }
+            NetballLiveEvent::Period(p) => {
+                self.period_times
+                    .get_or_insert_with(HashMap::new)
+                    .insert(p.period, occurred_at);
+                self.period_scores
+                    .get_or_insert_with(HashMap::new)
+                    .insert(p.period, p.score.clone());
+                // The one line that unifies both live-scoring methods — see
+                // `NetballPeriodEvent::score`'s doc comment.
+                self.score = p.score.clone();
+                self.period = Some(p.period);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detailed_score::netball::{NetballFoulKind, NetballPosition};
+    use chrono::{DateTime, TimeZone, Utc};
+
+    fn ts(minute: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_700_000_000 + minute * 60, 0).unwrap()
+    }
+
+    fn goal(side_id: &str, minute: u32) -> NetballLiveEvent {
+        NetballLiveEvent::Goal(NetballGoalEvent {
+            side_id: side_id.into(),
+            scorer_player_id: Some("shooter_1".into()),
+            scorer_position: Some(NetballPosition::GoalShooter),
+            two_points: false,
+            minute: Some(minute),
+        })
+    }
+
+    #[test]
+    fn event_by_event_mode_derives_score_from_goals() {
+        let events = vec![
+            (ts(0), goal("kestrels", 2)),
+            (ts(1), goal("kestrels", 5)),
+            (ts(2), goal("harriers", 9)),
+            (
+                ts(3),
+                NetballLiveEvent::Foul(NetballFoulEvent {
+                    side_id: "harriers".into(),
+                    player_id: Some("defender_1".into()),
+                    foul_kind: NetballFoulKind::Contact,
+                    minute: Some(10),
+                }),
+            ),
+            (
+                ts(4),
+                NetballLiveEvent::Period(NetballPeriodEvent {
+                    period: NetballPeriod::QuarterOneEnd,
+                    score: HashMap::from([
+                        ("kestrels".to_string(), 2),
+                        ("harriers".to_string(), 1),
+                    ]),
+                }),
+            ),
+        ];
+
+        let score = NetballScore::from_events(&events);
+
+        assert_eq!(score.score.get("kestrels"), Some(&2));
+        assert_eq!(score.score.get("harriers"), Some(&1));
+        assert_eq!(score.goals.as_ref().unwrap().len(), 3);
+        assert_eq!(score.fouls.as_ref().unwrap().len(), 1);
+        assert!(matches!(score.period, Some(NetballPeriod::QuarterOneEnd)));
+        assert_eq!(
+            score
+                .period_scores
+                .as_ref()
+                .unwrap()
+                .get(&NetballPeriod::QuarterOneEnd),
+            Some(&HashMap::from([
+                ("kestrels".to_string(), 2),
+                ("harriers".to_string(), 1)
+            ]))
+        );
+        assert_eq!(
+            score
+                .period_times
+                .as_ref()
+                .unwrap()
+                .get(&NetballPeriod::QuarterOneEnd),
+            Some(&ts(4))
+        );
+    }
+
+    #[test]
+    fn quarter_only_mode_derives_score_purely_from_period_markers() {
+        // No Goal/Foul events at all — just quarter-end markers, each
+        // carrying the running score directly.
+        let events = vec![
+            (
+                ts(15),
+                NetballLiveEvent::Period(NetballPeriodEvent {
+                    period: NetballPeriod::QuarterOneEnd,
+                    score: HashMap::from([
+                        ("kestrels".to_string(), 12),
+                        ("harriers".to_string(), 9),
+                    ]),
+                }),
+            ),
+            (
+                ts(30),
+                NetballLiveEvent::Period(NetballPeriodEvent {
+                    period: NetballPeriod::QuarterTwoEnd,
+                    score: HashMap::from([
+                        ("kestrels".to_string(), 22),
+                        ("harriers".to_string(), 18),
+                    ]),
+                }),
+            ),
+        ];
+
+        let score = NetballScore::from_events(&events);
+
+        assert_eq!(score.score.get("kestrels"), Some(&22));
+        assert_eq!(score.score.get("harriers"), Some(&18));
+        assert!(score.goals.as_ref().unwrap().is_empty());
+        assert!(matches!(score.period, Some(NetballPeriod::QuarterTwoEnd)));
+        assert_eq!(score.period_scores.as_ref().unwrap().len(), 2);
+        // Q1's snapshot survives untouched alongside Q2's.
+        assert_eq!(
+            score
+                .period_scores
+                .as_ref()
+                .unwrap()
+                .get(&NetballPeriod::QuarterOneEnd),
+            Some(&HashMap::from([
+                ("kestrels".to_string(), 12),
+                ("harriers".to_string(), 9)
+            ]))
+        );
+    }
+
+    #[test]
+    fn two_point_goals_count_double() {
+        let events = vec![(
+            ts(0),
+            NetballLiveEvent::Goal(NetballGoalEvent {
+                side_id: "kestrels".into(),
+                scorer_player_id: Some("shooter_1".into()),
+                scorer_position: Some(NetballPosition::GoalAttack),
+                two_points: true,
+                minute: Some(4),
+            }),
+        )];
+
+        let score = NetballScore::from_events(&events);
+        assert_eq!(score.score.get("kestrels"), Some(&2));
+    }
+
+    #[test]
+    fn incremental_and_full_fold_agree() {
+        let events = vec![
+            (ts(0), goal("kestrels", 2)),
+            (ts(1), goal("harriers", 5)),
+            (
+                ts(2),
+                NetballLiveEvent::Period(NetballPeriodEvent {
+                    period: NetballPeriod::QuarterOneEnd,
+                    score: HashMap::from([
+                        ("kestrels".to_string(), 1),
+                        ("harriers".to_string(), 1),
+                    ]),
+                }),
+            ),
+        ];
+
+        let full = NetballScore::from_events(&events);
+
+        let mut incremental = NetballScore {
+            score: HashMap::new(),
+            goals: Some(Vec::new()),
+            fouls: Some(Vec::new()),
+            period: None,
+            period_times: Some(HashMap::new()),
+            period_scores: Some(HashMap::new()),
+            players: HashMap::new(),
+        };
+        for (occurred_at, event) in &events {
+            incremental.apply_event(*occurred_at, event);
+        }
+
+        assert_eq!(incremental.score, full.score);
+        assert_eq!(
+            incremental.goals.as_ref().unwrap().len(),
+            full.goals.as_ref().unwrap().len()
+        );
+        assert_eq!(incremental.period_times, full.period_times);
+        assert_eq!(incremental.period_scores, full.period_scores);
+    }
+}

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -66,6 +66,7 @@ use detailed_score::{
         FootballCardEvent, FootballGoalEvent, FootballPenaltyShootoutKick, FootballPeriod,
         FootballSubstitutionEvent,
     },
+    netball::{NetballFoulEvent, NetballGoalEvent, NetballPeriod},
 };
 
 mod live_score;
@@ -350,6 +351,10 @@ enum Score {
     /// completed football match — live-scored or manually entered. Carries
     /// enough to render the feed/detail goal ticker without a separate fetch.
     Football(FootballScore),
+    /// Goals scored (plus optional fouls and per-quarter breakdown), the
+    /// result of a completed netball match — live-scored (either
+    /// event-by-event or quarter-only) or manually entered.
+    Netball(NetballScore),
 }
 
 #[derive(Object)]
@@ -495,6 +500,43 @@ struct FootballScore {
     players: HashMap<String, RosterPreviewPlayer>,
 }
 
+/// A netball match's result: the goal tally, plus optional richer detail.
+/// See `live_score::netball`'s doc comment for how the two live-scoring
+/// methods (event-by-event, quarter-only) both fold into this one shape.
+#[derive(Object)]
+struct NetballScore {
+    /// Goal tally, keyed by side id — exactly one entry per side, same
+    /// "map, not a list" convention as `FootballScore.score`. In
+    /// event-by-event mode this is folded from `goals`; in quarter-only mode
+    /// it's just whatever the last `Period` marker said.
+    score: HashMap<String, u32>,
+    /// Every goal scored, if there's a goal-by-goal breakdown to hand over —
+    /// `None` for a quarter-only-scored or manually-entered result, which
+    /// has no such detail. Reuses `detailed_score::netball::NetballGoalEvent`
+    /// verbatim.
+    goals: Option<Vec<NetballGoalEvent>>,
+    /// Non-scoring infringements, for stat display — same role as
+    /// `FootballScore.cards`. `None` for a quarter-only-scored or
+    /// manually-entered result.
+    fouls: Option<Vec<NetballFoulEvent>>,
+    /// The most recent period marker seen, if any. `None` for a result with
+    /// no live detail behind it.
+    period: Option<NetballPeriod>,
+    /// When each period marker was recorded, keyed by kind — same convention
+    /// as `FootballScore.period_times`.
+    period_times: Option<HashMap<NetballPeriod, chrono::DateTime<chrono::Utc>>>,
+    /// The score *as of* each quarter-end marker — this is what lets a
+    /// client render "Q1 12-9, Q2 22-18, ..." regardless of which
+    /// live-scoring method produced it (see `live_score::netball::
+    /// NetballPeriodEvent::score`'s doc comment).
+    period_scores: Option<HashMap<NetballPeriod, HashMap<String, u32>>>,
+    /// Live name/avatar for every player id referenced anywhere else in this
+    /// score — goals' scorer, fouls' player — keyed by that same
+    /// (match-scoped) player id. Same mechanism and rationale as
+    /// `FootballScore.players`.
+    players: HashMap<String, RosterPreviewPlayer>,
+}
+
 /// The sport a match was played in. Determines the expected `Score` shape
 /// (e.g. racket sports use `Score::Sets`, football uses `Score::Football`,
 /// and cricket uses `Score::Cricket`). Extend as more sports are supported.
@@ -507,6 +549,7 @@ pub enum MatchType {
     TableTennis,
     Football,
     Cricket,
+    Netball,
     /// Fallback for sports not yet modelled explicitly.
     Other,
 }
@@ -2613,6 +2656,7 @@ impl Api {
                     .flat_map(|i| [i.batting_side_id.as_str(), i.bowling_side_id.as_str()])
                     .collect(),
                 Score::Football(s) => s.score.keys().map(|k| k.as_str()).collect(),
+                Score::Netball(s) => s.score.keys().map(|k| k.as_str()).collect(),
             };
             if score_sides.iter().any(|sid| !valid_sides.contains(sid)) {
                 return Ok(UpdateMatchResponse::ValidationError(PlainText(
@@ -3173,8 +3217,16 @@ impl Api {
                     s.apply_event(e.occurred_at, event);
                 }
             }
-            // Live scoring only ever creates a `Cricket`/`Football` record
-            // for this match_id/sport pair — unreachable in practice.
+            Score::Netball(s) => {
+                for e in new_events {
+                    let LiveEventInput::Netball(event) = &e.event else {
+                        return Ok(None);
+                    };
+                    s.apply_event(e.occurred_at, event);
+                }
+            }
+            // Live scoring only ever creates a `Cricket`/`Football`/`Netball`
+            // record for this match_id/sport pair — unreachable in practice.
             Score::Simple(_) | Score::Sets(_) => return Ok(None),
         }
 
@@ -5286,6 +5338,66 @@ fn resolve_score_ids(
                 players: HashMap::new(),
             }))
         }
+        Score::Netball(s) => {
+            let mut score = HashMap::with_capacity(s.score.len());
+            for (side_id, goals) in &s.score {
+                score.insert(map(side_id)?, *goals);
+            }
+            let goals = match &s.goals {
+                Some(gs) => {
+                    let mut out = Vec::with_capacity(gs.len());
+                    for g in gs {
+                        out.push(NetballGoalEvent {
+                            side_id: map(&g.side_id)?,
+                            scorer_player_id: pmap_opt(&g.scorer_player_id)?,
+                            scorer_position: g.scorer_position,
+                            two_points: g.two_points,
+                            minute: g.minute,
+                        });
+                    }
+                    Some(out)
+                }
+                None => None,
+            };
+            let fouls = match &s.fouls {
+                Some(fs) => {
+                    let mut out = Vec::with_capacity(fs.len());
+                    for fo in fs {
+                        out.push(NetballFoulEvent {
+                            side_id: map(&fo.side_id)?,
+                            player_id: pmap_opt(&fo.player_id)?,
+                            foul_kind: fo.foul_kind,
+                            minute: fo.minute,
+                        });
+                    }
+                    Some(out)
+                }
+                None => None,
+            };
+            let period_scores = match &s.period_scores {
+                Some(pss) => {
+                    let mut out = HashMap::with_capacity(pss.len());
+                    for (period, entries) in pss {
+                        let mut mapped = HashMap::with_capacity(entries.len());
+                        for (side_id, goals) in entries {
+                            mapped.insert(map(side_id)?, *goals);
+                        }
+                        out.insert(*period, mapped);
+                    }
+                    Some(out)
+                }
+                None => None,
+            };
+            Some(Score::Netball(NetballScore {
+                score,
+                goals,
+                fouls,
+                period: s.period,
+                period_times: s.period_times.clone(),
+                period_scores,
+                players: HashMap::new(),
+            }))
+        }
     }
 }
 
@@ -5296,6 +5408,7 @@ fn set_score_players(score: &mut Score, resolved: HashMap<String, RosterPreviewP
     match score {
         Score::Cricket(s) => s.players = resolved,
         Score::Football(s) => s.players = resolved,
+        Score::Netball(s) => s.players = resolved,
         Score::Simple(_) | Score::Sets(_) => {}
     }
 }
@@ -5336,6 +5449,7 @@ fn score_player_ids(score: &Score) -> Vec<String> {
     match score {
         Score::Cricket(s) => cricket_score_player_ids(s),
         Score::Football(s) => football_score_player_ids(s),
+        Score::Netball(s) => netball_score_player_ids(s),
         Score::Simple(_) | Score::Sets(_) => Vec::new(),
     }
 }
@@ -5401,6 +5515,20 @@ fn football_score_player_ids(score: &FootballScore) -> Vec<String> {
     ids
 }
 
+/// Every player id referenced in a `NetballScore`: each goal's scorer, each
+/// foul's player. Same "may repeat, deduped downstream" contract as
+/// [`cricket_score_player_ids`].
+fn netball_score_player_ids(score: &NetballScore) -> Vec<String> {
+    let mut ids = Vec::new();
+    for goal in score.goals.iter().flatten() {
+        ids.extend(goal.scorer_player_id.clone());
+    }
+    for foul in score.fouls.iter().flatten() {
+        ids.extend(foul.player_id.clone());
+    }
+    ids
+}
+
 /// Derives the winner (when decidable) from a live-scored match's persisted
 /// score — used by `update_match` to finish a live-scored match without the
 /// client having to work out and resubmit a margin the server already has
@@ -5436,6 +5564,9 @@ fn winner_from_score(score: &Score, side_ids: &[String]) -> Option<String> {
                 *totals.entry(i.batting_side_id.as_str()).or_insert(0) += i.runs;
             }
             two_side_winner(side_ids, |sid| *totals.get(sid).unwrap_or(&0) as i64)
+        }
+        Score::Netball(s) => {
+            two_side_winner(side_ids, |sid| *s.score.get(sid).unwrap_or(&0) as i64)
         }
         Score::Simple(_) | Score::Sets(_) => None,
     }

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -61,11 +61,11 @@ use agon_core::dao::records::{
     InningsEndReasonRecord, InvitationContextRecord, InvitationKindRecord, InvitationRecord,
     LiveEventPayloadRecord, LiveEventRecord, MatchFormatRecord, MatchLikeRecord, MatchPlayerRecord,
     MatchRecord, MatchScoreRecord, MatchSideRecord, NetballFormatRecord, NetballFoulEventRecord,
-    NetballFoulKindRecord, NetballGoalEventRecord, NetballLiveEventRecord, NetballPeriodEventRecord,
-    NetballPeriodRecord, NetballPositionRecord, NextBallContextRecord, NotificationKindRecord,
-    NotificationRecord, OversRecord, PendingScoreRecord, ScoreConfirmationRecord, ScoreRecord,
-    ScoreResponseRecord, ScoreSubmissionRecord, TeamMemberRecord, TeamRecord, UserRecord,
-    UserSportStatsRecord,
+    NetballFoulKindRecord, NetballGoalEventRecord, NetballLiveEventRecord,
+    NetballPeriodEventRecord, NetballPeriodRecord, NetballPositionRecord, NextBallContextRecord,
+    NotificationKindRecord, NotificationRecord, OversRecord, PendingScoreRecord,
+    ScoreConfirmationRecord, ScoreRecord, ScoreResponseRecord, ScoreSubmissionRecord,
+    TeamMemberRecord, TeamRecord, UserRecord, UserSportStatsRecord,
 };
 
 /// Parse an RFC-3339 timestamp string stored by the DAO into a UTC datetime,
@@ -1407,7 +1407,10 @@ fn netball_goal_event_from_record(rec: &NetballGoalEventRecord) -> NetballGoalEv
     NetballGoalEvent {
         side_id: rec.side_id.clone(),
         scorer_player_id: rec.scorer_player_id.clone(),
-        scorer_position: rec.scorer_position.as_ref().map(netball_position_from_record),
+        scorer_position: rec
+            .scorer_position
+            .as_ref()
+            .map(netball_position_from_record),
         two_points: rec.two_points,
         minute: rec.minute,
     }
@@ -1773,9 +1776,7 @@ pub fn derive_live_score(
                     LiveEventPayloadRecord::Football(f) => {
                         Some((parse_ts(&r.occurred_at), football_live_event_from_record(f)))
                     }
-                    LiveEventPayloadRecord::Cricket(_) | LiveEventPayloadRecord::Netball(_) => {
-                        None
-                    }
+                    LiveEventPayloadRecord::Cricket(_) | LiveEventPayloadRecord::Netball(_) => None,
                 })
                 .collect();
             Some(Score::Football(FootballScore::from_events(&events)))
@@ -2076,10 +2077,7 @@ mod tests {
             }),
             NetballLiveEvent::Period(NetballPeriodEvent {
                 period: NetballPeriod::QuarterOneEnd,
-                score: HashMap::from([
-                    ("kestrels".to_string(), 12),
-                    ("harriers".to_string(), 9),
-                ]),
+                score: HashMap::from([("kestrels".to_string(), 12), ("harriers".to_string(), 9)]),
             }),
         ];
 
@@ -2322,10 +2320,7 @@ mod tests {
                     ),
                     (
                         NetballPeriod::FullTime,
-                        HashMap::from([
-                            ("kestrels".to_string(), 45),
-                            ("harriers".to_string(), 38),
-                        ]),
+                        HashMap::from([("kestrels".to_string(), 45), ("harriers".to_string(), 38)]),
                     ),
                 ])),
                 players: HashMap::new(),

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -16,6 +16,9 @@ use crate::detailed_score::football::{
     FootballCardColor, FootballCardEvent, FootballGoalEvent, FootballPenaltyShootoutKick,
     FootballPeriod, FootballSubstitutionEvent,
 };
+use crate::detailed_score::netball::{
+    NetballFoulEvent, NetballFoulKind, NetballGoalEvent, NetballPeriod, NetballPosition,
+};
 use crate::live_score::{
     LiveEvent, LiveEventInput, NewLiveEventInput,
     cricket::{
@@ -23,8 +26,9 @@ use crate::live_score::{
         InningsEndReason,
     },
     football::{FootballLiveEvent, FootballPeriodEvent},
+    netball::{NetballLiveEvent, NetballPeriodEvent},
 };
-use crate::match_format::{CricketFormat, FootballFormat, MatchFormat};
+use crate::match_format::{CricketFormat, FootballFormat, MatchFormat, NetballFormat};
 use crate::membership::{
     ExternalMember, Invitation, InvitationContext, InvitationKind, InvitationMatchContext,
     InvitationStatus, InvitationTeamContext, Member, TokenInvitation, UserInvitation, UserMember,
@@ -37,10 +41,10 @@ use crate::notification::{
 use crate::team::{Team, TeamListItem, TeamMember, TeamRole};
 use crate::{
     Comment, ConfirmedScore, CricketScore, CricketScoreInnings, FeedMatch, FootballScore, Location,
-    Match, MatchOutcome, MatchPlayer, MatchSide, MatchSocial, MatchStatus, MatchType, PendingScore,
-    Photo, RosterPreviewPlayer, Score, ScoreConfirmation, ScoreResponseKind, ScoreSubmission,
-    ScoreSubmissionResponse, ScoreSubmissionStatus, SearchMatch, SetsScore, SimpleScore,
-    UserProfile, UserSportStats,
+    Match, MatchOutcome, MatchPlayer, MatchSide, MatchSocial, MatchStatus, MatchType, NetballScore,
+    PendingScore, Photo, RosterPreviewPlayer, Score, ScoreConfirmation, ScoreResponseKind,
+    ScoreSubmission, ScoreSubmissionResponse, ScoreSubmissionStatus, SearchMatch, SetsScore,
+    SimpleScore, UserProfile, UserSportStats,
 };
 use agon_core::dao::error::DaoError;
 use agon_core::dao::live_score_ops::NewLiveEvent;
@@ -56,7 +60,9 @@ use agon_core::dao::records::{
     FootballPeriodEventRecord, FootballPeriodRecord, FootballSubstitutionEventRecord,
     InningsEndReasonRecord, InvitationContextRecord, InvitationKindRecord, InvitationRecord,
     LiveEventPayloadRecord, LiveEventRecord, MatchFormatRecord, MatchLikeRecord, MatchPlayerRecord,
-    MatchRecord, MatchScoreRecord, MatchSideRecord, NextBallContextRecord, NotificationKindRecord,
+    MatchRecord, MatchScoreRecord, MatchSideRecord, NetballFormatRecord, NetballFoulEventRecord,
+    NetballFoulKindRecord, NetballGoalEventRecord, NetballLiveEventRecord, NetballPeriodEventRecord,
+    NetballPeriodRecord, NetballPositionRecord, NextBallContextRecord, NotificationKindRecord,
     NotificationRecord, OversRecord, PendingScoreRecord, ScoreConfirmationRecord, ScoreRecord,
     ScoreResponseRecord, ScoreSubmissionRecord, TeamMemberRecord, TeamRecord, UserRecord,
     UserSportStatsRecord,
@@ -94,6 +100,7 @@ pub fn match_type_from_tag(tag: &str) -> MatchType {
         "table_tennis" => MatchType::TableTennis,
         "football" => MatchType::Football,
         "cricket" => MatchType::Cricket,
+        "netball" => MatchType::Netball,
         _ => MatchType::Other,
     }
 }
@@ -107,6 +114,7 @@ pub fn match_type_tag(mt: &MatchType) -> &'static str {
         MatchType::TableTennis => "table_tennis",
         MatchType::Football => "football",
         MatchType::Cricket => "cricket",
+        MatchType::Netball => "netball",
         MatchType::Other => "other",
     }
 }
@@ -243,6 +251,35 @@ pub fn score_from_record(rec: &ScoreRecord) -> Score {
                     .collect()
             }),
             penalty_shootout_score: penalty_shootout_score.clone(),
+            // Not stored — `Api::hydrate_score_players` fills this afterward.
+            players: std::collections::HashMap::new(),
+        }),
+        ScoreRecord::Netball {
+            score,
+            goals,
+            fouls,
+            period,
+            period_times,
+            period_scores,
+        } => Score::Netball(NetballScore {
+            score: score.clone(),
+            goals: goals
+                .as_ref()
+                .map(|gs| gs.iter().map(netball_goal_event_from_record).collect()),
+            fouls: fouls
+                .as_ref()
+                .map(|fs| fs.iter().map(netball_foul_event_from_record).collect()),
+            period: period.as_ref().map(netball_period_from_record),
+            period_times: period_times.as_ref().map(|pts| {
+                pts.iter()
+                    .map(|(p, t)| (netball_period_from_record(p), parse_ts(t)))
+                    .collect()
+            }),
+            period_scores: period_scores.as_ref().map(|pss| {
+                pss.iter()
+                    .map(|(p, entries)| (netball_period_from_record(p), entries.clone()))
+                    .collect()
+            }),
             // Not stored — `Api::hydrate_score_players` fills this afterward.
             players: std::collections::HashMap::new(),
         }),
@@ -472,6 +509,33 @@ pub fn score_to_record(score: &Score) -> ScoreRecord {
                     .collect()
             }),
             penalty_shootout_score: s.penalty_shootout_score.clone(),
+        },
+        Score::Netball(s) => ScoreRecord::Netball {
+            score: s.score.clone(),
+            goals: s
+                .goals
+                .as_ref()
+                .map(|gs| gs.iter().map(netball_goal_event_to_record).collect()),
+            fouls: s
+                .fouls
+                .as_ref()
+                .map(|fs| fs.iter().map(netball_foul_event_to_record).collect()),
+            period: s.period.as_ref().map(netball_period_to_record),
+            period_times: s.period_times.as_ref().map(|pts| {
+                pts.iter()
+                    .map(|(p, t)| {
+                        (
+                            netball_period_to_record(p),
+                            t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                        )
+                    })
+                    .collect()
+            }),
+            period_scores: s.period_scores.as_ref().map(|pss| {
+                pss.iter()
+                    .map(|(p, entries)| (netball_period_to_record(p), entries.clone()))
+                    .collect()
+            }),
         },
     }
 }
@@ -1026,6 +1090,7 @@ pub fn match_score_to_record(score: &Score, last_seq: Option<u32>) -> MatchScore
     let sport = match score {
         Score::Football(_) => "football",
         Score::Cricket(_) => "cricket",
+        Score::Netball(_) => "netball",
         Score::Simple(_) => "simple",
         Score::Sets(_) => "sets",
     }
@@ -1068,6 +1133,12 @@ pub fn match_format_to_record(fmt: &MatchFormat) -> MatchFormatRecord {
             no_ball_is_extra_ball: f.no_ball_is_extra_ball,
             free_hit_after_no_ball: f.free_hit_after_no_ball,
         }),
+        MatchFormat::Netball(f) => MatchFormatRecord::Netball(NetballFormatRecord {
+            num_quarters: f.num_quarters,
+            quarter_length_minutes: f.quarter_length_minutes,
+            two_point_zone: f.two_point_zone,
+            extra_time: f.extra_time,
+        }),
     }
 }
 
@@ -1092,6 +1163,12 @@ pub fn match_format_from_record(rec: &MatchFormatRecord) -> MatchFormat {
             no_ball_is_extra_ball: f.no_ball_is_extra_ball,
             free_hit_after_no_ball: f.free_hit_after_no_ball,
         }),
+        MatchFormatRecord::Netball(f) => MatchFormat::Netball(NetballFormat {
+            num_quarters: f.num_quarters,
+            quarter_length_minutes: f.quarter_length_minutes,
+            two_point_zone: f.two_point_zone,
+            extra_time: f.extra_time,
+        }),
     }
 }
 
@@ -1102,6 +1179,7 @@ pub fn match_format_sport_tag(fmt: &MatchFormat) -> &'static str {
     match fmt {
         MatchFormat::Football(_) => "football",
         MatchFormat::Cricket(_) => "cricket",
+        MatchFormat::Netball(_) => "netball",
     }
 }
 
@@ -1120,6 +1198,7 @@ pub fn live_event_sport_tag(event: &LiveEventInput) -> &'static str {
     match event {
         LiveEventInput::Football(_) => "football",
         LiveEventInput::Cricket(_) => "cricket",
+        LiveEventInput::Netball(_) => "netball",
     }
 }
 
@@ -1131,6 +1210,9 @@ pub fn live_event_input_to_record(event: &LiveEventInput) -> LiveEventPayloadRec
         LiveEventInput::Cricket(c) => {
             LiveEventPayloadRecord::Cricket(cricket_live_event_to_record(c))
         }
+        LiveEventInput::Netball(n) => {
+            LiveEventPayloadRecord::Netball(netball_live_event_to_record(n))
+        }
     }
 }
 
@@ -1141,6 +1223,9 @@ pub fn live_event_payload_from_record(rec: &LiveEventPayloadRecord) -> LiveEvent
         }
         LiveEventPayloadRecord::Cricket(c) => {
             LiveEventInput::Cricket(cricket_live_event_from_record(c))
+        }
+        LiveEventPayloadRecord::Netball(n) => {
+            LiveEventInput::Netball(netball_live_event_from_record(n))
         }
     }
 }
@@ -1300,6 +1385,144 @@ fn football_live_event_from_record(rec: &FootballLiveEventRecord) -> FootballLiv
                 scored: k.scored,
             })
         }
+    }
+}
+
+// ---- Netball --------------------------------------------------------------
+
+/// Shared by the live-event mapping below and `score_to_record`'s `Netball`
+/// arm — both carry the same `NetballGoalEvent`/`NetballGoalEventRecord`
+/// shape.
+fn netball_goal_event_to_record(g: &NetballGoalEvent) -> NetballGoalEventRecord {
+    NetballGoalEventRecord {
+        side_id: g.side_id.clone(),
+        scorer_player_id: g.scorer_player_id.clone(),
+        scorer_position: g.scorer_position.as_ref().map(netball_position_to_record),
+        two_points: g.two_points,
+        minute: g.minute,
+    }
+}
+
+fn netball_goal_event_from_record(rec: &NetballGoalEventRecord) -> NetballGoalEvent {
+    NetballGoalEvent {
+        side_id: rec.side_id.clone(),
+        scorer_player_id: rec.scorer_player_id.clone(),
+        scorer_position: rec.scorer_position.as_ref().map(netball_position_from_record),
+        two_points: rec.two_points,
+        minute: rec.minute,
+    }
+}
+
+fn netball_position_to_record(p: &NetballPosition) -> NetballPositionRecord {
+    match p {
+        NetballPosition::GoalShooter => NetballPositionRecord::GoalShooter,
+        NetballPosition::GoalAttack => NetballPositionRecord::GoalAttack,
+        NetballPosition::WingAttack => NetballPositionRecord::WingAttack,
+        NetballPosition::Centre => NetballPositionRecord::Centre,
+        NetballPosition::WingDefence => NetballPositionRecord::WingDefence,
+        NetballPosition::GoalDefence => NetballPositionRecord::GoalDefence,
+        NetballPosition::GoalKeeper => NetballPositionRecord::GoalKeeper,
+    }
+}
+
+fn netball_position_from_record(rec: &NetballPositionRecord) -> NetballPosition {
+    match rec {
+        NetballPositionRecord::GoalShooter => NetballPosition::GoalShooter,
+        NetballPositionRecord::GoalAttack => NetballPosition::GoalAttack,
+        NetballPositionRecord::WingAttack => NetballPosition::WingAttack,
+        NetballPositionRecord::Centre => NetballPosition::Centre,
+        NetballPositionRecord::WingDefence => NetballPosition::WingDefence,
+        NetballPositionRecord::GoalDefence => NetballPosition::GoalDefence,
+        NetballPositionRecord::GoalKeeper => NetballPosition::GoalKeeper,
+    }
+}
+
+/// Shared by the live-event mapping below and `score_to_record`'s `Netball`
+/// arm, same reasoning as `netball_goal_event_to_record`.
+fn netball_foul_event_to_record(fo: &NetballFoulEvent) -> NetballFoulEventRecord {
+    NetballFoulEventRecord {
+        side_id: fo.side_id.clone(),
+        player_id: fo.player_id.clone(),
+        foul_kind: match fo.foul_kind {
+            NetballFoulKind::Contact => NetballFoulKindRecord::Contact,
+            NetballFoulKind::Obstruction => NetballFoulKindRecord::Obstruction,
+            NetballFoulKind::Footwork => NetballFoulKindRecord::Footwork,
+            NetballFoulKind::Offside => NetballFoulKindRecord::Offside,
+            NetballFoulKind::HeldBall => NetballFoulKindRecord::HeldBall,
+            NetballFoulKind::Other => NetballFoulKindRecord::Other,
+        },
+        minute: fo.minute,
+    }
+}
+
+fn netball_foul_event_from_record(rec: &NetballFoulEventRecord) -> NetballFoulEvent {
+    NetballFoulEvent {
+        side_id: rec.side_id.clone(),
+        player_id: rec.player_id.clone(),
+        foul_kind: match rec.foul_kind {
+            NetballFoulKindRecord::Contact => NetballFoulKind::Contact,
+            NetballFoulKindRecord::Obstruction => NetballFoulKind::Obstruction,
+            NetballFoulKindRecord::Footwork => NetballFoulKind::Footwork,
+            NetballFoulKindRecord::Offside => NetballFoulKind::Offside,
+            NetballFoulKindRecord::HeldBall => NetballFoulKind::HeldBall,
+            NetballFoulKindRecord::Other => NetballFoulKind::Other,
+        },
+        minute: rec.minute,
+    }
+}
+
+/// Shared by the live-event mapping below and `score_to_record`'s `Netball`
+/// arm (`period`/`period_times`/`period_scores`' map keys) — both need the
+/// same `NetballPeriod`/`NetballPeriodRecord` correspondence.
+fn netball_period_to_record(period: &NetballPeriod) -> NetballPeriodRecord {
+    match period {
+        NetballPeriod::Start => NetballPeriodRecord::Start,
+        NetballPeriod::QuarterOneEnd => NetballPeriodRecord::QuarterOneEnd,
+        NetballPeriod::QuarterTwoEnd => NetballPeriodRecord::QuarterTwoEnd,
+        NetballPeriod::QuarterThreeEnd => NetballPeriodRecord::QuarterThreeEnd,
+        NetballPeriod::FullTime => NetballPeriodRecord::FullTime,
+        NetballPeriod::ExtraTimeStart => NetballPeriodRecord::ExtraTimeStart,
+        NetballPeriod::ExtraTimeEnd => NetballPeriodRecord::ExtraTimeEnd,
+    }
+}
+
+fn netball_period_from_record(rec: &NetballPeriodRecord) -> NetballPeriod {
+    match rec {
+        NetballPeriodRecord::Start => NetballPeriod::Start,
+        NetballPeriodRecord::QuarterOneEnd => NetballPeriod::QuarterOneEnd,
+        NetballPeriodRecord::QuarterTwoEnd => NetballPeriod::QuarterTwoEnd,
+        NetballPeriodRecord::QuarterThreeEnd => NetballPeriod::QuarterThreeEnd,
+        NetballPeriodRecord::FullTime => NetballPeriod::FullTime,
+        NetballPeriodRecord::ExtraTimeStart => NetballPeriod::ExtraTimeStart,
+        NetballPeriodRecord::ExtraTimeEnd => NetballPeriod::ExtraTimeEnd,
+    }
+}
+
+fn netball_live_event_to_record(event: &NetballLiveEvent) -> NetballLiveEventRecord {
+    match event {
+        NetballLiveEvent::Goal(g) => NetballLiveEventRecord::Goal(netball_goal_event_to_record(g)),
+        NetballLiveEvent::Foul(fo) => {
+            NetballLiveEventRecord::Foul(netball_foul_event_to_record(fo))
+        }
+        NetballLiveEvent::Period(p) => NetballLiveEventRecord::Period(NetballPeriodEventRecord {
+            period: netball_period_to_record(&p.period),
+            score: p.score.clone(),
+        }),
+    }
+}
+
+fn netball_live_event_from_record(rec: &NetballLiveEventRecord) -> NetballLiveEvent {
+    match rec {
+        NetballLiveEventRecord::Goal(g) => {
+            NetballLiveEvent::Goal(netball_goal_event_from_record(g))
+        }
+        NetballLiveEventRecord::Foul(fo) => {
+            NetballLiveEvent::Foul(netball_foul_event_from_record(fo))
+        }
+        NetballLiveEventRecord::Period(p) => NetballLiveEvent::Period(NetballPeriodEvent {
+            period: netball_period_from_record(&p.period),
+            score: p.score.clone(),
+        }),
     }
 }
 
@@ -1550,7 +1773,9 @@ pub fn derive_live_score(
                     LiveEventPayloadRecord::Football(f) => {
                         Some((parse_ts(&r.occurred_at), football_live_event_from_record(f)))
                     }
-                    LiveEventPayloadRecord::Cricket(_) => None,
+                    LiveEventPayloadRecord::Cricket(_) | LiveEventPayloadRecord::Netball(_) => {
+                        None
+                    }
                 })
                 .collect();
             Some(Score::Football(FootballScore::from_events(&events)))
@@ -1560,7 +1785,9 @@ pub fn derive_live_score(
                 .iter()
                 .filter_map(|r| match &r.payload {
                     LiveEventPayloadRecord::Cricket(c) => Some(cricket_live_event_from_record(c)),
-                    LiveEventPayloadRecord::Football(_) => None,
+                    LiveEventPayloadRecord::Football(_) | LiveEventPayloadRecord::Netball(_) => {
+                        None
+                    }
                 })
                 .collect();
             let (balls_per_over, wide_is_extra_ball, no_ball_is_extra_ball) =
@@ -1571,6 +1798,20 @@ pub fn derive_live_score(
                 wide_is_extra_ball,
                 no_ball_is_extra_ball,
             )))
+        }
+        "netball" => {
+            let events: Vec<(chrono::DateTime<chrono::Utc>, NetballLiveEvent)> = records
+                .iter()
+                .filter_map(|r| match &r.payload {
+                    LiveEventPayloadRecord::Netball(n) => {
+                        Some((parse_ts(&r.occurred_at), netball_live_event_from_record(n)))
+                    }
+                    LiveEventPayloadRecord::Football(_) | LiveEventPayloadRecord::Cricket(_) => {
+                        None
+                    }
+                })
+                .collect();
+            Some(Score::Netball(NetballScore::from_events(&events)))
         }
         _ => None,
     }
@@ -1818,6 +2059,39 @@ mod tests {
     }
 
     #[test]
+    fn netball_live_event_round_trips_through_dao_mirror() {
+        let events = vec![
+            NetballLiveEvent::Goal(NetballGoalEvent {
+                side_id: "kestrels".into(),
+                scorer_player_id: Some("shooter_1".into()),
+                scorer_position: Some(NetballPosition::GoalShooter),
+                two_points: false,
+                minute: Some(4),
+            }),
+            NetballLiveEvent::Foul(NetballFoulEvent {
+                side_id: "harriers".into(),
+                player_id: Some("defender_1".into()),
+                foul_kind: NetballFoulKind::Contact,
+                minute: Some(6),
+            }),
+            NetballLiveEvent::Period(NetballPeriodEvent {
+                period: NetballPeriod::QuarterOneEnd,
+                score: HashMap::from([
+                    ("kestrels".to_string(), 12),
+                    ("harriers".to_string(), 9),
+                ]),
+            }),
+        ];
+
+        for event in events {
+            let input = LiveEventInput::Netball(event);
+            let original_json = input.to_json();
+            let round_tripped = live_event_payload_from_record(&live_event_input_to_record(&input));
+            assert_eq!(original_json, round_tripped.to_json());
+        }
+    }
+
+    #[test]
     fn match_format_round_trips_through_dao_mirror() {
         let formats = vec![
             MatchFormat::Football(FootballFormat {
@@ -1836,6 +2110,12 @@ mod tests {
                 wide_is_extra_ball: true,
                 no_ball_is_extra_ball: false,
                 free_hit_after_no_ball: false,
+            }),
+            MatchFormat::Netball(NetballFormat {
+                num_quarters: 4,
+                quarter_length_minutes: 15,
+                two_point_zone: false,
+                extra_time: true,
             }),
         ];
 
@@ -2025,6 +2305,66 @@ mod tests {
                     scored: true,
                 }]),
                 penalty_shootout_score: Some(HashMap::from([("side_red".to_string(), 1)])),
+                players: HashMap::new(),
+            }),
+            // A manually-entered / quarter-only-scored netball result: goal
+            // tally only, no goal-by-goal detail.
+            Score::Netball(NetballScore {
+                score: HashMap::from([("kestrels".to_string(), 45), ("harriers".to_string(), 38)]),
+                goals: None,
+                fouls: None,
+                period: Some(NetballPeriod::FullTime),
+                period_times: None,
+                period_scores: Some(HashMap::from([
+                    (
+                        NetballPeriod::QuarterOneEnd,
+                        HashMap::from([("kestrels".to_string(), 12), ("harriers".to_string(), 9)]),
+                    ),
+                    (
+                        NetballPeriod::FullTime,
+                        HashMap::from([
+                            ("kestrels".to_string(), 45),
+                            ("harriers".to_string(), 38),
+                        ]),
+                    ),
+                ])),
+                players: HashMap::new(),
+            }),
+            // A live-scored (event-by-event) netball result: full goal/foul
+            // detail.
+            Score::Netball(NetballScore {
+                score: HashMap::from([("kestrels".to_string(), 2), ("harriers".to_string(), 1)]),
+                goals: Some(vec![
+                    NetballGoalEvent {
+                        side_id: "kestrels".into(),
+                        scorer_player_id: Some("player_1".into()),
+                        scorer_position: Some(NetballPosition::GoalShooter),
+                        two_points: false,
+                        minute: Some(3),
+                    },
+                    NetballGoalEvent {
+                        side_id: "kestrels".into(),
+                        scorer_player_id: Some("player_2".into()),
+                        scorer_position: Some(NetballPosition::GoalAttack),
+                        two_points: true,
+                        minute: Some(7),
+                    },
+                ]),
+                fouls: Some(vec![NetballFoulEvent {
+                    side_id: "harriers".into(),
+                    player_id: Some("player_3".into()),
+                    foul_kind: NetballFoulKind::Obstruction,
+                    minute: Some(5),
+                }]),
+                period: Some(NetballPeriod::QuarterOneEnd),
+                period_times: Some(HashMap::from([(
+                    NetballPeriod::QuarterOneEnd,
+                    parse_ts("2024-05-01T20:15:00.000Z"),
+                )])),
+                period_scores: Some(HashMap::from([(
+                    NetballPeriod::QuarterOneEnd,
+                    HashMap::from([("kestrels".to_string(), 2), ("harriers".to_string(), 1)]),
+                )])),
                 players: HashMap::new(),
             }),
         ];

--- a/agon_service/src/match_format.rs
+++ b/agon_service/src/match_format.rs
@@ -23,6 +23,7 @@ use poem_openapi::{Object, Union};
 pub enum MatchFormat {
     Football(FootballFormat),
     Cricket(CricketFormat),
+    Netball(NetballFormat),
 }
 
 #[derive(Object, Clone)]
@@ -69,4 +70,20 @@ pub struct CricketFormat {
     pub no_ball_is_extra_ball: bool,
     /// Whether the delivery after a no-ball is a free hit.
     pub free_hit_after_no_ball: bool,
+}
+
+#[derive(Object, Clone)]
+pub struct NetballFormat {
+    /// Quarters per match — normally 4; some social leagues play 2 longer
+    /// halves instead, so this isn't hardcoded to 4.
+    pub num_quarters: u32,
+    /// Minutes per quarter, e.g. 15 for a standard game or 12 for Fast5.
+    pub quarter_length_minutes: u32,
+    /// Whether a goal from the two-point zone counts double (Fast5/Netball
+    /// Superleague Power Play rules). `false` for standard scoring, where
+    /// every goal is worth one regardless of where it's shot from.
+    pub two_point_zone: bool,
+    /// Whether an extra period is played (typically "first to score" /
+    /// golden goal) if the match is level after full time.
+    pub extra_time: bool,
 }

--- a/agon_tests/Cargo.lock
+++ b/agon_tests/Cargo.lock
@@ -28,6 +28,7 @@ dependencies = [
  "progenitor",
  "reqwest",
  "serde",
+ "serde_json",
  "tokio",
  "uuid",
 ]

--- a/agon_tests/Cargo.toml
+++ b/agon_tests/Cargo.toml
@@ -19,5 +19,6 @@ futures = "0.3"
 progenitor = { git = "https://github.com/oxidecomputer/progenitor" }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 openapi = { path = "../openapi_client" }
 uuid = { version = "1.16.0", features = ["v4"] }

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -1679,6 +1679,7 @@ fn simple_score_points(score: &models::Score) -> Vec<(String, i32)> {
         models::Score::Sets(_) => panic!("expected a simple score"),
         models::Score::Cricket(_) => panic!("expected a simple score"),
         models::Score::Football(_) => panic!("expected a simple score"),
+        models::Score::Netball(_) => panic!("expected a simple score"),
     };
     points.sort_by(|a, b| a.0.cmp(&b.0));
     points
@@ -3240,4 +3241,195 @@ async fn attach_rejects_wrong_purpose_asset() {
     )
     .await;
     assert_bad_request(response);
+}
+
+// ---------------------------------------------------------------------------
+// Netball live scoring — both of netball's two live-scoring methods
+// (event-by-event, quarter-only) fold through the same `NetballLiveEvent`
+// vocabulary, so both are exercised here against the real service.
+//
+// The append call is made with raw JSON over `reqwest` rather than the
+// generated client: the generated Rust model for a *sport* union nested
+// around a *kind* union (`LiveEventInput` -> `NetballLiveEvent`/
+// `FootballLiveEvent`/...) flattens incorrectly (a pre-existing
+// openapi-generator limitation that predates netball and affects football's
+// Goal/Card/Substitution/Period kinds too — see `docs/openapi-client.md`),
+// so its `kind` enum only ever contains one variant instead of all of them.
+// Reading the result back is unaffected — `GET /matches/:id/score` returns
+// `Score`, which embeds goals/fouls as plain (non-nested-union) structs — so
+// that leg of each test still goes through the typed client.
+// ---------------------------------------------------------------------------
+
+/// A netball match between two invited users, scheduled in the future (no
+/// create-time score) so live events can be appended afterward. The owner is
+/// assigned to side "a" so they're a participant and can record events.
+fn netball_match_input(invited_user_id: &str) -> models::CreateMatchInput {
+    let mut input = create_match_input(invited_user_id);
+    input.match_type = models::MatchType::Netball;
+    input.creator_side_client_id = Some("a".to_string());
+    input
+}
+
+fn netball_goal_event_json(side_id: &str, two_points: bool) -> serde_json::Value {
+    serde_json::json!({
+        "sport": "Netball",
+        "kind": "Goal",
+        "side_id": side_id,
+        "two_points": two_points,
+    })
+}
+
+fn netball_foul_event_json(side_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "sport": "Netball",
+        "kind": "Foul",
+        "side_id": side_id,
+        "foul_kind": "contact",
+    })
+}
+
+fn netball_period_event_json(period: &str, scores: &[(&str, i32)]) -> serde_json::Value {
+    serde_json::json!({
+        "sport": "Netball",
+        "kind": "Period",
+        "period": period,
+        "score": scores.iter().copied().collect::<std::collections::HashMap<_, _>>(),
+    })
+}
+
+/// POST `/matches/:id/live/events` with raw JSON events (see this section's
+/// doc comment for why), returning the parsed `LiveScoreSnapshot`.
+async fn append_live_events_raw(
+    config: &Configuration,
+    match_id: &str,
+    expected_last_seq: i32,
+    events: Vec<serde_json::Value>,
+) -> models::LiveScoreSnapshot {
+    let body = serde_json::json!({
+        "expected_last_seq": expected_last_seq,
+        "events": events
+            .into_iter()
+            .map(|event| serde_json::json!({ "occurred_at": iso_offset_hours(0), "event": event }))
+            .collect::<Vec<_>>(),
+    });
+    let res = reqwest::Client::new()
+        .post(format!(
+            "{}/matches/{match_id}/live/events",
+            config.base_path
+        ))
+        .bearer_auth(
+            config
+                .bearer_access_token
+                .as_ref()
+                .expect("config has a bearer token"),
+        )
+        .json(&body)
+        .send()
+        .await
+        .expect("send append request");
+    assert!(
+        res.status().is_success(),
+        "append live events failed: {} {}",
+        res.status(),
+        res.text().await.unwrap_or_default()
+    );
+    res.json().await.expect("parse LiveScoreSnapshot")
+}
+
+/// Appending `Goal`/`Foul` events (plus a `Period` marker for time-tracking)
+/// derives the running score from the goals themselves — the event-by-event
+/// method.
+#[tokio::test]
+async fn netball_event_by_event_scoring_derives_score_from_goals() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+    let side_b = created.sides[1].id.clone();
+
+    let snapshot = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![
+            netball_goal_event_json(&side_a, false),
+            netball_goal_event_json(&side_a, true),
+            netball_goal_event_json(&side_b, false),
+            netball_foul_event_json(&side_b),
+            netball_period_event_json("quarter_one_end", &[(&side_a, 3), (&side_b, 1)]),
+        ],
+    )
+    .await;
+    assert_eq!(snapshot.last_seq, 5);
+
+    let score = matches_match_id_score_get(&owner_config, &created.id)
+        .await
+        .expect("get score");
+    match score {
+        models::Score::Netball(s) => {
+            assert_eq!(s.score.get(&side_a), Some(&3));
+            assert_eq!(s.score.get(&side_b), Some(&1));
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(3));
+            assert_eq!(s.fouls.as_ref().map(Vec::len), Some(1));
+            assert!(matches!(
+                s.period,
+                Some(models::NetballPeriod::QuarterOneEnd)
+            ));
+            let quarter_one_score = s
+                .period_scores
+                .as_ref()
+                .expect("period_scores present")
+                .get("quarter_one_end")
+                .expect("quarter one entry present");
+            assert_eq!(quarter_one_score.get(&side_a), Some(&3));
+            assert_eq!(quarter_one_score.get(&side_b), Some(&1));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+}
+
+/// Appending only `Period` markers (no `Goal`/`Foul` events at all) derives
+/// the score purely from each marker's own `score` field — the quarter-only
+/// method.
+#[tokio::test]
+async fn netball_quarter_only_scoring_uses_period_marker_score_directly() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+    let side_b = created.sides[1].id.clone();
+
+    append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![
+            netball_period_event_json("quarter_one_end", &[(&side_a, 12), (&side_b, 9)]),
+            netball_period_event_json("quarter_two_end", &[(&side_a, 22), (&side_b, 18)]),
+        ],
+    )
+    .await;
+
+    let score = matches_match_id_score_get(&owner_config, &created.id)
+        .await
+        .expect("get score");
+    match score {
+        models::Score::Netball(s) => {
+            assert_eq!(s.score.get(&side_a), Some(&22));
+            assert_eq!(s.score.get(&side_b), Some(&18));
+            // No Goal events at all — no goal-by-goal detail to hand over.
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(0));
+            assert!(matches!(
+                s.period,
+                Some(models::NetballPeriod::QuarterTwoEnd)
+            ));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
 }

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -15,11 +15,15 @@ import { MatchHeaderCarousel } from './MatchHeaderCarousel'
 import { InvitationResponseDialog } from './InvitationResponseDialog'
 import { LiveMatchBlock } from './live/LiveMatchBlock'
 import { CricketMatchBlock } from './live/CricketMatchBlock'
+import { NetballMatchBlock } from './live/NetballMatchBlock'
 import { CricketScoreBlock } from './CricketScoreBlock'
 import { KnownPlayersRow } from './KnownPlayersRow'
 import { FootballScorersBySide } from './FootballScorersBySide'
+import { NetballScorersBySide } from './NetballScorersBySide'
 import { useMatchScore } from '@/hooks/useMatchScore'
 import { footballScoreFrom } from '@/lib/liveScore'
+import { netballGoalsFromScore } from '@/lib/score'
+import { netballScoreFrom } from '@/lib/netballScore'
 import {
   cricketProgressFromScore,
   cricketScoreFrom,
@@ -210,7 +214,8 @@ export function MatchCard({
   const aWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideA?.id
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
 
-  const isLiveSport = match.match_type === 'football' || match.match_type === 'cricket'
+  const isLiveSport =
+    match.match_type === 'football' || match.match_type === 'cricket' || match.match_type === 'netball'
   const isCurrentlyLive = isLiveSport && match.status === 'in_progress'
   // Only fetched while live — a finished match doesn't need it. Football's
   // confirmed/pending `Score.Football` already embeds its goals (see
@@ -233,17 +238,21 @@ export function MatchCard({
   // live block/badge for a match that finished after the card last mounted.
   const footballState = isCurrentlyLive ? footballScoreFrom(scoreQuery.data) : null
   const cricketState = isCurrentlyLive ? cricketScoreFrom(scoreQuery.data) : null
-  // Goals for a finished football match, read straight off the
+  const netballState = isCurrentlyLive ? netballScoreFrom(scoreQuery.data) : null
+  // Goals for a finished football/netball match, read straight off the
   // confirmed/pending score (no fetch) — shown under the plain score box
-  // below (the live ticker in `LiveMatchBlock` only renders while
-  // `footballState` is set, i.e. while still in progress).
+  // below (the live ticker in `LiveMatchBlock`/`NetballMatchBlock` only
+  // renders while still in progress).
   const finishedFootballGoals = scoreInfo && !isCurrentlyLive ? footballGoalsFromScore(scoreInfo.score) : null
+  const finishedNetballGoals = scoreInfo && !isCurrentlyLive ? netballGoalsFromScore(scoreInfo.score) : null
   // Resolved server-side on `confirmed_score`/`pending_score` itself (see
   // `Api::hydrate_confirmed_pending_score_players`) — this card's `match` is
   // a `FeedMatch`/`SearchMatch`/`Match`, none of which reliably carry a full
   // player roster to resolve scorer names from locally.
   const finishedFootballScorePlayers =
     scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
+  const finishedNetballScorePlayers =
+    scoreInfo && !isCurrentlyLive ? netballScoreFrom(scoreInfo.score)?.players : undefined
   // A cricket match's confirmed score carries its own per-innings detail once
   // it's been live-scored (`Score::Cricket`; see `finishMatch` in
   // `CricketLiveScoringPage`) — a manually-logged result still degrades to
@@ -323,6 +332,10 @@ export function MatchCard({
         <div className="mx-3.5 mb-3">
           <LiveMatchBlock match={match} state={footballState} />
         </div>
+      ) : netballState ? (
+        <div className="mx-3.5 mb-3">
+          <NetballMatchBlock match={match} state={netballState} />
+        </div>
       ) : cricketState ? (
         <div className="mx-3.5 mb-3">
           <CricketMatchBlock match={match} state={cricketState} showDescription={false} />
@@ -369,6 +382,16 @@ export function MatchCard({
                 goals={finishedFootballGoals}
                 match={match}
                 players={finishedFootballScorePlayers}
+                sideA={sideA}
+                sideB={sideB}
+                className="mt-2.5 text-[11px]"
+              />
+            )}
+            {finishedNetballGoals && (
+              <NetballScorersBySide
+                goals={finishedNetballGoals}
+                match={match}
+                players={finishedNetballScorePlayers}
                 sideA={sideA}
                 sideB={sideB}
                 className="mt-2.5 text-[11px]"

--- a/agon_ui/src/components/agon/MatchFormatCard.tsx
+++ b/agon_ui/src/components/agon/MatchFormatCard.tsx
@@ -4,13 +4,15 @@ import { Pencil } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
-import { CricketFields, FootballFields } from './MatchFormatEditor'
+import { CricketFields, FootballFields, NetballFields } from './MatchFormatEditor'
 import {
   cricketFormat,
   footballFormat,
+  netballFormat,
   oversLimitLabel,
   type CricketFormat,
   type FootballFormat,
+  type NetballFormat,
 } from '@/lib/matchFormat'
 
 type Match = components['schemas']['Match']
@@ -38,6 +40,16 @@ function FormatSummary({ match }: { match: Match }) {
         {fmt.num_halves} × {fmt.half_length_minutes}min
         {fmt.extra_time && ' · extra time'}
         {fmt.penalties && ' · penalties'}
+      </p>
+    )
+  }
+  if (match.match_type === 'netball') {
+    const fmt = netballFormat(match.format)
+    return (
+      <p className="text-xs text-muted-foreground">
+        {fmt.num_quarters} × {fmt.quarter_length_minutes}min
+        {fmt.two_point_zone && ' · 2pt zone'}
+        {fmt.extra_time && ' · extra time'}
       </p>
     )
   }
@@ -71,6 +83,9 @@ export function MatchFormatCard({
   const [cricketDraft, setCricketDraft] = useState<CricketFormat>(() =>
     cricketFormat(match.format),
   )
+  const [netballDraft, setNetballDraft] = useState<NetballFormat>(() =>
+    netballFormat(match.format),
+  )
 
   const save = useMutation({
     mutationFn: async () => {
@@ -80,7 +95,9 @@ export function MatchFormatCard({
           format:
             match.match_type === 'cricket'
               ? { sport: 'Cricket', ...cricketDraft }
-              : { sport: 'Football', ...footballDraft },
+              : match.match_type === 'netball'
+                ? { sport: 'Netball', ...netballDraft }
+                : { sport: 'Football', ...footballDraft },
         },
       })
       if (error) throw new Error('Failed to save the match format')
@@ -91,7 +108,9 @@ export function MatchFormatCard({
     },
   })
 
-  if (match.match_type !== 'football' && match.match_type !== 'cricket') return null
+  if (match.match_type !== 'football' && match.match_type !== 'cricket' && match.match_type !== 'netball') {
+    return null
+  }
 
   if (!editing) {
     return (
@@ -108,6 +127,7 @@ export function MatchFormatCard({
             onClick={() => {
               setFootballDraft(footballFormat(match.format))
               setCricketDraft(cricketFormat(match.format))
+              setNetballDraft(netballFormat(match.format))
               setEditing(true)
             }}
           >
@@ -123,6 +143,8 @@ export function MatchFormatCard({
       <p className="mb-3 text-sm font-medium">Format</p>
       {match.match_type === 'cricket' ? (
         <CricketFields value={cricketDraft} onChange={setCricketDraft} />
+      ) : match.match_type === 'netball' ? (
+        <NetballFields value={netballDraft} onChange={setNetballDraft} />
       ) : (
         <FootballFields value={footballDraft} onChange={setFootballDraft} />
       )}

--- a/agon_ui/src/components/agon/MatchFormatEditor.tsx
+++ b/agon_ui/src/components/agon/MatchFormatEditor.tsx
@@ -6,9 +6,11 @@ import type { MatchType } from '@/lib/sports'
 import {
   DEFAULT_CRICKET_FORMAT,
   DEFAULT_FOOTBALL_FORMAT,
+  DEFAULT_NETBALL_FORMAT,
   type CricketFormat,
   type FootballFormat,
   type MatchFormat,
+  type NetballFormat,
 } from '@/lib/matchFormat'
 
 /**
@@ -185,19 +187,57 @@ export function CricketFields({
   )
 }
 
+export function NetballFields({
+  value,
+  onChange,
+}: {
+  value: NetballFormat
+  onChange: (value: NetballFormat) => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-2">
+        <NumberField
+          label="Quarters"
+          value={value.num_quarters}
+          min={1}
+          onChange={(v) => onChange({ ...value, num_quarters: v ?? 4 })}
+        />
+        <NumberField
+          label="Quarter length (min)"
+          value={value.quarter_length_minutes}
+          min={1}
+          onChange={(v) => onChange({ ...value, quarter_length_minutes: v ?? 15 })}
+        />
+      </div>
+      <ToggleRow
+        label="Two-point zone (Fast5/Power Play)"
+        checked={value.two_point_zone}
+        onChange={(two_point_zone) => onChange({ ...value, two_point_zone })}
+      />
+      <ToggleRow
+        label="Extra time if level"
+        checked={value.extra_time}
+        onChange={(extra_time) => onChange({ ...value, extra_time })}
+      />
+    </div>
+  )
+}
+
 /**
  * Sport-specific match format settings (half length, overs limit, penalty
  * runs, ...) — `null` while unset, in which case the app just falls back to
  * its own defaults everywhere (see `lib/matchFormat`) without the match
  * having pinned specific values. Renders nothing for a sport with no format
- * modelled yet (only football and cricket, matching the backend union).
+ * modelled yet (only football, cricket, and netball, matching the backend
+ * union).
  *
  * The on/off toggle here is for *creating* a match, where "unset" is a real,
  * meaningful choice. There's no way to clear a format back to unset once
  * one exists (the update API only supports leaving it unchanged or setting
  * it, not clearing it) — editing an existing match's format uses
- * `FootballFields`/`CricketFields` directly instead, always against a
- * concrete value.
+ * `FootballFields`/`CricketFields`/`NetballFields` directly instead, always
+ * against a concrete value.
  */
 export function MatchFormatEditor({
   sport,
@@ -208,7 +248,7 @@ export function MatchFormatEditor({
   value: MatchFormat | null
   onChange: (value: MatchFormat | null) => void
 }) {
-  if (sport !== 'football' && sport !== 'cricket') return null
+  if (sport !== 'football' && sport !== 'cricket' && sport !== 'netball') return null
 
   const enabled = value !== null
 
@@ -225,7 +265,9 @@ export function MatchFormatEditor({
           onChange(
             sport === 'cricket'
               ? { sport: 'Cricket', ...DEFAULT_CRICKET_FORMAT }
-              : { sport: 'Football', ...DEFAULT_FOOTBALL_FORMAT },
+              : sport === 'netball'
+                ? { sport: 'Netball', ...DEFAULT_NETBALL_FORMAT }
+                : { sport: 'Football', ...DEFAULT_FOOTBALL_FORMAT },
           )
         }}
       />
@@ -235,6 +277,11 @@ export function MatchFormatEditor({
             <CricketFields
               value={value}
               onChange={(v) => onChange({ sport: 'Cricket', ...v })}
+            />
+          ) : value.sport === 'Netball' ? (
+            <NetballFields
+              value={value}
+              onChange={(v) => onChange({ sport: 'Netball', ...v })}
             />
           ) : (
             <FootballFields

--- a/agon_ui/src/components/agon/MatchResultEditor.tsx
+++ b/agon_ui/src/components/agon/MatchResultEditor.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { isSetsSport } from '@/lib/sports'
 import { FootballScoreFields } from '@/components/agon/FootballScoreFields'
 import { CricketScoreFields } from '@/components/agon/CricketScoreFields'
+import { NetballScoreFields } from '@/components/agon/NetballScoreFields'
 import { displayScore, headlineBySide } from '@/lib/score'
 import { cricketProgressFromScore, matchTotalsBySide } from '@/lib/cricketScore'
 
@@ -104,6 +105,7 @@ export function MatchResultEditor({
 
   const isFootball = match.match_type === 'football'
   const isCricket = match.match_type === 'cricket'
+  const isNetball = match.match_type === 'netball'
   const setsMode = isSetsSport(match.match_type)
   // The result to prepopulate the form with: confirmed if there is one, else
   // a still-pending submission awaiting the other side's confirmation.
@@ -115,7 +117,7 @@ export function MatchResultEditor({
 
   /** Build the score payload + derived winner, or null when incomplete. */
   const build = (): { score: Score; winner?: string } | null => {
-    if (isFootball || isCricket) {
+    if (isFootball || isCricket || isNetball) {
       return detailBuilt ? { score: detailBuilt.score, winner: detailBuilt.winnerSideId } : null
     }
 
@@ -223,6 +225,14 @@ export function MatchResultEditor({
         />
       ) : isCricket && sideA && sideB ? (
         <CricketScoreFields
+          sideA={sideA}
+          sideB={sideB}
+          players={match.players}
+          initial={currentScore}
+          onChange={setDetailBuilt}
+        />
+      ) : isNetball && sideA && sideB ? (
+        <NetballScoreFields
           sideA={sideA}
           sideB={sideB}
           players={match.players}

--- a/agon_ui/src/components/agon/NetballQuarterBreakdown.tsx
+++ b/agon_ui/src/components/agon/NetballQuarterBreakdown.tsx
@@ -1,0 +1,54 @@
+import type { components } from '@/types/api'
+import { periodLabel, type NetballPeriod, type NetballScore } from '@/lib/netballScore'
+
+type MatchSide = components['schemas']['MatchSide']
+
+/** The quarter-end markers shown here, in play order — `start`/
+ *  `extra_time_end` aren't quarter *scores* so they're excluded. */
+const QUARTER_MARKERS: NetballPeriod[] = [
+  'quarter_one_end',
+  'quarter_two_end',
+  'quarter_three_end',
+  'full_time',
+  'extra_time_start',
+]
+
+/**
+ * Quarter-by-quarter score breakdown — "Q1 12-9, Q2 22-18, ..." — read
+ * straight off `NetballScore.period_scores`. Unlike `NetballScorecard`
+ * (goal-by-goal detail, event-by-event mode only) this renders identically
+ * regardless of which of netball's two live-scoring methods produced the
+ * score, since both populate `period_scores` the same way (see its backend
+ * doc comment). Renders nothing once there's no quarter marker recorded yet.
+ */
+export function NetballQuarterBreakdown({
+  score,
+  sideA,
+  sideB,
+}: {
+  score: NetballScore
+  sideA: MatchSide | undefined
+  sideB: MatchSide | undefined
+}) {
+  const rows = QUARTER_MARKERS
+    .map((period) => ({ period, entry: score.period_scores?.[period] }))
+    .filter((row): row is { period: NetballPeriod; entry: Record<string, number> } => !!row.entry)
+
+  if (rows.length === 0) return null
+
+  return (
+    <div className="rounded-xl border bg-card p-4">
+      <p className="mb-3 text-sm font-medium">Quarter by quarter</p>
+      <div className="flex flex-col gap-1.5 text-sm">
+        {rows.map(({ period, entry }) => (
+          <div key={period} className="flex items-center justify-between">
+            <span className="text-muted-foreground">{periodLabel(period)}</span>
+            <span className="font-medium tabular-nums">
+              {entry[sideA?.id ?? ''] ?? 0} – {entry[sideB?.id ?? ''] ?? 0}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/NetballScoreFields.tsx
+++ b/agon_ui/src/components/agon/NetballScoreFields.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react'
+import { Plus } from 'lucide-react'
+import type { components } from '@/types/api'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { RecordNetballEventDialog, type NetballEventKind } from '@/components/agon/live/RecordNetballEventDialog'
+import { describeEvent, eventEmoji, goalEventsToViews, type NetballEventView } from '@/lib/netballScore'
+
+type Match = components['schemas']['Match']
+type MatchSide = components['schemas']['MatchSide']
+type MatchPlayer = components['schemas']['MatchPlayer']
+type Score = components['schemas']['Score']
+type NetballGoalEvent = components['schemas']['NetballGoalEvent']
+type NetballFoulEvent = components['schemas']['NetballFoulEvent']
+type NetballLiveEvent = components['schemas']['NetballLiveEvent']
+
+export interface NetballScoreFieldsProps {
+  sideA: MatchSide
+  sideB: MatchSide
+  /** Roster to pick a scorer/fouling player from — real `match.players` when
+   *  editing, or a synthesized roster (see `LogMatchPage`) when composing a
+   *  match that doesn't exist yet. */
+  players: MatchPlayer[]
+  /** Seeds from an existing confirmed score, when editing. */
+  initial?: Score
+  onChange: (built: { score: Score; winnerSideId?: string } | null) => void
+}
+
+function sideLabel(side: MatchSide, fallback: string): string {
+  return side.name?.trim() || fallback
+}
+
+function seedPoints(initial: Score | undefined, aId: string, bId: string): [string, string] {
+  if (initial?.type === 'Netball') {
+    return [String(initial.score[aId] ?? 0), String(initial.score[bId] ?? 0)]
+  }
+  return ['', '']
+}
+
+/**
+ * Netball's result entry: a points pair by default, plus an optional
+ * goal-by-goal detail section reusing `RecordNetballEventDialog` (the same
+ * dialog event-by-event live scoring uses) to build up `goals`/`fouls`
+ * locally instead of posting to `/live/events` — same pattern as
+ * `FootballScoreFields`. Once at least one goal is added, the points become
+ * derived from the goal tally (two-point-zone goals already counted double).
+ * There's no manual-entry equivalent of quarter-only scoring's
+ * `period_scores` breakdown here — a bare final tally covers the same
+ * "just the numbers" case for a manually-logged result.
+ */
+export function NetballScoreFields({ sideA, sideB, players, initial, onChange }: NetballScoreFieldsProps) {
+  const aId = sideA.id
+  const bId = sideB.id
+  const nameA = sideLabel(sideA, 'Side A')
+  const nameB = sideLabel(sideB, 'Side B')
+
+  const [points, setPoints] = useState<[string, string]>(() => seedPoints(initial, aId, bId))
+  const [goals, setGoals] = useState<NetballGoalEvent[]>(() =>
+    initial?.type === 'Netball' ? (initial.goals ?? []) : [],
+  )
+  const [fouls, setFouls] = useState<NetballFoulEvent[]>(() =>
+    initial?.type === 'Netball' ? (initial.fouls ?? []) : [],
+  )
+  const [detailOpen, setDetailOpen] = useState(goals.length > 0)
+  const [dialogKind, setDialogKind] = useState<NetballEventKind | null>(null)
+
+  const match: Pick<Match, 'sides' | 'players'> = { sides: [sideA, sideB], players }
+
+  const submitEvent = (event: NetballLiveEvent) => {
+    if (event.kind === 'Goal') {
+      setGoals((g) => [
+        ...g,
+        {
+          side_id: event.side_id,
+          scorer_player_id: event.scorer_player_id,
+          scorer_position: event.scorer_position,
+          two_points: event.two_points,
+          minute: event.minute,
+        },
+      ])
+    } else if (event.kind === 'Foul') {
+      setFouls((f) => [
+        ...f,
+        {
+          side_id: event.side_id,
+          player_id: event.player_id,
+          foul_kind: event.foul_kind,
+          minute: event.minute,
+        },
+      ])
+    }
+    setDialogKind(null)
+  }
+
+  const [pointsA, pointsB] = points
+  const tallyFor = (sideId: string) =>
+    goals.filter((g) => g.side_id === sideId).reduce((sum, g) => sum + (g.two_points ? 2 : 1), 0)
+  const goalsForA = tallyFor(aId)
+  const goalsForB = tallyFor(bId)
+
+  useEffect(() => {
+    const hasDetail = goals.length > 0
+    const a = hasDetail ? goalsForA : Number(pointsA)
+    const b = hasDetail ? goalsForB : Number(pointsB)
+    if (!hasDetail && (pointsA === '' || pointsB === '' || !Number.isFinite(a) || !Number.isFinite(b))) {
+      onChange(null)
+      return
+    }
+    // `players` (the score's resolved-name map) is server-only — the backend
+    // never persists it (see `NetballScore.players`'s doc comment) — so a
+    // manually-built score has nothing to put here.
+    const score: Score = {
+      type: 'Netball',
+      score: { [aId]: a, [bId]: b },
+      players: {},
+      ...(hasDetail ? { goals, fouls } : {}),
+    }
+    const winnerSideId = a === b ? undefined : a > b ? aId : bId
+    onChange({ score, winnerSideId })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pointsA, pointsB, goals, fouls, aId, bId])
+
+  const events: NetballEventView[] = [
+    ...goalEventsToViews(goals),
+    ...fouls.map((f): NetballEventView => ({ kind: 'foul', side_id: f.side_id, minute: f.minute, player_id: f.player_id })),
+  ].sort((a, b) => (a.minute ?? Infinity) - (b.minute ?? Infinity))
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+        <div className="flex flex-col gap-1">
+          <span className="truncate text-center text-xs text-muted-foreground">{nameA}</span>
+          <Input
+            type="number"
+            min={0}
+            inputMode="numeric"
+            value={goals.length > 0 ? goalsForA : pointsA}
+            disabled={goals.length > 0}
+            onChange={(e) => setPoints([e.target.value, pointsB])}
+            placeholder="0"
+          />
+        </div>
+        <span className="pt-5 text-muted-foreground">–</span>
+        <div className="flex flex-col gap-1">
+          <span className="truncate text-center text-xs text-muted-foreground">{nameB}</span>
+          <Input
+            type="number"
+            min={0}
+            inputMode="numeric"
+            value={goals.length > 0 ? goalsForB : pointsB}
+            disabled={goals.length > 0}
+            onChange={(e) => setPoints([pointsA, e.target.value])}
+            placeholder="0"
+          />
+        </div>
+      </div>
+
+      {!detailOpen ? (
+        <Button type="button" variant="ghost" size="sm" className="self-start" onClick={() => setDetailOpen(true)}>
+          <Plus className="size-3.5" /> Add goal-by-goal detail
+        </Button>
+      ) : (
+        <div className="flex flex-col gap-2 rounded-lg border bg-muted/30 p-3">
+          {events.length > 0 && (
+            <div className="flex flex-col gap-1">
+              {events.map((event, i) => {
+                const isSideB = event.side_id === bId
+                return (
+                  <p
+                    key={i}
+                    className={`flex items-baseline gap-1.5 text-xs ${isSideB ? 'flex-row-reverse text-right' : ''}`}
+                  >
+                    <span aria-hidden>{eventEmoji(event.kind)}</span>
+                    {event.minute !== undefined && (
+                      <span className="font-medium text-foreground">{event.minute}'</span>
+                    )}
+                    <span className="truncate">{describeEvent(event, match)}</span>
+                  </p>
+                )
+              })}
+            </div>
+          )}
+          <div className="flex gap-1.5">
+            <Button type="button" variant="outline" size="sm" onClick={() => setDialogKind('goal')}>
+              + Goal
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => setDialogKind('foul')}>
+              + Foul
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <RecordNetballEventDialog
+        open={dialogKind !== null}
+        kind={dialogKind}
+        match={match}
+        initialMinute={0}
+        onOpenChange={(open) => !open && setDialogKind(null)}
+        onSubmit={submitEvent}
+        submitting={false}
+      />
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/NetballScorecard.tsx
+++ b/agon_ui/src/components/agon/NetballScorecard.tsx
@@ -1,0 +1,44 @@
+import type { components } from '@/types/api'
+import { describeEvent, eventEmoji, eventsFromDetail, minuteLabel, type NetballEventSource } from '@/lib/netballScore'
+
+type Match = components['schemas']['Match']
+
+/**
+ * A netball match's full event timeline — every goal and foul recorded
+ * (event-by-event live scoring only; quarter-only scoring has no
+ * goal-by-goal detail to show — see `netballEventSourceFromScore`), each
+ * attributed to a player and minute. Same role as `FootballScorecard`:
+ * unlike `LiveMatchBlock`'s mini-ticker this isn't gated on the match still
+ * being in progress, so it's what keeps goals visible on the match detail
+ * page once the match is completed. Renders nothing if there's no event
+ * detail recorded.
+ */
+export function NetballScorecard({ match, detail }: { match: Match; detail: NetballEventSource }) {
+  const events = eventsFromDetail(detail)
+  if (events.length === 0) return null
+
+  const [, sideB] = match.sides
+
+  return (
+    <div className="rounded-xl border bg-card p-4">
+      <p className="mb-3 text-sm font-medium">Match events</p>
+      <div className="flex flex-col gap-1.5">
+        {events.map((event, i) => {
+          const isSideB = event.side_id === sideB?.id
+          return (
+            <p
+              key={i}
+              className={`flex items-baseline gap-1.5 text-sm ${isSideB ? 'flex-row-reverse text-right' : ''}`}
+            >
+              <span aria-hidden>{eventEmoji(event.kind)}</span>
+              <span className="font-medium tabular-nums text-muted-foreground">
+                {minuteLabel(event.minute)}
+              </span>
+              <span>{describeEvent(event, match, detail.players)}</span>
+            </p>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/NetballScorersBySide.tsx
+++ b/agon_ui/src/components/agon/NetballScorersBySide.tsx
@@ -1,0 +1,71 @@
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { scorersBySide, type NetballScorerLine } from '@/lib/netballScore'
+import type { ScorePlayers } from '@/lib/members'
+
+type NetballGoalEvent = components['schemas']['NetballGoalEvent']
+type MatchSide = components['schemas']['MatchSide']
+type Match = components['schemas']['Match']
+type FeedMatch = components['schemas']['FeedMatch']
+type SearchMatch = components['schemas']['SearchMatch']
+
+/**
+ * Every netball scorer for a finished match, grouped by side and merged onto
+ * one line per player with each minute they scored — same role and layout as
+ * `FootballScorersBySide`. Empty (renders nothing) for a quarter-only-scored
+ * or manually-entered result, which has no goal-by-goal detail to draw from.
+ */
+export function NetballScorersBySide({
+  goals,
+  match,
+  players,
+  sideA,
+  sideB,
+  className,
+}: {
+  goals: NetballGoalEvent[]
+  match: Match | FeedMatch | SearchMatch
+  players?: ScorePlayers
+  sideA: MatchSide | undefined
+  sideB: MatchSide | undefined
+  className?: string
+}) {
+  const bySide = scorersBySide(goals, match, players)
+  const scorersA = bySide[sideA?.id ?? ''] ?? []
+  const scorersB = bySide[sideB?.id ?? ''] ?? []
+
+  if (scorersA.length === 0 && scorersB.length === 0) return null
+
+  return (
+    <div className={cn('flex justify-between gap-3 border-t pt-2 text-muted-foreground', className)}>
+      <ScorerColumn scorers={scorersA} />
+      <ScorerColumn scorers={scorersB} align="right" />
+    </div>
+  )
+}
+
+function ScorerColumn({
+  scorers,
+  align,
+}: {
+  scorers: NetballScorerLine[]
+  align?: 'right'
+}) {
+  return (
+    <div className={cn('min-w-0 flex-1 space-y-1', align === 'right' && 'text-right')}>
+      {scorers.map((s) => (
+        <p key={s.key} className="truncate">
+          {s.name}
+          {s.minutes.length > 0 && (
+            <>
+              {' '}
+              <span className="font-medium text-foreground">
+                {s.minutes.map((m) => `${m}'`).join(', ')}
+              </span>
+            </>
+          )}
+        </p>
+      ))}
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/SportPicker.tsx
+++ b/agon_ui/src/components/agon/SportPicker.tsx
@@ -9,6 +9,7 @@ const SPORTS: MatchType[] = [
   'table_tennis',
   'football',
   'cricket',
+  'netball',
   'other',
 ]
 

--- a/agon_ui/src/components/agon/live/NetballMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/NetballMatchBlock.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+import type { components } from '@/types/api'
+import { Avatar } from '@/components/agon/Avatar'
+import { LiveIndicator } from './LiveIndicator'
+import {
+  describeEvent,
+  eventEmoji,
+  liveClockLabel,
+  recentEvents,
+  type NetballScore,
+} from '@/lib/netballScore'
+
+/** How often the clock label re-renders. Minute-granularity, so this just
+ *  needs to be frequent enough to feel live, not per-second. */
+const CLOCK_TICK_MS = 15_000
+
+type Match = components['schemas']['Match']
+type FeedMatch = components['schemas']['FeedMatch']
+type SearchMatch = components['schemas']['SearchMatch']
+type MatchSide = components['schemas']['MatchSide']
+
+function sideName(side: MatchSide | undefined, fallback: string): string {
+  return side?.name?.trim() || fallback
+}
+
+/**
+ * The score block + mini-ticker for a netball match being scored live — same
+ * role/layout as football's `LiveMatchBlock`. Shows recent goals/fouls when
+ * there's event-by-event detail to draw from (`recentEvents`); a
+ * quarter-only-scored match just shows the running score and clock, no
+ * ticker, since there's no goal-by-goal detail behind it at all.
+ * Presentational: the caller fetches the live score (`useMatchScore`) and
+ * passes the derived netball score down.
+ */
+export function NetballMatchBlock({
+  match,
+  state,
+  tickerLimit = 2,
+}: {
+  match: Match | FeedMatch | SearchMatch
+  state: NetballScore
+  /** How many recent events to show under the score. */
+  tickerLimit?: number
+}) {
+  const [sideA, sideB] = match.sides
+  const nameA = sideName(sideA, 'Side A')
+  const nameB = sideName(sideB, 'Side B')
+  const goalsFor = (sideId: string | undefined) =>
+    (sideId ? state.score[sideId] : undefined) ?? 0
+
+  const events = recentEvents(state, tickerLimit)
+
+  // Ticks every viewer's clock in lockstep — the minute is computed from the
+  // shared period-marker timestamps on `state`, not a per-device clock.
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), CLOCK_TICK_MS)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <div className="rounded-lg bg-muted/50 px-3.5 py-3">
+      <div className="flex items-center justify-between">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Avatar name={nameA} size="md" />
+          <span className="truncate text-xs font-medium">{nameA}</span>
+        </div>
+        <div className="px-3 text-center">
+          <div className="text-2xl font-medium leading-none tracking-tight">
+            {goalsFor(sideA?.id)}
+            <span className="text-muted-foreground">–</span>
+            {goalsFor(sideB?.id)}
+          </div>
+          <div className="mt-1 flex items-center justify-center">
+            {(() => {
+              const label = liveClockLabel(state, now)
+              return <LiveIndicator>{label === 'LIVE' ? undefined : label}</LiveIndicator>
+            })()}
+          </div>
+        </div>
+        <div className="flex min-w-0 flex-1 flex-row-reverse items-center gap-2 text-right">
+          <Avatar name={nameB} size="md" />
+          <span className="truncate text-xs font-medium">{nameB}</span>
+        </div>
+      </div>
+
+      {events.length > 0 && (
+        <div className="mt-2.5 space-y-1 border-t pt-2">
+          {events.map((event, i) => {
+            const isSideB = event.side_id === sideB?.id
+            return (
+              <p
+                key={i}
+                className={`flex items-baseline gap-1.5 truncate text-xs text-muted-foreground ${isSideB ? 'flex-row-reverse text-right' : ''}`}
+              >
+                <span aria-hidden>{eventEmoji(event.kind)}</span>
+                {event.minute !== undefined && (
+                  <span className="font-medium text-foreground">{event.minute}'</span>
+                )}
+                <span className="truncate">{describeEvent(event, match, state.players)}</span>
+              </p>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/agon_ui/src/components/agon/live/RecordNetballEventDialog.tsx
+++ b/agon_ui/src/components/agon/live/RecordNetballEventDialog.tsx
@@ -1,0 +1,236 @@
+import { useEffect, useState } from 'react'
+import type { components } from '@/types/api'
+import { cn } from '@/lib/utils'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { playersOnSide } from '@/lib/members'
+import { PlayerPicker, SidePicker } from './Pickers'
+
+type Match = components['schemas']['Match']
+type NetballLiveEvent = components['schemas']['NetballLiveEvent']
+type NetballFoulKind = components['schemas']['NetballFoulKind']
+
+export type NetballEventKind = 'goal' | 'foul'
+
+const FOUL_KINDS: NetballFoulKind[] = ['contact', 'obstruction', 'footwork', 'offside', 'held_ball', 'other']
+const FOUL_KIND_LABEL: Record<NetballFoulKind, string> = {
+  contact: 'Contact',
+  obstruction: 'Obstruction',
+  footwork: 'Footwork',
+  offside: 'Offside',
+  held_ball: 'Held ball',
+  other: 'Other',
+}
+
+function MinuteField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  return (
+    <div className="flex items-center gap-2">
+      <Label htmlFor="netball-event-minute" className="shrink-0 text-xs text-muted-foreground">
+        Minute (this quarter)
+      </Label>
+      <Input
+        id="netball-event-minute"
+        type="number"
+        min={0}
+        inputMode="numeric"
+        className="h-8 w-20"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </div>
+  )
+}
+
+interface GoalDraft {
+  side_id?: string
+  scorer_player_id?: string
+  two_points: boolean
+  minute: string
+}
+
+interface FoulDraft {
+  side_id?: string
+  player_id?: string
+  foul_kind?: NetballFoulKind
+  minute: string
+}
+
+function toMinute(minute: string): number | undefined {
+  const n = Number(minute)
+  return minute !== '' && Number.isFinite(n) && n >= 0 ? n : undefined
+}
+
+/**
+ * The event-entry dialog for netball's event-by-event live scoring — one
+ * component covers both recordable kinds (goal / foul), same pattern as
+ * football's `RecordEventDialog`. Quarter-only scoring never opens this;
+ * it records period-end scores directly (see `LiveScoringPage`'s netball
+ * flow).
+ */
+export function RecordNetballEventDialog({
+  open,
+  kind,
+  match,
+  initialMinute,
+  onOpenChange,
+  onSubmit,
+  submitting,
+}: {
+  open: boolean
+  kind: NetballEventKind | null
+  /** Only `sides`/`players` are read — a manual-entry caller without a real
+   *  match yet (see `NetballScoreFields`) can pass a synthetic object with
+   *  just these two fields. */
+  match: Pick<Match, 'sides' | 'players'>
+  initialMinute: number
+  onOpenChange: (open: boolean) => void
+  onSubmit: (event: NetballLiveEvent) => void
+  submitting: boolean
+}) {
+  const [goal, setGoal] = useState<GoalDraft>({ two_points: false, minute: '' })
+  const [foul, setFoul] = useState<FoulDraft>({ minute: '' })
+
+  useEffect(() => {
+    if (!open) return
+    const minute = String(initialMinute)
+    setGoal({ two_points: false, minute })
+    setFoul({ minute })
+  }, [open, initialMinute, kind])
+
+  if (!kind) return null
+
+  const side = match.sides.find((s) => s.id === (kind === 'goal' ? goal.side_id : foul.side_id))
+  const roster = side ? playersOnSide(match.players, side) : []
+
+  const title = kind === 'goal' ? 'Goal' : 'Foul'
+
+  const canSubmit = kind === 'goal' ? !!goal.side_id : !!foul.side_id && !!foul.foul_kind
+
+  const submit = () => {
+    if (kind === 'goal' && goal.side_id) {
+      onSubmit({
+        kind: 'Goal',
+        side_id: goal.side_id,
+        scorer_player_id: goal.scorer_player_id,
+        two_points: goal.two_points,
+        minute: toMinute(goal.minute),
+      } as NetballLiveEvent)
+    } else if (kind === 'foul' && foul.side_id && foul.foul_kind) {
+      onSubmit({
+        kind: 'Foul',
+        side_id: foul.side_id,
+        player_id: foul.player_id,
+        foul_kind: foul.foul_kind,
+        minute: toMinute(foul.minute),
+      } as NetballLiveEvent)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <div>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Side
+            </p>
+            <SidePicker
+              sides={match.sides}
+              value={kind === 'goal' ? goal.side_id : foul.side_id}
+              onChange={(sideId) => {
+                if (kind === 'goal') setGoal((d) => ({ ...d, side_id: sideId, scorer_player_id: undefined }))
+                else setFoul((d) => ({ ...d, side_id: sideId, player_id: undefined }))
+              }}
+            />
+          </div>
+
+          {side && kind === 'goal' && (
+            <>
+              <label className="flex items-center gap-1.5 text-xs">
+                <input
+                  type="checkbox"
+                  checked={goal.two_points}
+                  onChange={(e) => setGoal((d) => ({ ...d, two_points: e.target.checked }))}
+                />
+                Two-point zone
+              </label>
+              <div>
+                <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Scorer (optional)
+                </p>
+                <PlayerPicker
+                  players={roster}
+                  value={goal.scorer_player_id}
+                  onChange={(id) =>
+                    setGoal((d) => ({
+                      ...d,
+                      scorer_player_id: d.scorer_player_id === id ? undefined : id,
+                    }))
+                  }
+                />
+              </div>
+            </>
+          )}
+
+          {side && kind === 'foul' && (
+            <>
+              <div>
+                <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  Player (optional)
+                </p>
+                <PlayerPicker
+                  players={roster}
+                  value={foul.player_id}
+                  onChange={(id) =>
+                    setFoul((d) => ({ ...d, player_id: d.player_id === id ? undefined : id }))
+                  }
+                />
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                {FOUL_KINDS.map((fk) => (
+                  <button
+                    key={fk}
+                    type="button"
+                    aria-pressed={foul.foul_kind === fk}
+                    onClick={() => setFoul((d) => ({ ...d, foul_kind: fk }))}
+                    className={cn(
+                      'rounded-lg border p-2 text-xs font-medium transition-colors',
+                      foul.foul_kind === fk
+                        ? 'border-primary bg-accent text-accent-foreground'
+                        : 'text-muted-foreground hover:bg-muted',
+                    )}
+                  >
+                    {FOUL_KIND_LABEL[fk]}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+
+          <MinuteField
+            value={kind === 'goal' ? goal.minute : foul.minute}
+            onChange={(v) => {
+              if (kind === 'goal') setGoal((d) => ({ ...d, minute: v }))
+              else setFoul((d) => ({ ...d, minute: v }))
+            }}
+          />
+
+          <Button disabled={!canSubmit || submitting} onClick={submit}>
+            {submitting ? 'Saving…' : `Add ${title.toLowerCase()}`}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -7,6 +7,7 @@ type LiveEvent = components['schemas']['LiveEvent']
 type NewLiveEventInput = components['schemas']['NewLiveEventInput']
 type FootballLiveEvent = components['schemas']['FootballLiveEvent']
 type CricketLiveEvent = components['schemas']['CricketLiveEvent']
+type NetballLiveEvent = components['schemas']['NetballLiveEvent']
 
 /** Drains every page of a match's raw live event log, oldest first. */
 async function drainLiveEvents(matchId: string): Promise<LiveEvent[]> {
@@ -121,6 +122,10 @@ export function useAppendFootballEvent(matchId: string) {
 
 export function useAppendCricketEvent(matchId: string) {
   return useAppendLiveEvent<CricketLiveEvent>(matchId, 'Cricket')
+}
+
+export function useAppendNetballEvent(matchId: string) {
+  return useAppendLiveEvent<NetballLiveEvent>(matchId, 'Netball')
 }
 
 /**

--- a/agon_ui/src/lib/matchFormat.ts
+++ b/agon_ui/src/lib/matchFormat.ts
@@ -3,6 +3,7 @@ import type { components } from '@/types/api'
 export type MatchFormat = components['schemas']['MatchFormat']
 export type FootballFormat = components['schemas']['FootballFormat']
 export type CricketFormat = components['schemas']['CricketFormat']
+export type NetballFormat = components['schemas']['NetballFormat']
 
 /**
  * App-side defaults for an unconfigured match — the backend stores `format`
@@ -30,6 +31,14 @@ export const DEFAULT_CRICKET_FORMAT: CricketFormat = {
   free_hit_after_no_ball: true,
 }
 
+/** Standard 4×15-minute-quarters defaults — the most common club format. */
+export const DEFAULT_NETBALL_FORMAT: NetballFormat = {
+  num_quarters: 4,
+  quarter_length_minutes: 15,
+  two_point_zone: false,
+  extra_time: false,
+}
+
 // `Match.format`'s generated type erases the union discriminant (same quirk
 // as `Invitation.kind` in `lib/members.ts` — openapi-typescript widens a
 // union nested inside an object to `Omit<Union, "sport"> & unknown`, so
@@ -55,4 +64,12 @@ export function cricketFormat(format: unknown): CricketFormat {
 /** "20 overs" / "Unlimited overs" for a cricket format summary. */
 export function oversLimitLabel(fmt: CricketFormat): string {
   return fmt.overs_per_innings ? `${fmt.overs_per_innings} overs` : 'Unlimited overs'
+}
+
+/** The netball format to use — the match's own if set for netball, else the
+ *  app default. */
+export function netballFormat(format: unknown): NetballFormat {
+  const fmt = format as MatchFormat | null | undefined
+  if (fmt && fmt.sport === 'Netball') return fmt
+  return DEFAULT_NETBALL_FORMAT
 }

--- a/agon_ui/src/lib/netballScore.ts
+++ b/agon_ui/src/lib/netballScore.ts
@@ -1,0 +1,418 @@
+import type { components } from '@/types/api'
+import { memberName, type ScorePlayers } from './members'
+
+export type NetballPeriod = components['schemas']['NetballPeriod']
+export type NetballGoalEvent = components['schemas']['NetballGoalEvent']
+type NetballFoulEvent = components['schemas']['NetballFoulEvent']
+type Score = components['schemas']['Score']
+type MatchPlayer = components['schemas']['MatchPlayer']
+type FeedMatch = components['schemas']['FeedMatch']
+type SearchMatch = components['schemas']['SearchMatch']
+/** Anything with an optional `players` list — see `members.ts`'s `MatchLike`
+ *  for why `FeedMatch`/`SearchMatch` need their own explicit branches. */
+type MatchLike = { players?: MatchPlayer[] } | FeedMatch | SearchMatch
+
+/** A netball `Score` — live or finished, confirmed or not, and regardless of
+ *  which of netball's two live-scoring methods produced it (see
+ *  `NetballScore`'s backend doc comment). Narrowed via `type`, so this
+ *  retains the `type: 'Netball'` tag and is itself a valid `Score` to send
+ *  back on a PATCH, same as `FootballScore` in `lib/liveScore.ts`. */
+export type NetballScore = Extract<Score, { type: 'Netball' }>
+
+/** Narrows a match's score to its netball variant, or `null` when there's
+ *  none yet or it's for a different sport. */
+export function netballScoreFrom(score: Score | null | undefined): NetballScore | null {
+  if (!score || score.type !== 'Netball') return null
+  return score
+}
+
+/** What `eventsFromDetail` reads off a `NetballScore` — narrowed so a
+ *  finished match's `Score.Netball` and a live one can both feed the same
+ *  timeline (same pattern as `FootballEventSource`). `null` for a
+ *  quarter-only-scored or manually-entered result, which carries no
+ *  goal-by-goal detail at all. */
+export type NetballEventSource = {
+  goals: NetballGoalEvent[]
+  fouls: NetballFoulEvent[]
+  players: ScorePlayers
+}
+
+export function netballEventSourceFromScore(score: Score | null | undefined): NetballEventSource | null {
+  if (!score || score.type !== 'Netball') return null
+  if (!score.goals && !score.fouls) return null
+  return { goals: score.goals ?? [], fouls: score.fouls ?? [], players: score.players }
+}
+
+/** A client-side view of one netball event, merging `NetballScore`'s
+ *  separately-typed `goals`/`fouls` lists into one timeline — same role as
+ *  `FootballEventView`. */
+export type NetballEventKind = 'goal' | 'two_point_goal' | 'foul'
+export interface NetballEventView {
+  kind: NetballEventKind
+  side_id: string
+  minute?: number
+  player_id?: string
+}
+
+function goalKind(g: NetballGoalEvent): NetballEventKind {
+  return g.two_points ? 'two_point_goal' : 'goal'
+}
+
+/** Maps a bare goals list — `NetballScore.goals`, live or finished — to
+ *  event views. Unsorted; callers order as needed. Empty in quarter-only
+ *  mode, where there's no goal-by-goal detail behind the tally at all. */
+export function goalEventsToViews(goals: NetballGoalEvent[]): NetballEventView[] {
+  return goals.map((g): NetballEventView => ({
+    kind: goalKind(g),
+    side_id: g.side_id,
+    minute: g.minute,
+    player_id: g.scorer_player_id,
+  }))
+}
+
+/** All of a netball score's goals/fouls merged into one timeline, ordered by
+ *  minute (undated events last). Takes just `NetballEventSource` (not the
+ *  full `NetballScore`) so a finished match's `Score.Netball` can feed it
+ *  too — see `netballEventSourceFromScore`. */
+export function eventsFromDetail(detail: NetballEventSource): NetballEventView[] {
+  const events: NetballEventView[] = [
+    ...goalEventsToViews(detail.goals),
+    ...detail.fouls.map((f): NetballEventView => ({
+      kind: 'foul',
+      side_id: f.side_id,
+      minute: f.minute,
+      player_id: f.player_id,
+    })),
+  ]
+  return events.sort((a, b) => (a.minute ?? Infinity) - (b.minute ?? Infinity))
+}
+
+const EVENT_LABEL: Record<NetballEventKind, string> = {
+  goal: 'Goal',
+  two_point_goal: '2pt goal',
+  foul: 'Foul',
+}
+
+const EVENT_EMOJI: Record<NetballEventKind, string> = {
+  goal: '🏐',
+  two_point_goal: '🏐',
+  foul: '🚫',
+}
+
+export function eventLabel(kind: NetballEventKind): string {
+  return EVENT_LABEL[kind]
+}
+
+export function eventEmoji(kind: NetballEventKind): string {
+  return EVENT_EMOJI[kind]
+}
+
+/** "12'" for a recorded minute (minutes into the *current quarter*, not
+ *  match-wide — see `NetballGoalEvent.minute`'s backend doc comment), else a
+ *  blank string. */
+export function minuteLabel(minute: number | undefined): string {
+  return minute === undefined ? '' : `${minute}'`
+}
+
+const PERIOD_LABEL: Record<NetballPeriod, string> = {
+  start: 'Start',
+  quarter_one_end: 'End of Q1',
+  quarter_two_end: 'Half-time',
+  quarter_three_end: 'End of Q3',
+  full_time: 'Full-time',
+  extra_time_start: 'Extra time',
+  extra_time_end: 'Extra time complete',
+}
+
+export function periodLabel(period: NetballPeriod): string {
+  return PERIOD_LABEL[period]
+}
+
+/** The most recent events first, capped to `limit` — for a mini-ticker. */
+export function recentEvents(detail: NetballScore, limit: number): NetballEventView[] {
+  return eventsFromDetail({
+    goals: detail.goals ?? [],
+    fouls: detail.fouls ?? [],
+    players: detail.players,
+  })
+    .reverse()
+    .slice(0, limit)
+}
+
+/** Player display name for a match-scoped player id — same contract as
+ *  football's `playerNameFor` in `lib/liveScore.ts`. */
+function playerNameFor(
+  match: MatchLike,
+  playerId: string | undefined,
+  scorePlayers?: ScorePlayers,
+): string | null {
+  if (!playerId) return null
+  const resolved = scorePlayers?.[playerId]
+  if (resolved) return resolved.name
+  const players = ('players' in match && match.players) || []
+  const player = players.find((p) => p.member.id === playerId)
+  return player ? memberName(player.member) : null
+}
+
+/** One-line human description of a netball event, e.g. "Goal — J. Elgar" or
+ *  "2pt goal — A. Silva". Which side it belongs to isn't repeated in the
+ *  text; callers convey that by aligning/positioning the row using
+ *  `event.side_id` instead (see football's `describeEvent`). */
+export function describeEvent(
+  event: NetballEventView,
+  match: MatchLike,
+  scorePlayers?: ScorePlayers,
+): string {
+  const scorer = playerNameFor(match, event.player_id, scorePlayers)
+  return scorer ? `${eventLabel(event.kind)} — ${scorer}` : eventLabel(event.kind)
+}
+
+/** One goalscorer's line for a side's scorer list — same shape/role as
+ *  football's `FootballScorerLine`. */
+export interface NetballScorerLine {
+  key: string
+  name: string
+  minutes: number[]
+}
+
+/** All of a netball match's goals, grouped by crediting side and then by
+ *  scorer — same construction as football's `scorersBySide`, minus the
+ *  own-goal handling netball has no equivalent of. */
+export function scorersBySide(
+  goals: NetballGoalEvent[],
+  match: MatchLike,
+  scorePlayers?: ScorePlayers,
+): Record<string, NetballScorerLine[]> {
+  const bySide: Record<string, Map<string, NetballScorerLine>> = {}
+  for (const g of goals) {
+    const lines = (bySide[g.side_id] ??= new Map())
+    const key = g.scorer_player_id ?? 'unknown'
+    const name = playerNameFor(match, g.scorer_player_id, scorePlayers) ?? 'Unknown'
+    const line = lines.get(key) ?? { key, name, minutes: [] }
+    if (g.minute !== undefined) line.minutes.push(g.minute)
+    lines.set(key, line)
+  }
+  const out: Record<string, NetballScorerLine[]> = {}
+  for (const [sideId, lines] of Object.entries(bySide)) {
+    out[sideId] = [...lines.values()]
+      .map((line) => ({ ...line, minutes: [...line.minutes].sort((a, b) => a - b) }))
+      .sort((a, b) => (a.minutes[0] ?? Infinity) - (b.minutes[0] ?? Infinity))
+  }
+  return out
+}
+
+/** The score as of a given quarter marker, straight off
+ *  `NetballScore.period_scores` — the same map both of netball's
+ *  live-scoring methods populate (see its backend doc comment), so this
+ *  works identically whichever produced the score. */
+export function periodScore(
+  detail: NetballScore,
+  period: NetballPeriod,
+): Record<string, number> | undefined {
+  return detail.period_scores?.[period]
+}
+
+/** When a given period marker was recorded, if at all. */
+export function periodTime(detail: NetballScore, period: NetballPeriod): string | undefined {
+  return detail.period_times?.[period]
+}
+
+// ---------------------------------------------------------------------------
+// Scoring method — which of netball's two live-scoring methods this match's
+// scorer is using. Client-only, same as football's `TrackPrefs`: the backend
+// doesn't need to know (both methods write the exact same `NetballLiveEvent`
+// vocabulary — see `NetballLiveEvent`'s backend doc comment), this just picks
+// which screen `NetballLiveScoringPage` shows. Chosen once, before the first
+// event, and inferred after that from whether the live state already has
+// goal-by-goal detail (see `NetballLiveScoringPage`), so this preference is
+// really just a tiebreaker for a fresh match with no events yet.
+// ---------------------------------------------------------------------------
+
+export type NetballScoringMethod = 'event_by_event' | 'quarter_only'
+
+function methodKey(matchId: string): string {
+  return `agon:netball-scoring-method:${matchId}`
+}
+
+export function loadNetballScoringMethod(matchId: string): NetballScoringMethod | null {
+  try {
+    const raw = localStorage.getItem(methodKey(matchId))
+    return raw === 'event_by_event' || raw === 'quarter_only' ? raw : null
+  } catch {
+    return null
+  }
+}
+
+export function saveNetballScoringMethod(matchId: string, method: NetballScoringMethod): void {
+  try {
+    localStorage.setItem(methodKey(matchId), method)
+  } catch {
+    // Best-effort — a private-browsing/full-storage failure just means the
+    // choice is asked again next visit, not worth surfacing.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Match clock — derived from `NetballScore.period_times`, the same "shared
+// server data, not a per-device stopwatch" approach as football's clock (see
+// `lib/liveScore.ts`'s module doc comment). Unlike football, a goal's
+// `minute` is scoped to the *current quarter* (it resets each quarter), so
+// the clock here doesn't need to accumulate across periods the way
+// football's does — it's just time since whichever marker started the
+// current quarter.
+// ---------------------------------------------------------------------------
+
+export type ClockPhase =
+  | 'not_started'
+  | 'quarter_1'
+  | 'quarter_2'
+  | 'quarter_3'
+  | 'quarter_4'
+  | 'full_time'
+  | 'extra_time'
+  | 'finished'
+
+/** Which phase the match is in right now, purely from recorded markers. Each
+ *  marker doubles as the start of the next quarter — netball's breaks are
+ *  too short to need a separate "quarter N start" event (see
+ *  `NetballPeriod`'s backend doc comment). */
+export function phaseFromState(state: NetballScore): ClockPhase {
+  if (periodTime(state, 'extra_time_end')) return 'finished'
+  if (periodTime(state, 'extra_time_start')) return 'extra_time'
+  if (periodTime(state, 'full_time')) return 'full_time'
+  if (periodTime(state, 'quarter_three_end')) return 'quarter_4'
+  if (periodTime(state, 'quarter_two_end')) return 'quarter_3'
+  if (periodTime(state, 'quarter_one_end')) return 'quarter_2'
+  if (periodTime(state, 'start')) return 'quarter_1'
+  return 'not_started'
+}
+
+/** The marker that starts the *current* quarter — what the clock counts
+ *  minutes from (`currentMinute`) — `undefined` for a phase with no clock
+ *  running (`not_started`, `full_time`, `finished`). */
+function currentQuarterStartedAt(state: NetballScore, phase: ClockPhase): string | undefined {
+  switch (phase) {
+    case 'quarter_1':
+      return periodTime(state, 'start')
+    case 'quarter_2':
+      return periodTime(state, 'quarter_one_end')
+    case 'quarter_3':
+      return periodTime(state, 'quarter_two_end')
+    case 'quarter_4':
+      return periodTime(state, 'quarter_three_end')
+    case 'extra_time':
+      return periodTime(state, 'extra_time_start')
+    case 'not_started':
+    case 'full_time':
+    case 'finished':
+      return undefined
+  }
+}
+
+/** Minutes elapsed in the current quarter — matches the scope of
+ *  `NetballGoalEvent.minute`, so this can prefill a new goal's minute field
+ *  directly. `null` when there's no quarter currently running. */
+export function currentMinute(state: NetballScore, now: Date = new Date()): number | null {
+  const phase = phaseFromState(state)
+  const startedAt = currentQuarterStartedAt(state, phase)
+  if (!startedAt) return null
+  return Math.max(0, Math.floor((now.getTime() - new Date(startedAt).getTime()) / 60_000))
+}
+
+/** Whether the ball is live right now — the phases a goal/foul can
+ *  meaningfully be recorded in. Used to gate the live scoring screen's quick
+ *  actions on the current phase, same role as football's `isLivePlayPhase`. */
+export function isLivePlayPhase(phase: ClockPhase): boolean {
+  return phase === 'quarter_1' || phase === 'quarter_2' || phase === 'quarter_3' || phase === 'quarter_4' || phase === 'extra_time'
+}
+
+/** Human label for the current phase, e.g. "3rd quarter" / "Half-time". */
+export function phaseLabel(phase: ClockPhase): string {
+  switch (phase) {
+    case 'not_started':
+      return 'Not started'
+    case 'quarter_1':
+      return '1st quarter'
+    case 'quarter_2':
+      return '2nd quarter'
+    case 'quarter_3':
+      return '3rd quarter'
+    case 'quarter_4':
+      return '4th quarter'
+    case 'full_time':
+      return 'Full-time'
+    case 'extra_time':
+      return 'Extra time'
+    case 'finished':
+      return 'Finished'
+  }
+}
+
+/** A compact clock label for a score box, e.g. "12'", "HT", "FT". */
+export function liveClockLabel(state: NetballScore, now: Date = new Date()): string {
+  const phase = phaseFromState(state)
+  if (phase === 'full_time' || phase === 'finished') return 'FT'
+  const minute = currentMinute(state, now)
+  return minute === null ? 'LIVE' : `${minute}'`
+}
+
+/** Whether extra time can extend the match beyond full time, and whether
+ *  it's currently needed (level on goals) — same role as football's
+ *  `FootballProgressionContext`. */
+export interface NetballProgressionContext {
+  isDraw: boolean
+  extraTime: boolean
+}
+
+/** The `NetballPeriod` marker to record for "the next thing that happens"
+ *  from the current phase — what the live scoring screen's quarter-end quick
+ *  action should send. `null` once the match is done, or before it's
+ *  started (the first event any live-scoring method records is `Start`
+ *  itself, so there's no "next marker" to prefill before that). */
+export function nextPeriodForPhase(
+  phase: ClockPhase,
+  ctx: NetballProgressionContext,
+): NetballPeriod | null {
+  switch (phase) {
+    case 'not_started':
+      return 'start'
+    case 'quarter_1':
+      return 'quarter_one_end'
+    case 'quarter_2':
+      return 'quarter_two_end'
+    case 'quarter_3':
+      return 'quarter_three_end'
+    case 'quarter_4':
+      return 'full_time'
+    case 'full_time':
+      return ctx.isDraw && ctx.extraTime ? 'extra_time_start' : null
+    case 'extra_time':
+      return 'extra_time_end'
+    case 'finished':
+      return null
+  }
+}
+
+/** Label for the clock's quick-action button, contextual to the current phase. */
+export function nextPhaseActionLabel(
+  phase: ClockPhase,
+  ctx: NetballProgressionContext,
+): string {
+  switch (phase) {
+    case 'not_started':
+      return 'Start match'
+    case 'quarter_1':
+      return 'End 1st quarter'
+    case 'quarter_2':
+      return 'End 2nd quarter (half-time)'
+    case 'quarter_3':
+      return 'End 3rd quarter'
+    case 'quarter_4':
+      return ctx.isDraw && ctx.extraTime ? 'Full-time — start extra time' : 'Full-time'
+    case 'extra_time':
+      return 'End extra time'
+    case 'full_time':
+    case 'finished':
+      return 'Full-time'
+  }
+}

--- a/agon_ui/src/lib/score.ts
+++ b/agon_ui/src/lib/score.ts
@@ -4,6 +4,7 @@ type Match = components['schemas']['Match']
 type Score = components['schemas']['Score']
 type MatchSide = components['schemas']['MatchSide']
 type FootballGoalEvent = components['schemas']['FootballGoalEvent']
+type NetballGoalEvent = components['schemas']['NetballGoalEvent']
 
 /** A finished football match's goals, straight off its confirmed/pending
  *  score — `null` for any other score type, or a football score with no
@@ -12,6 +13,14 @@ type FootballGoalEvent = components['schemas']['FootballGoalEvent']
  *  the match is over. */
 export function footballGoalsFromScore(score: Score): FootballGoalEvent[] | null {
   return score.type === 'Football' ? (score.goals ?? null) : null
+}
+
+/** A finished netball match's goals, straight off its confirmed/pending
+ *  score — `null` for any other score type, or a netball score with no
+ *  goal-by-goal detail attached (a quarter-only-scored or manual entry with
+ *  just the final tally). Same role as `footballGoalsFromScore`. */
+export function netballGoalsFromScore(score: Score): NetballGoalEvent[] | null {
+  return score.type === 'Netball' ? (score.goals ?? null) : null
 }
 
 /** The score to display for a match: the confirmed result if present, else the
@@ -40,14 +49,18 @@ export function displayScore(
  * The headline number a side shows: for a Sets score it's the count of sets won
  * (across index-aligned entries); for a Simple score it's the points; for a
  * Football score it's the goal tally (`score.score`, keyed by side id —
- * already correct including own goals, which credit the benefiting side).
- * Returns a map of side id → headline value. A `Cricket` score has no single
- * headline number to show here — `CricketMatchBlock`/`CricketScoreBlock`
- * render it their own way — so it's an empty map, same as "no score yet".
+ * already correct including own goals, which credit the benefiting side);
+ * for a Netball score it's the same kind of running goal tally, whichever of
+ * netball's two live-scoring methods produced it (see
+ * `NetballScore.score`'s backend doc comment). Returns a map of side id →
+ * headline value. A `Cricket` score has no single headline number to show
+ * here — `CricketMatchBlock`/`CricketScoreBlock` render it their own way —
+ * so it's an empty map, same as "no score yet".
  */
 export function headlineBySide(score: Score): Record<string, number> {
   if (score.type === 'Simple') return { ...score.entries }
   if (score.type === 'Football') return { ...score.score }
+  if (score.type === 'Netball') return { ...score.score }
   if (score.type === 'Cricket') return {}
   // Sets: a side wins a set at index i if its games exceed every other side's.
   const out: Record<string, number> = {}

--- a/agon_ui/src/lib/sports.ts
+++ b/agon_ui/src/lib/sports.ts
@@ -18,6 +18,7 @@ const SPORT_LABELS: Record<MatchType, string> = {
   table_tennis: 'Table Tennis',
   football: 'Football',
   cricket: 'Cricket',
+  netball: 'Netball',
   other: 'Other',
 }
 
@@ -34,6 +35,7 @@ const SPORT_ICONS: Record<MatchType, LucideIcon> = {
   table_tennis: CircleDot,
   football: Volleyball,
   cricket: Target,
+  netball: Target,
   other: Dumbbell,
 }
 
@@ -53,6 +55,7 @@ const SPORT_EMOJI: Record<MatchType, string> = {
   table_tennis: '🏓',
   football: '⚽',
   cricket: '🏏',
+  netball: '🏐',
   other: '🏅',
 }
 

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -11,6 +11,7 @@ import { RecordEventDialog, type EventKind } from '@/components/agon/live/Record
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { UndoLastEventButton } from '@/components/agon/live/UndoLastEventButton'
 import { CricketLiveScoringPage } from './CricketLiveScoringPage'
+import { NetballLiveScoringPage } from './NetballLiveScoringPage'
 import { footballFormat } from '@/lib/matchFormat'
 import {
   currentMinute,
@@ -39,9 +40,11 @@ function sideName(match: Match, index: number, fallback: string): string {
 
 /**
  * Route entry for `/matches/:matchId/live`: fetches the match once and
- * dispatches to the sport-specific scoring screen. Football and cricket have
- * different live-scoring shapes entirely (a running clock vs. overs/wickets),
- * so past the match fetch they don't share a component.
+ * dispatches to the sport-specific scoring screen. Football, cricket, and
+ * netball have different live-scoring shapes entirely (a running clock vs.
+ * overs/wickets vs. netball's own two-method choice — see
+ * `NetballLiveScoringPage`), so past the match fetch they don't share a
+ * component.
  */
 export function LiveScoringPage() {
   const { matchId } = useParams()
@@ -80,6 +83,9 @@ export function LiveScoringPage() {
   const match = matchQuery.data
   if (match.match_type === 'cricket') {
     return <CricketLiveScoringPage match={match} />
+  }
+  if (match.match_type === 'netball') {
+    return <NetballLiveScoringPage match={match} />
   }
   return <FootballLiveScoringPage match={match} />
 }

--- a/agon_ui/src/pages/LogMatchPage.tsx
+++ b/agon_ui/src/pages/LogMatchPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/agon/PlayerSideEditor'
 import { FootballScoreFields } from '@/components/agon/FootballScoreFields'
 import { CricketScoreFields } from '@/components/agon/CricketScoreFields'
+import { NetballScoreFields } from '@/components/agon/NetballScoreFields'
 import { cn } from '@/lib/utils'
 import { toDateTimeLocal } from '@/lib/datetime'
 import { addPendingMatch } from '@/hooks/usePendingMatches'
@@ -178,6 +179,7 @@ export function LogMatchPage() {
   const setsPlayable = isSetsSport(sport ?? 'other')
   const isFootball = sport === 'football'
   const isCricket = sport === 'cricket'
+  const isNetball = sport === 'netball'
 
   // Is the picked time valid for the chosen mode? Completed matches must be in
   // the past, scheduled ones in the future (matches the server's rule). Empty or
@@ -199,7 +201,7 @@ export function LogMatchPage() {
   // inline hint), or null when the score state is acceptable for the mode.
   const scoreError = useMemo((): string | null => {
     if (mode !== 'completed') return null
-    if (isFootball || isCricket) {
+    if (isFootball || isCricket || isNetball) {
       return detailBuilt ? null : 'Enter the score'
     }
     if (setsPlayable) {
@@ -222,7 +224,7 @@ export function LogMatchPage() {
     if (pointsA === '' || pointsB === '' || !Number.isFinite(a) || !Number.isFinite(b))
       return 'Enter the score for both sides'
     return null
-  }, [mode, isFootball, isCricket, detailBuilt, setsPlayable, sets, pointsA, pointsB])
+  }, [mode, isFootball, isCricket, isNetball, detailBuilt, setsPlayable, sets, pointsA, pointsB])
 
   // Validation: a sport, a match name, at least one player on each side (so the
   // match is meaningful), at least one opponent on side B, a time valid for the
@@ -298,7 +300,7 @@ export function LogMatchPage() {
     | null => {
     if (!recordResult || !sport) return null
 
-    if (isFootball || isCricket) {
+    if (isFootball || isCricket || isNetball) {
       if (!detailBuilt) return null
       return {
         score: detailBuilt.score as unknown as CreateMatchInput['score'],
@@ -405,8 +407,8 @@ export function LogMatchPage() {
         />
       </Section>
 
-      {/* Format (optional, football/cricket only) */}
-      {sport !== null && (sport === 'football' || sport === 'cricket') && (
+      {/* Format (optional, football/cricket/netball only) */}
+      {sport !== null && (sport === 'football' || sport === 'cricket' || sport === 'netball') && (
         <Section title="Match format">
           <MatchFormatEditor sport={sport} value={format} onChange={setFormat} />
         </Section>
@@ -509,7 +511,7 @@ export function LogMatchPage() {
       {mode === 'completed' &&
         (playersSet ? (
           <Section num={5} title="Score">
-          {(isFootball || isCricket) && (() => {
+          {(isFootball || isCricket || isNetball) && (() => {
             const sideAObj: MatchSide = { id: SIDE_A, name: sideAName.trim() || undefined }
             const sideBObj: MatchSide = { id: SIDE_B, name: sideBName.trim() || undefined }
             const players = [...toMatchPlayers(sideA, SIDE_A), ...toMatchPlayers(sideB, SIDE_B)]
@@ -520,8 +522,15 @@ export function LogMatchPage() {
                 players={players}
                 onChange={setDetailBuilt}
               />
-            ) : (
+            ) : isCricket ? (
               <CricketScoreFields
+                sideA={sideAObj}
+                sideB={sideBObj}
+                players={players}
+                onChange={setDetailBuilt}
+              />
+            ) : (
+              <NetballScoreFields
                 sideA={sideAObj}
                 sideB={sideBObj}
                 players={players}
@@ -530,7 +539,7 @@ export function LogMatchPage() {
             )
           })()}
 
-          {!isFootball && !isCricket && setsPlayable && (
+          {!isFootball && !isCricket && !isNetball && setsPlayable && (
             <div className="flex flex-col gap-2">
               <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 text-center text-[11px] uppercase tracking-wider text-muted-foreground">
                 <span className="truncate text-left">{sideName(sideA, sideAName, 'Your side')}</span>
@@ -594,7 +603,7 @@ export function LogMatchPage() {
             </div>
           )}
 
-          {!isFootball && !isCricket && !setsPlayable && (
+          {!isFootball && !isCricket && !isNetball && !setsPlayable && (
             <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
               <div className="flex flex-col gap-1">
                 <span className="truncate text-center text-xs text-muted-foreground">

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -13,16 +13,28 @@ import { StatusBadge, matchBadgeStatus } from '@/components/agon/StatusBadge'
 import { ScoreConfirmationBar } from '@/components/agon/ScoreConfirmationBar'
 import { LiveMatchBlock } from '@/components/agon/live/LiveMatchBlock'
 import { CricketMatchBlock } from '@/components/agon/live/CricketMatchBlock'
+import { NetballMatchBlock } from '@/components/agon/live/NetballMatchBlock'
 import { CricketScoreBlock } from '@/components/agon/CricketScoreBlock'
 import { CricketScorecard } from '@/components/agon/CricketScorecard'
 import { FootballScorecard } from '@/components/agon/FootballScorecard'
 import { FootballScorersBySide } from '@/components/agon/FootballScorersBySide'
+import { NetballScorecard } from '@/components/agon/NetballScorecard'
+import { NetballScorersBySide } from '@/components/agon/NetballScorersBySide'
+import { NetballQuarterBreakdown } from '@/components/agon/NetballQuarterBreakdown'
 import { useLiveEvents } from '@/hooks/useLiveScore'
 import { useMatchScore } from '@/hooks/useMatchScore'
 import { footballScoreFrom, footballEventSourceFromScore } from '@/lib/liveScore'
+import { netballScoreFrom, netballEventSourceFromScore } from '@/lib/netballScore'
 import { cricketInningsFor, cricketScoreFrom, inningsDeliveriesFromEvents } from '@/lib/cricketScore'
 import { useCurrentUserId } from '@/hooks/useCurrentUserId'
-import { displayScore, footballGoalsFromScore, headlineBySide, headlineLabel, setLine } from '@/lib/score'
+import {
+  displayScore,
+  footballGoalsFromScore,
+  netballGoalsFromScore,
+  headlineBySide,
+  headlineLabel,
+  setLine,
+} from '@/lib/score'
 import {
   isParticipant,
   memberAvatarUrl,
@@ -116,7 +128,8 @@ function MatchDetail({
 
   const canEdit = isParticipant(match, currentUserId)
   const cancelled = match.status === 'cancelled'
-  const isLiveSport = match.match_type === 'football' || match.match_type === 'cricket'
+  const isLiveSport =
+    match.match_type === 'football' || match.match_type === 'cricket' || match.match_type === 'netball'
 
   const [sideA, sideB] = match.sides
   const nameA = sideName(sideA, 'Side A')
@@ -143,15 +156,19 @@ function MatchDetail({
   const isCurrentlyLive = isLiveSport && match.status === 'in_progress'
   const footballState = isCurrentlyLive ? footballScoreFrom(scoreQuery.data) : null
   const cricketState = isCurrentlyLive ? cricketScoreFrom(scoreQuery.data) : null
-  const hasLiveState = !!footballState || !!cricketState
-  // Goals for a finished football match, read straight off the
+  const netballState = isCurrentlyLive ? netballScoreFrom(scoreQuery.data) : null
+  const hasLiveState = !!footballState || !!cricketState || !!netballState
+  // Goals for a finished football/netball match, read straight off the
   // confirmed/pending score — shown as a scorer breakdown under the plain
   // score box below (same as the feed/profile card's `MatchCard`); the full
-  // event timeline (goals *and* cards/subs) stays in `FootballScorecard`
-  // further down the page regardless.
+  // event timeline (goals *and* cards/subs, or goals *and* fouls) stays in
+  // `FootballScorecard`/`NetballScorecard` further down the page regardless.
   const finishedFootballGoals = scoreInfo && !isCurrentlyLive ? footballGoalsFromScore(scoreInfo.score) : null
   const finishedFootballScorePlayers =
     scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
+  const finishedNetballGoals = scoreInfo && !isCurrentlyLive ? netballGoalsFromScore(scoreInfo.score) : null
+  const finishedNetballScorePlayers =
+    scoreInfo && !isCurrentlyLive ? netballScoreFrom(scoreInfo.score)?.players : undefined
   // Same "live while in progress, else confirmed/pending" source as
   // `cricketScoreInnings` below — needed here just for `.players` (the
   // score's resolved-name map), passed to `CricketScorecard`.
@@ -162,10 +179,23 @@ function MatchDetail({
   const footballEventSource = footballEventSourceFromScore(
     isCurrentlyLive ? scoreQuery.data : scoreInfo?.score,
   )
-  // Football's setup screen also gates starting the clock; cricket has no
-  // equivalent preferences step, so it goes straight into scoring.
+  const netballEventSource = netballEventSourceFromScore(
+    isCurrentlyLive ? scoreQuery.data : scoreInfo?.score,
+  )
+  // Quarter-by-quarter breakdown reads the same way regardless of which of
+  // netball's two live-scoring methods produced the score (see
+  // `NetballQuarterBreakdown`'s doc comment) — shown even for a
+  // quarter-only-scored match with no goal-by-goal detail at all.
+  const netballQuarterScore = isCurrentlyLive ? netballState : netballScoreFrom(scoreInfo?.score ?? null)
+  // Football's and netball's setup screens also gate starting the clock;
+  // cricket has no equivalent preferences step, so it goes straight into
+  // scoring. Netball's "which live-scoring method" choice lives inline on
+  // its own live page instead of a separate setup route (see
+  // `NetballLiveScoringPage`).
   const liveEntryPath =
-    match.match_type === 'cricket' ? `/matches/${match.id}/live` : `/matches/${match.id}/live/setup`
+    match.match_type === 'cricket' || match.match_type === 'netball'
+      ? `/matches/${match.id}/live`
+      : `/matches/${match.id}/live/setup`
 
   // Each cricket innings' deliveries, folded in from the raw live event log
   // by matching innings order, for the run-rate graph — the score's own
@@ -222,6 +252,10 @@ function MatchDetail({
             <div className="mt-3">
               <LiveMatchBlock match={match} state={footballState} tickerLimit={3} />
             </div>
+          ) : netballState ? (
+            <div className="mt-3">
+              <NetballMatchBlock match={match} state={netballState} tickerLimit={3} />
+            </div>
           ) : cricketState ? (
             <div className="mt-3">
               <CricketMatchBlock match={match} state={cricketState} />
@@ -272,6 +306,17 @@ function MatchDetail({
               goals={finishedFootballGoals}
               match={match}
               players={finishedFootballScorePlayers}
+              sideA={sideA}
+              sideB={sideB}
+              className="mt-2 text-xs"
+            />
+          )}
+
+          {finishedNetballGoals && (
+            <NetballScorersBySide
+              goals={finishedNetballGoals}
+              match={match}
+              players={finishedNetballScorePlayers}
               sideA={sideA}
               sideB={sideB}
               className="mt-2 text-xs"
@@ -372,6 +417,19 @@ function MatchDetail({
           recorded (live-scored or entered directly) — stays visible after
           the match finishes, unlike the live score header above. */}
       {footballEventSource && <FootballScorecard match={match} detail={footballEventSource} />}
+
+      {/* Netball quarter breakdown — reads the same regardless of which
+          live-scoring method produced the score (see
+          `NetballQuarterBreakdown`'s doc comment), so it shows even for a
+          quarter-only-scored match. */}
+      {netballQuarterScore && (
+        <NetballQuarterBreakdown score={netballQuarterScore} sideA={sideA} sideB={sideB} />
+      )}
+
+      {/* Netball event timeline: goals/fouls, only present for an
+          event-by-event-scored match — stays visible after the match
+          finishes, unlike the live score header above. */}
+      {netballEventSource && <NetballScorecard match={match} detail={netballEventSource} />}
 
       {/* Invite more people (participants only). */}
       {canEdit && !cancelled && (

--- a/agon_ui/src/pages/NetballLiveScoringPage.tsx
+++ b/agon_ui/src/pages/NetballLiveScoringPage.tsx
@@ -1,0 +1,561 @@
+import { useEffect, useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useNavigate, Link } from 'react-router-dom'
+import { CircleDot, OctagonAlert, TimerReset } from 'lucide-react'
+import { fetchClient } from '@/lib/api-client'
+import type { components } from '@/types/api'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useAppendNetballEvent, useLiveSeq } from '@/hooks/useLiveScore'
+import { matchScoreQueryKey, useMatchScore } from '@/hooks/useMatchScore'
+import {
+  RecordNetballEventDialog,
+  type NetballEventKind,
+} from '@/components/agon/live/RecordNetballEventDialog'
+import { NetballQuarterBreakdown } from '@/components/agon/NetballQuarterBreakdown'
+import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
+import { UndoLastEventButton } from '@/components/agon/live/UndoLastEventButton'
+import { netballFormat } from '@/lib/matchFormat'
+import {
+  currentMinute,
+  describeEvent,
+  eventEmoji,
+  eventsFromDetail,
+  isLivePlayPhase,
+  loadNetballScoringMethod,
+  netballScoreFrom,
+  nextPeriodForPhase,
+  nextPhaseActionLabel,
+  phaseFromState,
+  phaseLabel,
+  saveNetballScoringMethod,
+  type ClockPhase,
+  type NetballPeriod,
+  type NetballScore,
+  type NetballScoringMethod,
+} from '@/lib/netballScore'
+
+type Match = components['schemas']['Match']
+type UpdateMatchInput = components['schemas']['UpdateMatchInput']
+type Score = components['schemas']['Score']
+
+function sideName(match: Match, index: number, fallback: string): string {
+  return match.sides[index]?.name?.trim() || fallback
+}
+
+/** The quarter-end markers in play order, extra time last — what
+ *  quarter-only mode walks through one at a time. */
+const QUARTER_SEQUENCE: NetballPeriod[] = [
+  'quarter_one_end',
+  'quarter_two_end',
+  'quarter_three_end',
+  'full_time',
+]
+
+/**
+ * Route entry for a netball match at `/matches/:matchId/live` (dispatched
+ * from `LiveScoringPage`). Netball has two live-scoring methods sharing one
+ * event vocabulary (see `live_score::netball`'s backend doc comment) — this
+ * asks once, before the first event, which one this scorer wants, then
+ * hands off to the matching screen. Once a match has *any* live state,
+ * the method is inferred from it instead (goal-by-goal detail present =
+ * event-by-event; otherwise quarter-only) rather than trusting the saved
+ * preference, so a second device picking up an already-started match
+ * renders the right screen even without its own local preference.
+ */
+export function NetballLiveScoringPage({ match }: { match: Match }) {
+  const scoreQuery = useMatchScore(match.id, { refetchInterval: 8000 })
+  const state = netballScoreFrom(scoreQuery.data)
+  // Only used as the picker's initial value below — once there's *any* live
+  // state, `method` is inferred from it instead (see the picker's own doc
+  // comment), so a stale/never-set local preference can't override reality.
+  const [pickedMethod, setPickedMethod] = useState<NetballScoringMethod | null>(() =>
+    loadNetballScoringMethod(match.id),
+  )
+
+  if (scoreQuery.isLoading) {
+    return (
+      <div className="mx-auto max-w-xl">
+        <div className="h-64 animate-pulse rounded-xl border bg-card" aria-hidden />
+      </div>
+    )
+  }
+
+  const inferredMethod: NetballScoringMethod | null = state
+    ? (state.goals?.length ?? 0) > 0
+      ? 'event_by_event'
+      : 'quarter_only'
+    : null
+  const method = inferredMethod ?? pickedMethod
+
+  if (!method) {
+    return (
+      <NetballScoringMethodPicker
+        match={match}
+        onChoose={(m) => {
+          saveNetballScoringMethod(match.id, m)
+          setPickedMethod(m)
+        }}
+      />
+    )
+  }
+
+  return method === 'event_by_event' ? (
+    <NetballEventByEventScoringPage match={match} state={state} />
+  ) : (
+    <NetballQuarterOnlyScoringPage match={match} state={state} />
+  )
+}
+
+function NetballScoringMethodPicker({
+  match,
+  onChoose,
+}: {
+  match: Match
+  onChoose: (method: NetballScoringMethod) => void
+}) {
+  const nameA = sideName(match, 0, 'Side A')
+  const nameB = sideName(match, 1, 'Side B')
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4">
+      <div>
+        <h1 className="text-lg font-semibold">How do you want to score this?</h1>
+        <p className="text-sm text-muted-foreground">
+          {nameA} vs {nameB} · Netball
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onChoose('event_by_event')}
+        className="rounded-xl border bg-card p-4 text-left transition-colors hover:bg-muted"
+      >
+        <p className="font-medium">Goal by goal</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Log every goal and foul as it happens, with a running quarter clock.
+        </p>
+      </button>
+
+      <button
+        type="button"
+        onClick={() => onChoose('quarter_only')}
+        className="rounded-xl border bg-card p-4 text-left transition-colors hover:bg-muted"
+      >
+        <p className="font-medium">Score at the end of each quarter</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Just enter the running score after each quarter — no goal-by-goal detail.
+        </p>
+      </button>
+    </div>
+  )
+}
+
+/** Shared "finish the match" mutation — PATCHes `status: completed` with
+ *  this device's own view of the live-derived score, same pattern (and same
+ *  409-on-disagreement handling) as football's `finishMatch`. */
+function useFinishNetballMatch(match: Match) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async () => {
+      const state = netballScoreFrom(
+        queryClient.getQueryData<Score | null>(matchScoreQueryKey(match.id)),
+      )
+      const body: UpdateMatchInput = { status: 'completed', score: state ?? undefined }
+      const { error, response } = await fetchClient.PATCH('/matches/{match_id}', {
+        params: { path: { match_id: match.id } },
+        body,
+      })
+      if (response.status === 409) {
+        await queryClient.refetchQueries({ queryKey: matchScoreQueryKey(match.id) })
+        throw new Error('The live score just changed — check the updated score above, then finish again')
+      }
+      if (error) throw new Error('Failed to finish the match')
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['match', match.id] })
+      queryClient.invalidateQueries({ queryKey: ['feed'] })
+      navigate(`/matches/${match.id}`)
+    },
+  })
+}
+
+/** How often the on-screen clock re-renders while a quarter is running. */
+const CLOCK_TICK_MS = 15_000
+
+/**
+ * Event-by-event netball scoring: quick actions to log goals/fouls as they
+ * happen, a running per-quarter clock, and the event log so far — the
+ * netball equivalent of football's `LiveScoringPage`. Advancing the clock
+ * (end of a quarter) auto-fills the `Period` marker's `score` from the
+ * running goal tally the client already has — the user never types a number
+ * here; that's quarter-only mode's job (`NetballQuarterOnlyScoringPage`).
+ */
+function NetballEventByEventScoringPage({ match, state }: { match: Match; state: NetballScore | null }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const seq = useLiveSeq(match.id)
+  const append = useAppendNetballEvent(match.id)
+  const finishMatch = useFinishNetballMatch(match)
+
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), CLOCK_TICK_MS)
+    return () => clearInterval(id)
+  }, [])
+
+  const [dialogKind, setDialogKind] = useState<NetballEventKind | null>(null)
+
+  const nameA = sideName(match, 0, 'Side A')
+  const nameB = sideName(match, 1, 'Side B')
+  const aId = match.sides[0]?.id
+  const bId = match.sides[1]?.id
+  const goalsFor = (sideId: string | undefined) => (sideId ? state?.score[sideId] : undefined) ?? 0
+
+  const format = netballFormat(match.format)
+  const phase: ClockPhase = state ? phaseFromState(state) : 'not_started'
+  const minute = state ? currentMinute(state, now) : null
+  const isDraw = !!state && goalsFor(aId) === goalsFor(bId)
+  const progressionCtx = { isDraw, extraTime: format.extra_time }
+
+  const handleQuarterEnd = () => {
+    const period = nextPeriodForPhase(phase, progressionCtx)
+    if (!period) return
+    append.mutate({ kind: 'Period', period, score: state?.score ?? {} })
+  }
+
+  const advanceClockPhases: ClockPhase[] = ['not_started', 'quarter_1', 'quarter_2', 'quarter_3', 'quarter_4', 'extra_time']
+  const showAdvanceClockTile = advanceClockPhases.includes(phase)
+
+  const actions: { key: string; label: string; icon: React.ReactNode; onClick: () => void; disabled?: boolean }[] = [
+    ...(isLivePlayPhase(phase)
+      ? [
+          { key: 'goal', label: 'Goal', icon: <CircleDot className="size-5" />, onClick: () => setDialogKind('goal') },
+          { key: 'foul', label: 'Foul', icon: <OctagonAlert className="size-5" />, onClick: () => setDialogKind('foul') },
+        ]
+      : []),
+    ...(showAdvanceClockTile
+      ? [
+          {
+            key: 'quarter_end',
+            label: nextPhaseActionLabel(phase, progressionCtx),
+            icon: <TimerReset className="size-5" />,
+            onClick: handleQuarterEnd,
+            disabled: nextPeriodForPhase(phase, progressionCtx) === null,
+          },
+        ]
+      : []),
+  ]
+
+  const decidingPhase = phase === 'full_time'
+  const continuationAvailable = decidingPhase && isDraw && format.extra_time
+  const readyToFinish = (decidingPhase && !continuationAvailable) || phase === 'finished'
+
+  const events = state
+    ? eventsFromDetail({ goals: state.goals ?? [], fouls: state.fouls ?? [], players: state.players }).reverse()
+    : []
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${match.id}`)}>
+          Back
+        </Button>
+        <div className="flex items-center gap-1">
+          <UndoLastEventButton matchId={match.id} seq={seq.data} />
+          <LiveIndicator />
+        </div>
+      </div>
+
+      <div>
+        <h1 className="text-lg font-semibold">
+          {nameA} vs {nameB}
+        </h1>
+        <p className="text-sm text-muted-foreground">You're scoring this match</p>
+      </div>
+
+      <div className="rounded-xl border bg-card p-4">
+        <div className="flex items-center justify-between">
+          <p className="flex-1 truncate text-sm font-medium">{nameA}</p>
+          <div className="px-3 text-center">
+            <div className="text-3xl font-medium tracking-tight">
+              {goalsFor(aId)}
+              <span className="text-muted-foreground">–</span>
+              {goalsFor(bId)}
+            </div>
+            <div className="mt-0.5 text-xs text-primary">
+              {minute !== null && `${minute}' · `}
+              {phaseLabel(phase)}
+            </div>
+          </div>
+          <p className="flex-1 truncate text-right text-sm font-medium">{nameB}</p>
+        </div>
+      </div>
+
+      {actions.length > 0 && (
+        <div className="grid grid-cols-2 gap-3">
+          {actions.map((a) => (
+            <button
+              key={a.key}
+              type="button"
+              disabled={a.disabled}
+              onClick={a.onClick}
+              className="flex flex-col items-center gap-1.5 rounded-xl border bg-card p-5 text-sm font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {a.icon}
+              {a.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {continuationAvailable && (
+        <div className="flex flex-col gap-2">
+          <Button size="lg" disabled={append.isPending} onClick={handleQuarterEnd}>
+            {nextPhaseActionLabel(phase, progressionCtx)}
+          </Button>
+          <Button variant="ghost" size="sm" disabled={finishMatch.isPending} onClick={() => finishMatch.mutate()}>
+            Or finish as a draw
+          </Button>
+        </div>
+      )}
+
+      {readyToFinish && (
+        <Button size="lg" disabled={finishMatch.isPending} onClick={() => finishMatch.mutate()}>
+          {finishMatch.isPending ? 'Finishing…' : 'Finish match'}
+        </Button>
+      )}
+
+      {finishMatch.isError && (
+        <p className="text-center text-xs text-destructive">{(finishMatch.error as Error).message}</p>
+      )}
+
+      <div className="border-t pt-3">
+        <p className="mb-2 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          Match events
+        </p>
+        {events.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No events recorded yet.</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {events.map((event, i) => {
+              const isSideB = event.side_id === match.sides[1]?.id
+              return (
+                <div key={i} className={`flex items-baseline gap-2 text-sm ${isSideB ? 'flex-row-reverse text-right' : ''}`}>
+                  <span className="w-8 shrink-0 text-xs text-muted-foreground">
+                    {event.minute !== undefined ? `${event.minute}'` : ''}
+                  </span>
+                  <span aria-hidden>{eventEmoji(event.kind)}</span>
+                  <span className="min-w-0 truncate">{describeEvent(event, match, state?.players)}</span>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {append.isError && <p className="text-center text-xs text-destructive">Failed to record that event — try again.</p>}
+
+      <RecordNetballEventDialog
+        open={dialogKind !== null}
+        kind={dialogKind}
+        match={match}
+        initialMinute={minute ?? 0}
+        onOpenChange={(open) => !open && setDialogKind(null)}
+        submitting={append.isPending}
+        onSubmit={(event) => {
+          append.mutate(event, {
+            onSuccess: () => {
+              setDialogKind(null)
+              queryClient.invalidateQueries({ queryKey: ['feed'] })
+            },
+          })
+        }}
+      />
+    </div>
+  )
+}
+
+/**
+ * Quarter-only netball scoring: no goal-by-goal detail at all — just the
+ * running score, typed in fresh after each quarter, submitted as a single
+ * `Period` event carrying that score (see `NetballPeriodEvent::score`'s
+ * backend doc comment for why that's the *only* source of the score in this
+ * mode). Walks `QUARTER_SEQUENCE` one marker at a time; each already-entered
+ * quarter shows in `NetballQuarterBreakdown` below.
+ */
+function NetballQuarterOnlyScoringPage({ match, state }: { match: Match; state: NetballScore | null }) {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const append = useAppendNetballEvent(match.id)
+  const finishMatch = useFinishNetballMatch(match)
+
+  const nameA = sideName(match, 0, 'Side A')
+  const nameB = sideName(match, 1, 'Side B')
+  const [sideA, sideB] = match.sides
+  const aId = sideA?.id
+  const bId = sideB?.id
+
+  const recordedPeriods = new Set(Object.keys(state?.period_scores ?? {}))
+  const nextPeriod = QUARTER_SEQUENCE.find((p) => !recordedPeriods.has(p)) ?? null
+  const currentTotalA = aId ? (state?.score[aId] ?? 0) : 0
+  const currentTotalB = bId ? (state?.score[bId] ?? 0) : 0
+
+  const [draft, setDraft] = useState<[string, string]>(['', ''])
+  useEffect(() => {
+    setDraft([String(currentTotalA), String(currentTotalB)])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nextPeriod])
+
+  const [draftA, draftB] = draft
+  const a = Number(draftA)
+  const b = Number(draftB)
+  const canSubmit =
+    !!nextPeriod && !!aId && !!bId && draftA !== '' && draftB !== '' && Number.isFinite(a) && Number.isFinite(b) && a >= 0 && b >= 0
+
+  const submitQuarter = () => {
+    if (!canSubmit || !nextPeriod || !aId || !bId) return
+    append.mutate({ kind: 'Period', period: nextPeriod, score: { [aId]: a, [bId]: b } })
+  }
+
+  const QUARTER_LABEL: Record<NetballPeriod, string> = {
+    start: 'Start',
+    quarter_one_end: 'End of 1st quarter',
+    quarter_two_end: 'End of 2nd quarter (half-time)',
+    quarter_three_end: 'End of 3rd quarter',
+    full_time: 'Full-time',
+    extra_time_start: 'Extra time',
+    extra_time_end: 'End of extra time',
+  }
+
+  const isDraw = currentTotalA === currentTotalB
+  const format = netballFormat(match.format)
+  const readyToFinish = !nextPeriod || (nextPeriod === 'full_time' && recordedPeriods.has('full_time'))
+  const allQuartersDone = recordedPeriods.has('full_time')
+  const offerExtraTime = allQuartersDone && isDraw && format.extra_time && !recordedPeriods.has('extra_time_end')
+
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${match.id}`)}>
+          Back
+        </Button>
+        <LiveIndicator />
+      </div>
+
+      <div>
+        <h1 className="text-lg font-semibold">
+          {nameA} vs {nameB}
+        </h1>
+        <p className="text-sm text-muted-foreground">Scoring by quarter</p>
+      </div>
+
+      <div className="rounded-xl border bg-card p-4">
+        <div className="flex items-center justify-between">
+          <p className="flex-1 truncate text-sm font-medium">{nameA}</p>
+          <div className="px-3 text-center text-3xl font-medium tracking-tight">
+            {currentTotalA}
+            <span className="text-muted-foreground">–</span>
+            {currentTotalB}
+          </div>
+          <p className="flex-1 truncate text-right text-sm font-medium">{nameB}</p>
+        </div>
+      </div>
+
+      {nextPeriod && !allQuartersDone && (
+        <div className="flex flex-col gap-3 rounded-xl border bg-card p-4">
+          <p className="text-sm font-medium">{QUARTER_LABEL[nextPeriod]} — running score</p>
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+            <div className="flex flex-col gap-1">
+              <span className="truncate text-center text-xs text-muted-foreground">{nameA}</span>
+              <Input
+                type="number"
+                min={0}
+                inputMode="numeric"
+                value={draftA}
+                onChange={(e) => setDraft([e.target.value, draftB])}
+              />
+            </div>
+            <span className="pt-5 text-muted-foreground">–</span>
+            <div className="flex flex-col gap-1">
+              <span className="truncate text-center text-xs text-muted-foreground">{nameB}</span>
+              <Input
+                type="number"
+                min={0}
+                inputMode="numeric"
+                value={draftB}
+                onChange={(e) => setDraft([draftA, e.target.value])}
+              />
+            </div>
+          </div>
+          <Button disabled={!canSubmit || append.isPending} onClick={submitQuarter}>
+            {append.isPending ? 'Saving…' : `Save ${QUARTER_LABEL[nextPeriod].toLowerCase()}`}
+          </Button>
+        </div>
+      )}
+
+      {offerExtraTime && (
+        <Button
+          variant="outline"
+          disabled={!aId || !bId || append.isPending}
+          onClick={() => aId && bId && append.mutate({ kind: 'Period', period: 'extra_time_start', score: { [aId]: currentTotalA, [bId]: currentTotalB } })}
+        >
+          Start extra time
+        </Button>
+      )}
+      {recordedPeriods.has('extra_time_start') && !recordedPeriods.has('extra_time_end') && (
+        <div className="flex flex-col gap-3 rounded-xl border bg-card p-4">
+          <p className="text-sm font-medium">Extra time — final score</p>
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+            <Input
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={draftA}
+              onChange={(e) => setDraft([e.target.value, draftB])}
+            />
+            <span className="pt-2 text-center text-muted-foreground">–</span>
+            <Input
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={draftB}
+              onChange={(e) => setDraft([draftA, e.target.value])}
+            />
+          </div>
+          <Button
+            disabled={!aId || !bId || draftA === '' || draftB === '' || append.isPending}
+            onClick={() =>
+              aId && bId && append.mutate({ kind: 'Period', period: 'extra_time_end', score: { [aId]: a, [bId]: b } })
+            }
+          >
+            Save extra time result
+          </Button>
+        </div>
+      )}
+
+      {readyToFinish && !offerExtraTime && (
+        <Button size="lg" disabled={finishMatch.isPending} onClick={() => finishMatch.mutate()}>
+          {finishMatch.isPending ? 'Finishing…' : 'Finish match'}
+        </Button>
+      )}
+
+      {(finishMatch.isError || append.isError) && (
+        <p className="text-center text-xs text-destructive">
+          {finishMatch.isError ? (finishMatch.error as Error).message : 'Failed to save that quarter — try again.'}
+        </p>
+      )}
+
+      {state && <NetballQuarterBreakdown score={state} sideA={sideA} sideB={sideB} />}
+
+      <Link
+        to={`/matches/${match.id}`}
+        className="text-center text-sm text-muted-foreground hover:underline"
+        onClick={() => queryClient.invalidateQueries({ queryKey: ['feed'] })}
+      >
+        Done for now
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
Backend: NetballScore/NetballFormat/NetballLiveEvent types mirroring
football's pattern, wired through main.rs, mapping.rs, and the DAO
records layer. Both of netball's live-scoring methods (event-by-event
goal/foul logging, and quarter-only score entry) share one event
vocabulary: Goal/Foul events accumulate the score in event-by-event
mode, while a Period marker always carries a score snapshot that is
the sole source of truth in quarter-only mode and a checkpoint
otherwise — one apply_event fold handles both without knowing which
mode a given match is using.

Caught and fixed a real bug along the way: NetballFoulEvent's own
`kind` field collided with the outer live-event union's `kind`
discriminator once flattened onto the same JSON object, silently
dropping the foul's kind on the wire. Renamed to `foul_kind` on both
the API and DAO record types, with a regression test locking in the
fix.

Regenerated the OpenAPI schema/client and TS types, extended the
agon_tests integration suite with event-by-event and quarter-only
coverage (via raw JSON — the generated Rust client's nested sport/kind
union flattening is a separate pre-existing limitation), and added
netball support across the UI: sport registry, match format editor,
score/scorecard/quarter-breakdown display, manual result entry, and a
dedicated live-scoring page for both methods.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YXVHeS4CpEafhUah4FJBwc