### PR TITLE
Guard Sets score entries and add a root error boundary

### DIFF
--- a/agon_ui/src/components/ErrorBoundary.tsx
+++ b/agon_ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import { Component, type ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+}
+
+/**
+ * Last-resort catch for uncaught render errors. Without this, React 18
+ * unmounts the *entire* tree on an uncaught error — the user gets a blank
+ * page with nothing but a console trace, which is what "loading the feed
+ * occasionally throws a TypeError" looks like from the outside.
+ *
+ * A common cause in a PWA like this one: `registerType: 'autoUpdate'`
+ * (see `vite.config.ts`) updates the service worker in the background, but
+ * a tab that's been open across a deploy keeps running the JS it already
+ * loaded — now talking to an already-redeployed API whose response shape
+ * has moved on. That class of error isn't preventable in general, but it
+ * *is* recoverable: reloading picks up the current build. So instead of a
+ * blank screen, show a "Reload" prompt.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: unknown, info: { componentStack: string }) {
+    console.error('Uncaught render error:', error, info.componentStack)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="text-center">
+            <h2 className="mb-2 text-xl font-semibold">Something went wrong</h2>
+            <p className="mb-4 text-muted-foreground">
+              Try reloading the page.
+            </p>
+            <Button onClick={() => window.location.reload()}>Reload</Button>
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/agon_ui/src/lib/score.ts
+++ b/agon_ui/src/lib/score.ts
@@ -63,13 +63,8 @@ export function headlineBySide(score: Score): Record<string, number> {
   if (score.type === 'Netball') return { ...score.score }
   if (score.type === 'Cricket') return {}
   // Sets: a side wins a set at index i if its games exceed every other side's.
-  // `score.entries` is guarded defensively (`?? {}`) even though the API type
-  // marks it required — a stale cached bundle can still be running against an
-  // already-redeployed API whose response shape moved on, and `Object.entries`
-  // on `undefined` throws ("can't convert undefined to object" in Firefox),
-  // crashing the whole feed instead of just rendering an empty headline.
   const out: Record<string, number> = {}
-  const entries = Object.entries(score.entries ?? {})
+  const entries = Object.entries(score.entries)
   const setCount = Math.max(0, ...entries.map(([, sets]) => sets.length))
   for (const [sideId] of entries) out[sideId] = 0
   for (let i = 0; i < setCount; i++) {
@@ -95,7 +90,7 @@ export function headlineBySide(score: Score): Record<string, number> {
 export function setLine(score: Score, sides: MatchSide[]): string[] {
   if (score.type !== 'Sets') return []
   const ordered = sides
-    .map((s) => score.entries?.[s.id])
+    .map((s) => score.entries[s.id])
     .filter((s): s is number[] => Array.isArray(s))
   if (ordered.length < 2) return []
   const setCount = Math.max(...ordered.map((s) => s.length))

--- a/agon_ui/src/lib/score.ts
+++ b/agon_ui/src/lib/score.ts
@@ -63,8 +63,13 @@ export function headlineBySide(score: Score): Record<string, number> {
   if (score.type === 'Netball') return { ...score.score }
   if (score.type === 'Cricket') return {}
   // Sets: a side wins a set at index i if its games exceed every other side's.
+  // `score.entries` is guarded defensively (`?? {}`) even though the API type
+  // marks it required — a stale cached bundle can still be running against an
+  // already-redeployed API whose response shape moved on, and `Object.entries`
+  // on `undefined` throws ("can't convert undefined to object" in Firefox),
+  // crashing the whole feed instead of just rendering an empty headline.
   const out: Record<string, number> = {}
-  const entries = Object.entries(score.entries)
+  const entries = Object.entries(score.entries ?? {})
   const setCount = Math.max(0, ...entries.map(([, sets]) => sets.length))
   for (const [sideId] of entries) out[sideId] = 0
   for (let i = 0; i < setCount; i++) {
@@ -90,7 +95,7 @@ export function headlineBySide(score: Score): Record<string, number> {
 export function setLine(score: Score, sides: MatchSide[]): string[] {
   if (score.type !== 'Sets') return []
   const ordered = sides
-    .map((s) => score.entries[s.id])
+    .map((s) => score.entries?.[s.id])
     .filter((s): s is number[] => Array.isArray(s))
   if (ordered.length < 2) return []
   const setCount = Math.max(...ordered.map((s) => s.length))

--- a/agon_ui/src/main.tsx
+++ b/agon_ui/src/main.tsx
@@ -3,13 +3,16 @@ import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
+import { ErrorBoundary } from '@/components/ErrorBoundary'
 
 const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
Root-caused the occasional "Uncaught TypeError: can't convert
undefined to object" seen loading the feed: headlineBySide() called
Object.entries(score.entries) unguarded for a Sets score, and setLine()
indexed score.entries[side.id] the same way. Object.entries(undefined)
throws exactly that error in Firefox. The API always sends entries
today, but a browser tab left open across a staging deploy keeps
running its already-loaded JS (the PWA's autoUpdate service worker
only swaps in the new build for future loads, not the live tab)
against an already-redeployed API — which is exactly the "occasionally,
fixed by a hard refresh" pattern reported. Guard both call sites so a
future shape drift degrades to an empty headline instead of crashing.

Also add a root ErrorBoundary: React 18 unmounts the whole tree on any
uncaught render error, which is why this showed up as nothing but a
console trace rather than an in-app message. Any similar future
version-skew mismatch now shows a "Something went wrong — Reload"
screen instead of a blank page.