### PR TITLE
Allow logging a match with no players on the opposition side

### DIFF
--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -276,12 +276,12 @@ struct MatchSide {
     /// the pick-from-squad UI). None = ad-hoc side with manually picked players.
     team_id: Option<String>,
     /// Display name for this side, resolved fresh on every response (see
-    /// `Api::hydrate_match`) — never None in practice. Priority: the sole
-    /// player's name if there's exactly one, else a custom name the creator
-    /// gave the side, else the team's name, else "Your side"/"Opposition"
-    /// relative to the caller, else a neutral "Team A"/"Team B". Computed
-    /// per-request rather than stored so it can't go stale and "your side"
-    /// always means the caller.
+    /// `Api::hydrate_match`) — never None in practice. Priority: a custom
+    /// name the creator gave the side, else the sole player's name if
+    /// there's exactly one, else the team's name, else "Your
+    /// side"/"Opposition" relative to the caller, else a neutral "Team
+    /// A"/"Team B". Computed per-request rather than stored so it can't go
+    /// stale and "your side" always means the caller.
     name: Option<String>,
     /// This side's full roster, when small enough to show directly instead of
     /// just `name`/`team_id`'s logo (1v1, doubles, a small squad). `None`
@@ -2297,8 +2297,8 @@ impl Api {
         }
 
         // A side with no players has no player to fall back on for its display
-        // name (see `Api::resolve_side_names`'s priority chain: sole player's
-        // name -> custom name -> team's name -> ...), so it needs a team or an
+        // name (see `Api::resolve_side_names`'s priority chain: custom name ->
+        // sole player's name -> team's name -> ...), so it needs a team or an
         // explicit name to be identifiable at all — e.g. recording a result
         // against an opposition you don't know the roster of.
         for side in &input.sides {
@@ -4947,10 +4947,10 @@ impl Api {
 
     /// Hydrate every match in `matches` for one response: fill in each `User`
     /// player's `name`/`avatar_url` from their account, and resolve every
-    /// side's display `name` — the sole player's name if there's exactly one,
-    /// else a custom name the creator gave the side (an ad-hoc side, or one
-    /// of two sides sharing a team), else the assigned team's name, else a
-    /// fallback relative to `viewer_uid` — "Your side"/"Opposition" if
+    /// side's display `name` — a custom name the creator gave the side (an
+    /// ad-hoc side, or one of two sides sharing a team), else the sole
+    /// player's name if there's exactly one, else the assigned team's name,
+    /// else a fallback relative to `viewer_uid` — "Your side"/"Opposition" if
     /// they're actually playing in the match, else a neutral "Team A"/
     /// "Team B" by side order. Resolved per-request rather than stored, so a
     /// side's name can't go stale and "your side" always reflects whoever is
@@ -5082,14 +5082,14 @@ impl Api {
                 .map(str::trim)
                 .filter(|n| !n.is_empty());
 
-            side.name = Some(match sole_player_name {
-                Some(name) => name,
-                // A custom name (only ever set alongside a team when two
-                // sides share it — see the create-time validation) wins over
-                // the team's own name, since it's there specifically to tell
-                // those sides apart.
-                None => match custom_name {
-                    Some(name) => name.to_string(),
+            side.name = Some(match custom_name {
+                // An explicit name always wins, over both the sole player's
+                // name and the team's own name — it's there specifically
+                // because the creator wanted something other than either
+                // default (e.g. to tell two sides sharing one team apart).
+                Some(name) => name.to_string(),
+                None => match sole_player_name {
+                    Some(name) => name,
                     None => match &side.team_id {
                         Some(team_id) => team_names
                             .get(team_id)
@@ -5108,7 +5108,7 @@ impl Api {
     }
 
     /// The same side-name priority chain as [`Self::resolve_side_names`]
-    /// (sole player's name → custom name → team name → "Your
+    /// (custom name → sole player's name → team name → "Your
     /// side"/"Opposition" → neutral "Team A"/"Team B"), for a `FeedMatch` or
     /// `SearchMatch` — which never have the full player list to scan.
     ///
@@ -5134,10 +5134,12 @@ impl Api {
                 .map(str::trim)
                 .filter(|n| !n.is_empty());
 
-            side.name = Some(match sole_player_name {
-                Some(name) => name,
-                None => match custom_name {
-                    Some(name) => name.to_string(),
+            side.name = Some(match custom_name {
+                // Same priority as `resolve_side_names`: an explicit name
+                // always wins over the sole player's name.
+                Some(name) => name.to_string(),
+                None => match sole_player_name {
+                    Some(name) => name,
                     None => match &side.team_id {
                         Some(team_id) => team_names
                             .get(team_id)

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2296,6 +2296,24 @@ impl Api {
             }
         }
 
+        // A side with no players has no player to fall back on for its display
+        // name (see `Api::resolve_side_names`'s priority chain: sole player's
+        // name -> custom name -> team's name -> ...), so it needs a team or an
+        // explicit name to be identifiable at all — e.g. recording a result
+        // against an opposition you don't know the roster of.
+        for side in &input.sides {
+            let side_id = &side_ids[&side.client_id];
+            let has_players = player_records
+                .iter()
+                .any(|p| p.side_id.as_deref() == Some(side_id.as_str()));
+            if !has_players && side.team_id.is_none() && side.name.is_none() {
+                return Ok(CreateMatchResponse::ValidationError(PlainText(format!(
+                    "side `{}` has no players, so it needs a name or a team",
+                    side.client_id
+                ))));
+            }
+        }
+
         // Resolve a create-time score's client-side ids to real side/player ids
         // (reject an unknown reference). This becomes a PENDING submission, not
         // a confirmed score: the reported result awaits the other side(s)'
@@ -2579,6 +2597,75 @@ impl Api {
                             rename.side_id
                         ))));
                     }
+                }
+            }
+        }
+
+        // A side with no players (after this request's roster edits, if any)
+        // needs a team or an explicit name to remain identifiable — same rule
+        // `create_match` enforces up front. Only worth projecting when this
+        // request can actually change a side's player count or name; an
+        // unrelated edit (e.g. renaming the match) leaves existing sides alone.
+        if input.added_players.is_some()
+            || input.removed_player_ids.is_some()
+            || input.side_assignments.is_some()
+            || input.side_names.is_some()
+        {
+            // Project each existing player's resulting side_id: drop removed
+            // ids, then apply this request's reassignments (unlisted players
+            // keep their current side). `added_players` contribute their own
+            // side_id straight away — they don't exist in `agg.players` yet.
+            let removed: std::collections::HashSet<&str> = input
+                .removed_player_ids
+                .iter()
+                .flatten()
+                .map(String::as_str)
+                .collect();
+            let reassigned: std::collections::HashMap<&str, &Option<String>> = input
+                .side_assignments
+                .iter()
+                .flatten()
+                .map(|a| (a.player_id.as_str(), &a.side_id))
+                .collect();
+
+            let mut final_side_ids: Vec<Option<String>> = agg
+                .players
+                .iter()
+                .filter(|p| !removed.contains(p.player_id.as_str()))
+                .map(|p| match reassigned.get(p.player_id.as_str()) {
+                    Some(side_id) => (*side_id).clone(),
+                    None => p.side_id.clone(),
+                })
+                .collect();
+            final_side_ids.extend(
+                input
+                    .added_players
+                    .iter()
+                    .flatten()
+                    .map(|p| p.side_id.clone()),
+            );
+
+            for side in &agg.sides {
+                let has_players = final_side_ids
+                    .iter()
+                    .any(|sid| sid.as_deref() == Some(side.side_id.as_str()));
+                if has_players {
+                    continue;
+                }
+                // A rename in this request wins over the side's existing
+                // custom name (mirrors how the rename itself is applied).
+                let effective_name = input
+                    .side_names
+                    .iter()
+                    .flatten()
+                    .find(|r| r.side_id == side.side_id)
+                    .map(|r| r.name.clone())
+                    .unwrap_or_else(|| side.name.clone());
+                if side.team_id.is_none() && effective_name.is_none() {
+                    return Ok(UpdateMatchResponse::ValidationError(PlainText(format!(
+                        "side `{}` would have no players, so it needs a name or a team",
+                        side.side_id
+                    ))));
                 }
             }
         }

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -487,17 +487,18 @@ async fn patch_match_updates_name() {
 }
 
 /// A match's ad-hoc side names (given at create time) can be edited afterwards
-/// via `side_names`, and clearing one (`name: None`) falls back to the
-/// server-resolved default rather than staying stuck on the old custom name.
+/// via `side_names`, and clearing one (`name: None`) falls back to the next
+/// entry in the priority chain rather than staying stuck on the old custom
+/// name.
 ///
-/// Renames side "b" specifically: side "a" carries the sole invited player,
-/// and a side with exactly one player always displays *that player's* name
-/// ahead of any custom name (see `Api::resolve_side_names`'s priority chain),
-/// so a rename there wouldn't be observable in the resolved `name`. Side "b"
-/// has no players, so its resolved name is its custom name (or, once
-/// cleared, the neutral "Team B" fallback — the owner isn't a participant on
-/// either side, so no "Your side"/"Opposition" applies) — a rename there is
-/// directly observable.
+/// Side "a" carries both a custom name *and* the sole invited player: an
+/// explicit name always wins over the sole player's name (see
+/// `Api::resolve_side_names`'s priority chain), so it resolves to "Side A"
+/// throughout, and clearing that name falls through to reveal the player's
+/// name underneath. Side "b" has no players, so its resolved name is its
+/// custom name; clearing *that* one is exercised separately (see
+/// `clearing_the_name_of_an_empty_side_is_rejected`) since an empty,
+/// teamless side can't be left without a name at all.
 #[tokio::test]
 async fn patch_match_renames_sides() {
     let (config, _owner) = new_user().await;
@@ -506,9 +507,25 @@ async fn patch_match_renames_sides() {
     let created = matches_post(&config, create_match_input(&invitee.profile.id))
         .await
         .expect("create match");
-    let side_a = created.sides[0].id.clone();
-    let side_b = created.sides[1].id.clone();
-    assert_eq!(created.sides[1].name.as_deref(), Some("Side B"));
+    // Response side order isn't creation order (sides sort by their
+    // generated id), so resolve "a"/"b" by roster rather than by index.
+    let side_a = side_id_for_user(&created, &invitee.profile.id);
+    let side_b = created
+        .sides
+        .iter()
+        .find(|s| s.id != side_a)
+        .expect("a second side")
+        .id
+        .clone();
+    assert_eq!(
+        created.sides.iter().find(|s| s.id == side_a).unwrap().name.as_deref(),
+        Some("Side A"),
+        "a custom name wins over the sole player's name"
+    );
+    assert_eq!(
+        created.sides.iter().find(|s| s.id == side_b).unwrap().name.as_deref(),
+        Some("Side B")
+    );
 
     let renamed = matches_match_id_patch(
         &config,
@@ -528,18 +545,19 @@ async fn patch_match_renames_sides() {
     assert_eq!(renamed_b.name.as_deref(), Some("The Champions"));
     assert_eq!(
         untouched_a.name.as_deref(),
-        Some("Test User"),
-        "a side not named in the request is left alone (still showing its sole player's name)"
+        Some("Side A"),
+        "a side not named in the request is left alone"
     );
 
-    // Clearing the custom name (name: None) falls back to the neutral
-    // "Team B" default (no team, no sole player, caller not a participant).
+    // Clearing side "a"'s custom name is safe (it still has a player to fall
+    // back on) and reveals the priority chain's next entry: the sole
+    // player's name.
     let cleared = matches_match_id_patch(
         &config,
         &created.id,
         models::UpdateMatchInput {
             side_names: Some(vec![models::UpdateMatchSideNameInput {
-                side_id: side_b.clone(),
+                side_id: side_a.clone(),
                 name: None,
             }]),
             ..Default::default()
@@ -547,11 +565,51 @@ async fn patch_match_renames_sides() {
     )
     .await
     .expect("clear side name");
-    let cleared_b = cleared.sides.iter().find(|s| s.id == side_b).unwrap();
+    let cleared_a = cleared.sides.iter().find(|s| s.id == side_a).unwrap();
     assert_eq!(
-        cleared_b.name.as_deref(),
-        Some("Team B"),
-        "clearing the custom name must not leave the old value in place"
+        cleared_a.name.as_deref(),
+        Some("Test User"),
+        "clearing the custom name falls back to the sole player's name"
+    );
+}
+
+/// The counterpart to `patch_match_renames_sides`'s side "a" case: side "b"
+/// has no players and no team, so its custom name is the only thing keeping
+/// it identifiable — clearing it (rather than replacing it) is rejected,
+/// same as at create time.
+#[tokio::test]
+async fn clearing_the_name_of_an_empty_side_is_rejected() {
+    let (config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&config, create_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = side_id_for_user(&created, &invitee.profile.id);
+    let side_b = created
+        .sides
+        .iter()
+        .find(|s| s.id != side_a)
+        .expect("a second side")
+        .id
+        .clone();
+
+    let response = matches_match_id_patch(
+        &config,
+        &created.id,
+        models::UpdateMatchInput {
+            side_names: Some(vec![models::UpdateMatchSideNameInput {
+                side_id: side_b,
+                name: None,
+            }]),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_status_with_content(
+        response,
+        reqwest::StatusCode::BAD_REQUEST,
+        "would have no players",
     );
 }
 

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -2291,6 +2291,91 @@ async fn creating_a_match_with_one_side_is_rejected() {
     );
 }
 
+/// A side with no players is fine (recording a result against an opposition
+/// whose roster you don't know) as long as it's identifiable some other way —
+/// here, an explicit name. `create_match_input`'s side "b" already carries no
+/// invites, so this only has to strip its name.
+#[tokio::test]
+async fn creating_a_match_with_an_unnamed_empty_side_is_rejected() {
+    let (config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+    let mut input = create_match_input(&invitee.profile.id);
+    input.sides[1].name = None; // side "b": no players, no team, now no name either
+    let response = matches_post(&config, input).await;
+    assert_status_with_content(
+        response,
+        reqwest::StatusCode::BAD_REQUEST,
+        "needs a name or a team",
+    );
+}
+
+/// The counterpart to the rejection above: an empty side with an explicit
+/// name is accepted, and that name is what the side resolves to (no players
+/// to fall back on, no team, so the custom name is the only source left).
+#[tokio::test]
+async fn creating_a_match_with_a_named_empty_side_succeeds() {
+    let (config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+    let input = create_match_input(&invitee.profile.id); // side "b" is empty, named "Side B"
+    let created = matches_post(&config, input).await.expect("create match");
+    // Response side order isn't creation order (sides sort by their generated
+    // id), so find the empty one by roster rather than assuming an index.
+    let side_b = created
+        .sides
+        .iter()
+        .find(|s| !created.players.iter().any(|p| p.side_id.as_deref() == Some(s.id.as_str())))
+        .expect("one side has no players");
+    assert_eq!(side_b.name.as_deref(), Some("Side B"));
+}
+
+/// Same rule, projected forward at edit time: a request that would both clear
+/// a side's name *and* move its only player off it (leaving it with no
+/// players and no name) is rejected, mirroring `create_match`'s check.
+#[tokio::test]
+async fn emptying_an_unnamed_side_via_side_assignments_is_rejected() {
+    let (owner_config, owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+    let created = matches_post(
+        &owner_config,
+        match_between("Test Match", &[&owner.profile.id], &[&invitee.profile.id]),
+    )
+    .await
+    .expect("create match");
+
+    let side_a = side_id_for_user(&created, &owner.profile.id);
+    let side_b = side_id_for_user(&created, &invitee.profile.id);
+    let player_b_id = created
+        .players
+        .iter()
+        .find_map(|p| match &*p.member {
+            models::Member::User(u) if u.user_id == invitee.profile.id => Some(u.id.clone()),
+            _ => None,
+        })
+        .expect("invitee player");
+
+    let response = matches_match_id_patch(
+        &owner_config,
+        &created.id,
+        models::UpdateMatchInput {
+            side_names: Some(vec![models::UpdateMatchSideNameInput {
+                side_id: side_b.clone(),
+                name: None,
+            }]),
+            side_assignments: Some(vec![models::SetPlayerSideInput {
+                player_id: player_b_id,
+                side_id: Some(side_a),
+            }]),
+            ..Default::default()
+        },
+    )
+    .await;
+    assert_status_with_content(
+        response,
+        reqwest::StatusCode::BAD_REQUEST,
+        "would have no players",
+    );
+}
+
 #[tokio::test]
 async fn scoring_an_unknown_side_is_rejected() {
     let (config, _owner) = new_user().await;

--- a/agon_ui/src/pages/LogMatchPage.tsx
+++ b/agon_ui/src/pages/LogMatchPage.tsx
@@ -229,15 +229,19 @@ export function LogMatchPage() {
   // Validation: a sport, a match name, at least one player on your own side
   // (so the match is meaningful), a time valid for the mode, and — for a
   // completed match — a result. The opposition (side B) may be left empty —
-  // e.g. recording a result against a team you don't know the roster of.
+  // e.g. recording a result against a team you don't know the roster of —
+  // but then needs an explicit name (this flow has no team picker, so a
+  // player-less side has nothing else to show as its name; see the server's
+  // matching check in `create_match`).
   const valid = useMemo(() => {
     if (!sport) return false
     if (name.trim().length === 0) return false
     if (sideA.length === 0) return false
+    if (sideB.length === 0 && sideBName.trim().length === 0) return false
     if (timeError) return false
     if (scoreError) return false
     return true
-  }, [sport, name, sideA.length, timeError, scoreError])
+  }, [sport, name, sideA.length, sideB.length, sideBName, timeError, scoreError])
 
   const mutation = useMutation({
     mutationFn: async (body: CreateMatchInput) => {
@@ -466,6 +470,12 @@ export function LogMatchPage() {
             name={sideBName}
             onNameChange={setSideBName}
           />
+          {sideB.length === 0 && sideBName.trim().length === 0 && (
+            <p className="px-1 text-xs text-muted-foreground">
+              No opponents tagged — give this side a name above (e.g. a team
+              or club name) so the match can show who it was against.
+            </p>
+          )}
         </div>
       </Section>
 

--- a/agon_ui/src/pages/LogMatchPage.tsx
+++ b/agon_ui/src/pages/LogMatchPage.tsx
@@ -226,18 +226,18 @@ export function LogMatchPage() {
     return null
   }, [mode, isFootball, isCricket, isNetball, detailBuilt, setsPlayable, sets, pointsA, pointsB])
 
-  // Validation: a sport, a match name, at least one player on each side (so the
-  // match is meaningful), at least one opponent on side B, a time valid for the
-  // mode, and — for a completed match — a result.
+  // Validation: a sport, a match name, at least one player on your own side
+  // (so the match is meaningful), a time valid for the mode, and — for a
+  // completed match — a result. The opposition (side B) may be left empty —
+  // e.g. recording a result against a team you don't know the roster of.
   const valid = useMemo(() => {
     if (!sport) return false
     if (name.trim().length === 0) return false
     if (sideA.length === 0) return false
-    if (sideB.length === 0) return false
     if (timeError) return false
     if (scoreError) return false
     return true
-  }, [sport, name, sideA.length, sideB.length, timeError, scoreError])
+  }, [sport, name, sideA.length, timeError, scoreError])
 
   const mutation = useMutation({
     mutationFn: async (body: CreateMatchInput) => {
@@ -385,7 +385,9 @@ export function LogMatchPage() {
     mutation.mutate(body)
   }
 
-  const playersSet = sport !== null && sideA.length > 0 && sideB.length > 0
+  // Side B (the opposition) is allowed to be empty — you might be recording
+  // your own team's result without knowing who's on the other side.
+  const playersSet = sport !== null && sideA.length > 0
 
   return (
     <div className="mx-auto flex max-w-xl flex-col gap-3">
@@ -645,7 +647,7 @@ export function LogMatchPage() {
             hint={
               sport === null
                 ? 'Pick a sport to enter the score'
-                : 'Add players to both sides to enter the score'
+                : 'Add players to your side to enter the score'
             }
           />
         ))}

--- a/agon_ui/src/pages/LogMatchPage.tsx
+++ b/agon_ui/src/pages/LogMatchPage.tsx
@@ -68,12 +68,14 @@ interface SetRow {
 /** Whether the match is upcoming (no score) or already played (with a score). */
 type MatchMode = 'scheduled' | 'completed'
 
-/** A display name for a side: the sole player's name, else the custom name
- *  typed for it (if any), else a generic fallback — mirrors the server's
+/** A display name for a side: the custom name typed for it (if any), else the
+ *  sole player's name, else a generic fallback — mirrors the server's
  *  resolution order for this compose form's own preview text. */
 function sideName(players: TaggedPlayer[], customName: string, fallback: string): string {
+  const trimmed = customName.trim()
+  if (trimmed) return trimmed
   if (players.length === 1) return players[0].name
-  return customName.trim() || fallback
+  return fallback
 }
 
 /** Default scheduled time: the next whole hour, at least an hour from now. */


### PR DESCRIPTION
The API already lets a side be created with zero players (see the
`patch_match_renames_sides` test), but LogMatchPage required at least
one player on both sides before the form could be submitted. Relax
that to only require players on the caller's own side — you can now
record a result for your team without tagging anyone on the other
side.