### PR TITLE
Add netball as a supported sport with two live-scoring methods

### DIFF
--- a/agon_ui/src/lib/netballScore.ts
+++ b/agon_ui/src/lib/netballScore.ts
@@ -217,40 +217,18 @@ export function periodTime(detail: NetballScore, period: NetballPeriod): string 
   return detail.period_times?.[period]
 }
 
-// ---------------------------------------------------------------------------
-// Scoring method — which of netball's two live-scoring methods this match's
-// scorer is using. Client-only, same as football's `TrackPrefs`: the backend
-// doesn't need to know (both methods write the exact same `NetballLiveEvent`
-// vocabulary — see `NetballLiveEvent`'s backend doc comment), this just picks
-// which screen `NetballLiveScoringPage` shows. Chosen once, before the first
-// event, and inferred after that from whether the live state already has
-// goal-by-goal detail (see `NetballLiveScoringPage`), so this preference is
-// really just a tiebreaker for a fresh match with no events yet.
-// ---------------------------------------------------------------------------
-
+/**
+ * Which of netball's two live-scoring methods a match's scorer is using.
+ * Not persisted anywhere — the backend doesn't need to know (both methods
+ * write the exact same `NetballLiveEvent` vocabulary; see
+ * `NetballLiveEvent`'s backend doc comment) and neither does the client
+ * beyond the current page: once the match's live event log has anything
+ * recorded, the method is unambiguous from the log itself (see
+ * `NetballLiveScoringPage`'s doc comment), so there's nothing worth
+ * remembering across visits — before that point, asking again is cheap and
+ * correct.
+ */
 export type NetballScoringMethod = 'event_by_event' | 'quarter_only'
-
-function methodKey(matchId: string): string {
-  return `agon:netball-scoring-method:${matchId}`
-}
-
-export function loadNetballScoringMethod(matchId: string): NetballScoringMethod | null {
-  try {
-    const raw = localStorage.getItem(methodKey(matchId))
-    return raw === 'event_by_event' || raw === 'quarter_only' ? raw : null
-  } catch {
-    return null
-  }
-}
-
-export function saveNetballScoringMethod(matchId: string, method: NetballScoringMethod): void {
-  try {
-    localStorage.setItem(methodKey(matchId), method)
-  } catch {
-    // Best-effort — a private-browsing/full-storage failure just means the
-    // choice is asked again next visit, not worth surfacing.
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Match clock — derived from `NetballScore.period_times`, the same "shared

--- a/agon_ui/src/pages/NetballLiveScoringPage.tsx
+++ b/agon_ui/src/pages/NetballLiveScoringPage.tsx
@@ -22,13 +22,11 @@ import {
   eventEmoji,
   eventsFromDetail,
   isLivePlayPhase,
-  loadNetballScoringMethod,
   netballScoreFrom,
   nextPeriodForPhase,
   nextPhaseActionLabel,
   phaseFromState,
   phaseLabel,
-  saveNetballScoringMethod,
   type ClockPhase,
   type NetballPeriod,
   type NetballScore,
@@ -63,21 +61,27 @@ const QUARTER_SEQUENCE: NetballPeriod[] = [
  * a `Start` marker or any goal means event-by-event (quarter-only never
  * records `Start` — its first event is always a quarter-end marker, see
  * `NetballQuarterOnlyScoringPage`); a quarter-end marker with neither means
- * quarter-only. This device's own saved choice only fills in before that —
- * bootstrapping straight past the picker on this device for a match it
- * already started, or (absent even that) falling through to the picker.
- * Crucially, a `Start` marker with zero goals *yet* (right after tapping
- * "Start match", before the first goal) must still read as event-by-event,
- * not fall back to "no goals ⇒ quarter-only" — that inversion was a real bug
- * here: it flipped the screen to the quarter-only score-entry form the
- * instant the match started, before anyone could log a goal or foul.
+ * quarter-only. Crucially, a `Start` marker with zero goals *yet* (right
+ * after tapping "Start match", before the first goal) must still read as
+ * event-by-event, not fall back to "no goals ⇒ quarter-only" — that
+ * inversion was a real bug here: it flipped the screen to the quarter-only
+ * score-entry form the instant the match started, before anyone could log a
+ * goal or foul.
+ *
+ * Before anything's recorded there's no log to read, so the picked method
+ * lives only in this component's own state — not persisted anywhere. Nothing
+ * has been written to the server yet at that point, so there's nothing to
+ * lose by picking again: leaving the page and coming back (or tapping
+ * "Change scoring method" on either screen, offered only while the log is
+ * still empty) just re-shows the picker. Once the log says something,
+ * changing your mind means undoing that event instead (see
+ * `UndoLastEventButton`, present on both screens) — the log is the only
+ * source of truth then, not a component-local guess.
  */
 export function NetballLiveScoringPage({ match }: { match: Match }) {
   const scoreQuery = useMatchScore(match.id, { refetchInterval: 8000 })
   const state = netballScoreFrom(scoreQuery.data)
-  const [pickedMethod, setPickedMethod] = useState<NetballScoringMethod | null>(() =>
-    loadNetballScoringMethod(match.id),
-  )
+  const [pickedMethod, setPickedMethod] = useState<NetballScoringMethod | null>(null)
 
   if (scoreQuery.isLoading) {
     return (
@@ -97,21 +101,18 @@ export function NetballLiveScoringPage({ match }: { match: Match }) {
   const method = inferredMethod ?? pickedMethod
 
   if (!method) {
-    return (
-      <NetballScoringMethodPicker
-        match={match}
-        onChoose={(m) => {
-          saveNetballScoringMethod(match.id, m)
-          setPickedMethod(m)
-        }}
-      />
-    )
+    return <NetballScoringMethodPicker match={match} onChoose={setPickedMethod} />
   }
 
+  // Only offered while nothing's recorded yet — once the log has anything,
+  // `inferredMethod` (not this local pick) is what decides the screen, so
+  // "changing your mind" at that point means undoing the event instead.
+  const onBackToPicker = inferredMethod ? undefined : () => setPickedMethod(null)
+
   return method === 'event_by_event' ? (
-    <NetballEventByEventScoringPage match={match} state={state} />
+    <NetballEventByEventScoringPage match={match} state={state} onBackToPicker={onBackToPicker} />
   ) : (
-    <NetballQuarterOnlyScoringPage match={match} state={state} />
+    <NetballQuarterOnlyScoringPage match={match} state={state} onBackToPicker={onBackToPicker} />
   )
 }
 
@@ -200,7 +201,17 @@ const CLOCK_TICK_MS = 15_000
  * running goal tally the client already has — the user never types a number
  * here; that's quarter-only mode's job (`NetballQuarterOnlyScoringPage`).
  */
-function NetballEventByEventScoringPage({ match, state }: { match: Match; state: NetballScore | null }) {
+function NetballEventByEventScoringPage({
+  match,
+  state,
+  onBackToPicker,
+}: {
+  match: Match
+  state: NetballScore | null
+  /** Present only while nothing's been recorded yet — see
+   *  `NetballLiveScoringPage`'s doc comment. */
+  onBackToPicker?: () => void
+}) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const seq = useLiveSeq(match.id)
@@ -280,7 +291,17 @@ function NetballEventByEventScoringPage({ match, state }: { match: Match; state:
         <h1 className="text-lg font-semibold">
           {nameA} vs {nameB}
         </h1>
-        <p className="text-sm text-muted-foreground">You're scoring this match</p>
+        <p className="text-sm text-muted-foreground">
+          You're scoring this match — goal by goal
+          {onBackToPicker && (
+            <>
+              {' · '}
+              <button type="button" onClick={onBackToPicker} className="text-primary hover:underline">
+                Change scoring method
+              </button>
+            </>
+          )}
+        </p>
       </div>
 
       <div className="rounded-xl border bg-card p-4">
@@ -393,9 +414,20 @@ function NetballEventByEventScoringPage({ match, state }: { match: Match; state:
  * mode). Walks `QUARTER_SEQUENCE` one marker at a time; each already-entered
  * quarter shows in `NetballQuarterBreakdown` below.
  */
-function NetballQuarterOnlyScoringPage({ match, state }: { match: Match; state: NetballScore | null }) {
+function NetballQuarterOnlyScoringPage({
+  match,
+  state,
+  onBackToPicker,
+}: {
+  match: Match
+  state: NetballScore | null
+  /** Present only while nothing's been recorded yet — see
+   *  `NetballLiveScoringPage`'s doc comment. */
+  onBackToPicker?: () => void
+}) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const seq = useLiveSeq(match.id)
   const append = useAppendNetballEvent(match.id)
   const finishMatch = useFinishNetballMatch(match)
 
@@ -449,14 +481,27 @@ function NetballQuarterOnlyScoringPage({ match, state }: { match: Match; state: 
         <Button variant="ghost" size="sm" onClick={() => navigate(`/matches/${match.id}`)}>
           Back
         </Button>
-        <LiveIndicator />
+        <div className="flex items-center gap-1">
+          <UndoLastEventButton matchId={match.id} seq={seq.data} />
+          <LiveIndicator />
+        </div>
       </div>
 
       <div>
         <h1 className="text-lg font-semibold">
           {nameA} vs {nameB}
         </h1>
-        <p className="text-sm text-muted-foreground">Scoring by quarter</p>
+        <p className="text-sm text-muted-foreground">
+          Scoring by quarter
+          {onBackToPicker && (
+            <>
+              {' · '}
+              <button type="button" onClick={onBackToPicker} className="text-primary hover:underline">
+                Change scoring method
+              </button>
+            </>
+          )}
+        </p>
       </div>
 
       <div className="rounded-xl border bg-card p-4">

--- a/agon_ui/src/pages/NetballLiveScoringPage.tsx
+++ b/agon_ui/src/pages/NetballLiveScoringPage.tsx
@@ -57,18 +57,24 @@ const QUARTER_SEQUENCE: NetballPeriod[] = [
  * from `LiveScoringPage`). Netball has two live-scoring methods sharing one
  * event vocabulary (see `live_score::netball`'s backend doc comment) — this
  * asks once, before the first event, which one this scorer wants, then
- * hands off to the matching screen. Once a match has *any* live state,
- * the method is inferred from it instead (goal-by-goal detail present =
- * event-by-event; otherwise quarter-only) rather than trusting the saved
- * preference, so a second device picking up an already-started match
- * renders the right screen even without its own local preference.
+ * hands off to the matching screen.
+ *
+ * The recorded log is the source of truth once it says anything unambiguous:
+ * a `Start` marker or any goal means event-by-event (quarter-only never
+ * records `Start` — its first event is always a quarter-end marker, see
+ * `NetballQuarterOnlyScoringPage`); a quarter-end marker with neither means
+ * quarter-only. This device's own saved choice only fills in before that —
+ * bootstrapping straight past the picker on this device for a match it
+ * already started, or (absent even that) falling through to the picker.
+ * Crucially, a `Start` marker with zero goals *yet* (right after tapping
+ * "Start match", before the first goal) must still read as event-by-event,
+ * not fall back to "no goals ⇒ quarter-only" — that inversion was a real bug
+ * here: it flipped the screen to the quarter-only score-entry form the
+ * instant the match started, before anyone could log a goal or foul.
  */
 export function NetballLiveScoringPage({ match }: { match: Match }) {
   const scoreQuery = useMatchScore(match.id, { refetchInterval: 8000 })
   const state = netballScoreFrom(scoreQuery.data)
-  // Only used as the picker's initial value below — once there's *any* live
-  // state, `method` is inferred from it instead (see the picker's own doc
-  // comment), so a stale/never-set local preference can't override reality.
   const [pickedMethod, setPickedMethod] = useState<NetballScoringMethod | null>(() =>
     loadNetballScoringMethod(match.id),
   )
@@ -82,9 +88,11 @@ export function NetballLiveScoringPage({ match }: { match: Match }) {
   }
 
   const inferredMethod: NetballScoringMethod | null = state
-    ? (state.goals?.length ?? 0) > 0
+    ? (state.goals?.length ?? 0) > 0 || !!state.period_times?.start
       ? 'event_by_event'
-      : 'quarter_only'
+      : Object.keys(state.period_scores ?? {}).length > 0
+        ? 'quarter_only'
+        : null
     : null
   const method = inferredMethod ?? pickedMethod
 


### PR DESCRIPTION
Backend: `NetballScore`/`NetballFormat`/`NetballLiveEvent` types mirroring football's pattern, wired through `main.rs`, `mapping.rs`, and the DAO records layer. Both of netball's live-scoring methods (event-by-event goal/foul logging, and quarter-only score entry) share one event vocabulary: `Goal`/`Foul` events accumulate the score in event-by-event mode, while a `Period` marker always carries a score snapshot that is the sole source of truth in quarter-only mode and a checkpoint otherwise — one `apply_event` fold handles both without knowing which mode a given match is using.

Caught and fixed a real bug along the way: `NetballFoulEvent`'s own `kind` field collided with the outer live-event union's `kind` discriminator once flattened onto the same JSON object, silently dropping the foul's kind on the wire. Renamed to `foul_kind` on both the API and DAO record types, with a regression test locking in the fix.

Regenerated the OpenAPI schema/client and TS types, extended the `agon_tests` integration suite with event-by-event and quarter-only coverage (via raw JSON — the generated Rust client's nested sport/kind union flattening is a separate pre-existing limitation), and added netball support across the UI: sport registry, match format editor, score/scorecard/quarter-breakdown display, manual result entry, and a dedicated live-scoring page for both methods.

**Follow-up fixes after initial review/testing:**
- `cargo fmt` formatting.
- Event-by-event mode was incorrectly flipping to the quarter-only screen the instant a match started (before any goal was logged) — the client-side mode inference treated "zero goals so far" as evidence of quarter-only, which is wrong right after tapping "Start match". Fixed the inference to also recognize the `Start` marker itself as an event-by-event signal.
- Dropped `localStorage` persistence for the scoring-method choice — nothing is recorded server-side until the first event, so there's nothing to lose by just asking again if you leave and come back. Added a "Change scoring method" link (shown only while the log is still empty) and an undo button on the quarter-only screen so a mistaken pick can be corrected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXVHeS4CpEafhUah4FJBwc)_