### PR TITLE
Fix feed card headline naming the loser as the winner

### DIFF
--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -213,6 +213,11 @@ export function MatchCard({
   const nameB = sideName(sideB, 'Side B')
   const aWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideA?.id
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
+  // The "X beat Y" headline needs the winner named first, or it reads
+  // backwards whenever B is the one who actually won (the score box below
+  // stays in match.sides order regardless — only this headline reorders).
+  const headlineFirstName = bWon ? nameB : nameA
+  const headlineSecondName = bWon ? nameA : nameB
 
   const isLiveSport =
     match.match_type === 'football' || match.match_type === 'cricket' || match.match_type === 'netball'
@@ -298,12 +303,12 @@ export function MatchCard({
             <span>{cricketDescription}</span>
           ) : (
             <>
-              <span className={cn(aWon && 'font-medium')}>{nameA}</span>
+              <span className={cn(!!scoreInfo?.winnerSideId && 'font-medium')}>{headlineFirstName}</span>
               <span className="text-primary">
                 {' '}
                 {match.match_type !== 'cricket' && scoreInfo?.winnerSideId ? 'beat' : 'vs'}{' '}
               </span>
-              <span className={cn(bWon && 'font-medium')}>{nameB}</span>
+              <span>{headlineSecondName}</span>
             </>
           )}
           <span className="text-muted-foreground"> · {relativeTime(match.starts_at)}</span>

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -216,8 +216,9 @@ export function MatchCard({
   // The "X beat Y" headline needs the winner named first, or it reads
   // backwards whenever B is the one who actually won (the score box below
   // stays in match.sides order regardless — only this headline reorders).
-  const headlineFirstName = bWon ? nameB : nameA
-  const headlineSecondName = bWon ? nameA : nameB
+  // No winner (tie/vs case) just falls back to A/B order, same as before.
+  const winningTeamName = bWon ? nameB : nameA
+  const losingTeamName = bWon ? nameA : nameB
 
   const isLiveSport =
     match.match_type === 'football' || match.match_type === 'cricket' || match.match_type === 'netball'
@@ -303,12 +304,12 @@ export function MatchCard({
             <span>{cricketDescription}</span>
           ) : (
             <>
-              <span className={cn(!!scoreInfo?.winnerSideId && 'font-medium')}>{headlineFirstName}</span>
+              <span className={cn(!!scoreInfo?.winnerSideId && 'font-medium')}>{winningTeamName}</span>
               <span className="text-primary">
                 {' '}
                 {match.match_type !== 'cricket' && scoreInfo?.winnerSideId ? 'beat' : 'vs'}{' '}
               </span>
-              <span>{headlineSecondName}</span>
+              <span>{losingTeamName}</span>
             </>
           )}
           <span className="text-muted-foreground"> · {relativeTime(match.starts_at)}</span>


### PR DESCRIPTION
MatchCard's "X beat Y" headline always read match.sides in order
(side A first, "beat", side B), only bolding whichever name actually
won. When side B was the winner, the sentence itself still said
"A beat B" — backwards, e.g. "John beat Net Prophets" on a 4-24 loss.

Name the winner first in the headline text; the side-by-side score
box below is unaffected since it already keys off side id, not
sentence position.