### PR TITLE
Add wall-clock timestamps and foul kinds to netball events

### DIFF
--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -634,6 +634,10 @@ pub struct FootballGoalEventRecord {
     pub penalty: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minute: Option<u32>,
+    /// Mirrors `agon_service::detailed_score::football::FootballGoalEvent::occurred_at`
+    /// — RFC3339, same string convention as `LiveEventRecord::occurred_at`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -643,6 +647,9 @@ pub struct FootballCardEventRecord {
     pub color: FootballCardColorRecord,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minute: Option<u32>,
+    /// Mirrors `FootballGoalEventRecord::occurred_at`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -659,6 +666,9 @@ pub struct FootballSubstitutionEventRecord {
     pub player_out_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minute: Option<u32>,
+    /// Mirrors `FootballGoalEventRecord::occurred_at`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -712,6 +722,10 @@ pub struct CricketDeliveryRecord {
     pub extra: Option<CricketDeliveryExtraRecord>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wicket: Option<CricketDeliveryWicketRecord>,
+    /// Mirrors `agon_service::detailed_score::cricket::CricketDelivery::occurred_at`
+    /// — RFC3339, same string convention as `LiveEventRecord::occurred_at`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -816,6 +816,10 @@ pub struct NetballGoalEventRecord {
     pub two_points: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minute: Option<u32>,
+    /// Mirrors `agon_service::detailed_score::netball::NetballGoalEvent::occurred_at`
+    /// — RFC3339, same string convention as `LiveEventRecord::occurred_at`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -842,6 +846,9 @@ pub struct NetballFoulEventRecord {
     pub foul_kind: NetballFoulKindRecord,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub minute: Option<u32>,
+    /// Mirrors `NetballGoalEventRecord::occurred_at`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -868,8 +875,11 @@ pub struct NetballPeriodEventRecord {
 pub enum NetballPeriodRecord {
     Start,
     QuarterOneEnd,
+    QuarterTwoStart,
     QuarterTwoEnd,
+    QuarterThreeStart,
     QuarterThreeEnd,
+    QuarterFourStart,
     FullTime,
     ExtraTimeStart,
     ExtraTimeEnd,

--- a/agon_service/src/detailed_score/cricket.rs
+++ b/agon_service/src/detailed_score/cricket.rs
@@ -90,6 +90,15 @@ pub struct CricketDelivery {
     pub extra: Option<CricketDeliveryExtra>,
     /// Wicket that fell on this delivery, if any.
     pub wicket: Option<CricketDeliveryWicket>,
+    /// When this actually happened, wall-clock — always overwritten by the
+    /// server from the live event envelope's own `occurred_at`, ignoring
+    /// whatever a client sends here. `None` for a manually logged result.
+    /// Cricket orders deliveries by over/ball rather than a clock, so unlike
+    /// `NetballGoalEvent::occurred_at`/`FootballGoalEvent::occurred_at` this
+    /// doesn't fix an ordering bug — it's stored for consistency with the
+    /// other sports and for any future pace-of-play-style stat, not read by
+    /// anything today.
+    pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Object, Clone)]

--- a/agon_service/src/detailed_score/football.rs
+++ b/agon_service/src/detailed_score/football.rs
@@ -9,7 +9,27 @@ pub struct FootballGoalEvent {
     pub assist_player_id: Option<String>,
     pub own_goal: bool,
     pub penalty: bool,
+    /// Free-text minutes-into-the-match, only ever set by a manually logged
+    /// historical result (no live clock to timestamp against — see
+    /// `agon_ui`'s `FootballScoreFields`). A live-scored goal leaves this
+    /// unset; `occurred_at` is its source of truth instead (see that field's
+    /// doc comment).
     pub minute: Option<u32>,
+    /// When this actually happened, wall-clock — always overwritten by the
+    /// server from the live event envelope's own `occurred_at` for anything
+    /// recorded through `/live/events` (see `FootballScore::apply_event`),
+    /// ignoring whatever a client sends here. `None` for a manually logged
+    /// historical result, same as `minute` above.
+    ///
+    /// This — not the free-text `minute` — is what a live-scored event's
+    /// displayed minute is derived from, bracketed against
+    /// `FootballScore.period_times` the same way the live clock itself is
+    /// (see `agon_ui`'s `lib/liveScore.ts`): added time carries over between
+    /// halves and extra time layers on top, all computed from period
+    /// boundaries rather than trusted from what was typed in. Second
+    /// precision also means two events recorded a few seconds apart no
+    /// longer collide on the same displayed minute.
+    pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Enum, Clone)]
@@ -24,7 +44,10 @@ pub struct FootballCardEvent {
     pub side_id: String,
     pub player_id: String,
     pub color: FootballCardColor,
+    /// Same convention as `FootballGoalEvent::minute` — manual entry only.
     pub minute: Option<u32>,
+    /// Same convention as `FootballGoalEvent::occurred_at`.
+    pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Object, Clone)]
@@ -32,7 +55,10 @@ pub struct FootballSubstitutionEvent {
     pub side_id: String,
     pub player_in_id: String,
     pub player_out_id: String,
+    /// Same convention as `FootballGoalEvent::minute` — manual entry only.
     pub minute: Option<u32>,
+    /// Same convention as `FootballGoalEvent::occurred_at`.
+    pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// One kick in a penalty shootout.

--- a/agon_service/src/detailed_score/netball.rs
+++ b/agon_service/src/detailed_score/netball.rs
@@ -24,9 +24,23 @@ pub struct NetballGoalEvent {
     /// Fast5/Power-Play-style two-point zone. `false` for standard scoring,
     /// where every goal is worth one.
     pub two_points: bool,
-    /// Minutes elapsed in the *current quarter*, not match-wide — netball's
-    /// clock resets each quarter, unlike football's continuous minute.
+    /// Free-text minutes-into-the-match, only ever set by a manually logged
+    /// historical result (no live clock to timestamp against — see
+    /// `agon_ui`'s `NetballScoreFields`). A live-scored goal leaves this
+    /// unset; `occurred_at` is its source of truth instead.
     pub minute: Option<u32>,
+    /// When this actually happened, wall-clock — always overwritten by the
+    /// server from the live event envelope's own `occurred_at` for anything
+    /// recorded through `/live/events` (see `NetballScore::apply_event`),
+    /// ignoring whatever a client sends here. `None` for a manually logged
+    /// historical result, same as `minute` above.
+    ///
+    /// This — not the quarter-relative `minute` — is what the events list
+    /// sorts by: `minute` resets every quarter, so sorting on it alone
+    /// scrambles a match's later quarters in with its earlier ones. Second
+    /// precision (not just minutes) also means two goals recorded a few
+    /// seconds apart no longer collide on the same displayed time.
+    pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Enum, Debug, Clone, Copy, PartialEq, Eq)]
@@ -56,20 +70,40 @@ pub struct NetballFoulEvent {
     /// object (the two would fight over one wire key). `NetballGoalEvent`
     /// has no such field, so it doesn't need the same care.
     pub foul_kind: NetballFoulKind,
+    /// Same convention as `NetballGoalEvent::minute` — manual entry only.
     pub minute: Option<u32>,
+    /// Same convention as `NetballGoalEvent::occurred_at` — the source of
+    /// truth for a live-scored foul's time and sort order.
+    pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// A netball match's quarters, plus an optional golden-goal-style decider if
 /// still level after full time — same shape/role as `FootballPeriod`.
+///
+/// Each quarter after the first has its own explicit `*Start` marker rather
+/// than the *End* marker before it doubling as the next quarter's start —
+/// unlike football's, netball's breaks (and half-time) are a real interval
+/// of unknown length, not a token gap, so the scorer has to tap "start" once
+/// play actually resumes. `ExtraTimeStart` already worked this way (the
+/// existing precedent this follows); `Start` itself doesn't need a separate
+/// pre-match marker since there's no "break" before the match has begun.
 #[derive(Enum, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[oai(rename_all = "snake_case")]
 pub enum NetballPeriod {
     /// First centre pass — the moment the match clock actually starts.
     Start,
     QuarterOneEnd,
+    /// The 2nd quarter actually starting, after the break following
+    /// `QuarterOneEnd` — see the enum's doc comment.
+    QuarterTwoStart,
     /// = half time.
     QuarterTwoEnd,
+    /// The 3rd quarter (2nd half) actually starting, after half-time.
+    QuarterThreeStart,
     QuarterThreeEnd,
+    /// The 4th quarter actually starting, after the break following
+    /// `QuarterThreeEnd`.
+    QuarterFourStart,
     FullTime,
     ExtraTimeStart,
     ExtraTimeEnd,
@@ -85,8 +119,11 @@ impl std::fmt::Display for NetballPeriod {
         f.write_str(match self {
             NetballPeriod::Start => "start",
             NetballPeriod::QuarterOneEnd => "quarter_one_end",
+            NetballPeriod::QuarterTwoStart => "quarter_two_start",
             NetballPeriod::QuarterTwoEnd => "quarter_two_end",
+            NetballPeriod::QuarterThreeStart => "quarter_three_start",
             NetballPeriod::QuarterThreeEnd => "quarter_three_end",
+            NetballPeriod::QuarterFourStart => "quarter_four_start",
             NetballPeriod::FullTime => "full_time",
             NetballPeriod::ExtraTimeStart => "extra_time_start",
             NetballPeriod::ExtraTimeEnd => "extra_time_end",
@@ -101,8 +138,11 @@ impl std::str::FromStr for NetballPeriod {
         match s {
             "start" => Ok(NetballPeriod::Start),
             "quarter_one_end" => Ok(NetballPeriod::QuarterOneEnd),
+            "quarter_two_start" => Ok(NetballPeriod::QuarterTwoStart),
             "quarter_two_end" => Ok(NetballPeriod::QuarterTwoEnd),
+            "quarter_three_start" => Ok(NetballPeriod::QuarterThreeStart),
             "quarter_three_end" => Ok(NetballPeriod::QuarterThreeEnd),
+            "quarter_four_start" => Ok(NetballPeriod::QuarterFourStart),
             "full_time" => Ok(NetballPeriod::FullTime),
             "extra_time_start" => Ok(NetballPeriod::ExtraTimeStart),
             "extra_time_end" => Ok(NetballPeriod::ExtraTimeEnd),

--- a/agon_service/src/live_score/cricket.rs
+++ b/agon_service/src/live_score/cricket.rs
@@ -281,7 +281,7 @@ impl CricketScore {
     /// (single-event) and slow (whole-log) paths share the exact same fold,
     /// so they can't disagree.
     pub fn from_events(
-        events: &[CricketLiveEvent],
+        events: &[(chrono::DateTime<chrono::Utc>, CricketLiveEvent)],
         balls_per_over: u32,
         wide_is_extra_ball: bool,
         no_ball_is_extra_ball: bool,
@@ -293,8 +293,9 @@ impl CricketScore {
             awaiting_next_innings: Some(true),
             players: HashMap::new(),
         };
-        for event in events {
+        for (occurred_at, event) in events {
             score.apply_event(
+                *occurred_at,
                 event,
                 balls_per_over,
                 wide_is_extra_ball,
@@ -305,9 +306,14 @@ impl CricketScore {
     }
 
     /// Folds one new event into this score in place — the fast path, run
-    /// on every append.
+    /// on every append. `occurred_at` (not `recorded_at`) is threaded
+    /// through separately from `event`, same reasoning as
+    /// `FootballScore::apply_event` — only `Delivery` reads it (see
+    /// `CricketDelivery::occurred_at`'s doc comment); every other variant
+    /// ignores it, same as before this parameter existed.
     pub fn apply_event(
         &mut self,
+        occurred_at: chrono::DateTime<chrono::Utc>,
         event: &CricketLiveEvent,
         balls_per_over: u32,
         wide_is_extra_ball: bool,
@@ -343,8 +349,14 @@ impl CricketScore {
                 );
                 self.next_ball_context = Some(next_context);
 
+                // Stamp with the envelope's own `occurred_at` before storing
+                // — see `CricketDelivery::occurred_at`'s doc comment. Stats
+                // are already folded above off the un-stamped `d`, so this
+                // only affects what gets stored/returned.
+                let mut d = d.clone();
+                d.occurred_at = Some(occurred_at);
                 let deliveries = self.recent_deliveries.get_or_insert_with(Vec::new);
-                deliveries.push(d.clone());
+                deliveries.push(d);
                 if deliveries.len() > RECENT_DELIVERIES_LIMIT {
                     deliveries.remove(0);
                 }
@@ -417,6 +429,11 @@ impl CricketScore {
 mod tests {
     use super::*;
     use crate::detailed_score::cricket::CricketDeliveryWicket;
+    use chrono::{DateTime, TimeZone, Utc};
+
+    fn ts(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(1_700_000_000 + seconds, 0).unwrap()
+    }
 
     fn ball(bowler: &str, striker: &str, non_striker: &str, runs: u32) -> CricketDelivery {
         CricketDelivery {
@@ -428,11 +445,45 @@ mod tests {
             runs_off_bat: runs,
             extra: None,
             wicket: None,
+            occurred_at: None,
         }
     }
 
+    /// Most tests only care about the fold's result, not real timestamps —
+    /// this pairs each event with a synthetic, strictly increasing one so
+    /// `from_events` (which now always wants a timestamp — see
+    /// `CricketScore::apply_event`) has something to thread through.
     fn score(events: &[CricketLiveEvent]) -> CricketScore {
-        CricketScore::from_events(events, 6, true, true)
+        let timed: Vec<_> = events
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (ts(i as i64), e.clone()))
+            .collect();
+        CricketScore::from_events(&timed, 6, true, true)
+    }
+
+    #[test]
+    fn deliveries_are_stamped_with_occurred_at_from_the_envelope() {
+        let events = vec![
+            (
+                ts(0),
+                CricketLiveEvent::InningsStart(CricketInningsStartEvent {
+                    batting_side_id: "warriors".into(),
+                    bowling_side_id: "mill_lane".into(),
+                }),
+            ),
+            (
+                ts(1),
+                CricketLiveEvent::Delivery(ball("patel", "sharma", "verma", 4)),
+            ),
+        ];
+
+        let d = CricketScore::from_events(&events, 6, true, true);
+
+        assert_eq!(
+            d.recent_deliveries.as_ref().unwrap()[0].occurred_at,
+            Some(ts(1))
+        );
     }
 
     #[test]
@@ -764,6 +815,11 @@ mod tests {
                 ..ball("patel", "verma", "sharma", 0)
             }),
         ];
+        let events: Vec<_> = events
+            .into_iter()
+            .enumerate()
+            .map(|(i, e)| (ts(i as i64), e))
+            .collect();
 
         let full = CricketScore::from_events(&events, 6, true, true);
 
@@ -776,8 +832,8 @@ mod tests {
             awaiting_next_innings: Some(true),
             players: HashMap::new(),
         };
-        for event in &events {
-            incremental.apply_event(event, 6, true, true);
+        for (occurred_at, event) in &events {
+            incremental.apply_event(*occurred_at, event, 6, true, true);
         }
 
         assert_eq!(incremental.innings.len(), full.innings.len());

--- a/agon_service/src/live_score/football.rs
+++ b/agon_service/src/live_score/football.rs
@@ -72,15 +72,23 @@ impl FootballScore {
         match event {
             FootballLiveEvent::Goal(g) => {
                 *self.score.entry(g.side_id.clone()).or_insert(0) += 1;
-                self.goals.get_or_insert_with(Vec::new).push(g.clone());
+                // Stamp with the envelope's own `occurred_at` — the
+                // recording device's clock — regardless of whatever (if
+                // anything) the client sent in the payload itself (see
+                // `FootballGoalEvent::occurred_at`'s doc comment).
+                let mut g = g.clone();
+                g.occurred_at = Some(occurred_at);
+                self.goals.get_or_insert_with(Vec::new).push(g);
             }
             FootballLiveEvent::Card(c) => {
-                self.cards.get_or_insert_with(Vec::new).push(c.clone());
+                let mut c = c.clone();
+                c.occurred_at = Some(occurred_at);
+                self.cards.get_or_insert_with(Vec::new).push(c);
             }
             FootballLiveEvent::Substitution(sub) => {
-                self.substitutions
-                    .get_or_insert_with(Vec::new)
-                    .push(sub.clone());
+                let mut sub = sub.clone();
+                sub.occurred_at = Some(occurred_at);
+                self.substitutions.get_or_insert_with(Vec::new).push(sub);
             }
             FootballLiveEvent::Period(p) => {
                 self.period_times
@@ -126,6 +134,7 @@ mod tests {
                     own_goal: false,
                     penalty: false,
                     minute: Some(41),
+                    occurred_at: None,
                 }),
             ),
             (
@@ -135,6 +144,7 @@ mod tests {
                     player_id: "khan".into(),
                     color: FootballCardColor::Yellow,
                     minute: Some(58),
+                    occurred_at: None,
                 }),
             ),
             // An own goal counts for the side benefiting from it.
@@ -147,6 +157,7 @@ mod tests {
                     own_goal: true,
                     penalty: false,
                     minute: Some(63),
+                    occurred_at: None,
                 }),
             ),
             (
@@ -156,6 +167,7 @@ mod tests {
                     player_in_id: "moreno".into(),
                     player_out_id: "khan".into(),
                     minute: Some(70),
+                    occurred_at: None,
                 }),
             ),
             (
@@ -335,6 +347,45 @@ mod tests {
         assert!(score.goals.as_ref().unwrap().is_empty());
     }
 
+    /// Same guard as netball's — see
+    /// `netball::tests::goals_and_fouls_are_stamped_with_occurred_at_from_the_envelope_in_recorded_order`.
+    /// Football's `minute` doesn't reset per period the way netball's does,
+    /// so this doesn't fix a scrambling bug, but it still has to hold: a
+    /// live-scored goal is timestamped by the server's own clock, not
+    /// whatever (if anything) a client sends.
+    #[test]
+    fn goals_cards_and_subs_are_stamped_with_occurred_at_from_the_envelope() {
+        let events = vec![
+            (
+                ts(0),
+                FootballLiveEvent::Goal(FootballGoalEvent {
+                    side_id: "riverside".into(),
+                    scorer_player_id: Some("alvarez".into()),
+                    assist_player_id: None,
+                    own_goal: false,
+                    penalty: false,
+                    minute: None,
+                    occurred_at: None,
+                }),
+            ),
+            (
+                ts(1),
+                FootballLiveEvent::Card(FootballCardEvent {
+                    side_id: "oak_park".into(),
+                    player_id: "khan".into(),
+                    color: FootballCardColor::Yellow,
+                    minute: None,
+                    occurred_at: None,
+                }),
+            ),
+        ];
+
+        let score = FootballScore::from_events(&events);
+
+        assert_eq!(score.goals.as_ref().unwrap()[0].occurred_at, Some(ts(0)));
+        assert_eq!(score.cards.as_ref().unwrap()[0].occurred_at, Some(ts(1)));
+    }
+
     #[test]
     fn incremental_and_full_fold_agree() {
         let events = vec![
@@ -353,6 +404,7 @@ mod tests {
                     own_goal: false,
                     penalty: false,
                     minute: Some(12),
+                    occurred_at: None,
                 }),
             ),
             (
@@ -362,6 +414,7 @@ mod tests {
                     player_id: "khan".into(),
                     color: FootballCardColor::Yellow,
                     minute: Some(58),
+                    occurred_at: None,
                 }),
             ),
         ];

--- a/agon_service/src/live_score/mod.rs
+++ b/agon_service/src/live_score/mod.rs
@@ -143,6 +143,7 @@ mod tests {
             player_id: Some("p1".into()),
             foul_kind: NetballFoulKind::Contact,
             minute: Some(10),
+            occurred_at: None,
         }));
 
         let json = event.to_json().expect("serializes");

--- a/agon_service/src/live_score/mod.rs
+++ b/agon_service/src/live_score/mod.rs
@@ -103,6 +103,7 @@ mod tests {
             player_id: "p1".into(),
             color: FootballCardColor::Yellow,
             minute: Some(58),
+            occurred_at: None,
         }));
 
         let json = event.to_json().expect("serializes");

--- a/agon_service/src/live_score/netball.rs
+++ b/agon_service/src/live_score/netball.rs
@@ -80,10 +80,20 @@ impl NetballScore {
             NetballLiveEvent::Goal(g) => {
                 *self.score.entry(g.side_id.clone()).or_insert(0) +=
                     if g.two_points { 2 } else { 1 };
-                self.goals.get_or_insert_with(Vec::new).push(g.clone());
+                // Stamp with the envelope's own `occurred_at` — the
+                // recording device's clock — regardless of whatever (if
+                // anything) the client sent in the payload itself. This is
+                // what makes `occurred_at`, not the quarter-relative
+                // `minute`, the authoritative order for a live-scored goal
+                // (see `NetballGoalEvent::occurred_at`'s doc comment).
+                let mut g = g.clone();
+                g.occurred_at = Some(occurred_at);
+                self.goals.get_or_insert_with(Vec::new).push(g);
             }
             NetballLiveEvent::Foul(fo) => {
-                self.fouls.get_or_insert_with(Vec::new).push(fo.clone());
+                let mut fo = fo.clone();
+                fo.occurred_at = Some(occurred_at);
+                self.fouls.get_or_insert_with(Vec::new).push(fo);
             }
             NetballLiveEvent::Period(p) => {
                 self.period_times
@@ -118,6 +128,7 @@ mod tests {
             scorer_position: Some(NetballPosition::GoalShooter),
             two_points: false,
             minute: Some(minute),
+            occurred_at: None,
         })
     }
 
@@ -134,6 +145,7 @@ mod tests {
                     player_id: Some("defender_1".into()),
                     foul_kind: NetballFoulKind::Contact,
                     minute: Some(10),
+                    occurred_at: None,
                 }),
             ),
             (
@@ -234,11 +246,47 @@ mod tests {
                 scorer_position: Some(NetballPosition::GoalAttack),
                 two_points: true,
                 minute: Some(4),
+                occurred_at: None,
             }),
         )];
 
         let score = NetballScore::from_events(&events);
         assert_eq!(score.score.get("kestrels"), Some(&2));
+    }
+
+    /// The bug this guards against: `minute` is quarter-relative and reset
+    /// every quarter, so two goals in different quarters can carry the same
+    /// (or an out-of-order) `minute` — sorting the events list on that alone
+    /// scrambles later quarters in with earlier ones. `occurred_at` is
+    /// absolute, so folding always produces goals/fouls in true chronological
+    /// (recorded) order regardless of what `minute` says, and it's stamped
+    /// from the envelope's own clock even when the client sends none.
+    #[test]
+    fn goals_and_fouls_are_stamped_with_occurred_at_from_the_envelope_in_recorded_order() {
+        let events = vec![
+            (ts(0), goal("kestrels", 3)),
+            (
+                ts(1),
+                NetballLiveEvent::Period(NetballPeriodEvent {
+                    period: NetballPeriod::QuarterOneEnd,
+                    score: HashMap::from([("kestrels".to_string(), 1)]),
+                }),
+            ),
+            // A new quarter's clock resets, so this goal's `minute` (2) is
+            // numerically *less* than the first goal's (3) despite happening
+            // later in the match — exactly the scrambling `minute`-only
+            // sorting produced.
+            (ts(2), goal("kestrels", 2)),
+        ];
+
+        let score = NetballScore::from_events(&events);
+        let goals = score.goals.as_ref().unwrap();
+        assert_eq!(goals.len(), 2);
+        assert_eq!(goals[0].occurred_at, Some(ts(0)));
+        assert_eq!(goals[1].occurred_at, Some(ts(2)));
+        // Recorded (array) order already reflects true chronological order,
+        // regardless of the quarter-relative `minute` values above.
+        assert!(goals[0].occurred_at < goals[1].occurred_at);
     }
 
     #[test]

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -5353,6 +5353,7 @@ fn resolve_score_ids(
                             scorer_position: g.scorer_position,
                             two_points: g.two_points,
                             minute: g.minute,
+                            occurred_at: g.occurred_at,
                         });
                     }
                     Some(out)
@@ -5368,6 +5369,7 @@ fn resolve_score_ids(
                             player_id: pmap_opt(&fo.player_id)?,
                             foul_kind: fo.foul_kind,
                             minute: fo.minute,
+                            occurred_at: fo.occurred_at,
                         });
                     }
                     Some(out)

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -3202,6 +3202,7 @@ impl Api {
                         return Ok(None);
                     };
                     s.apply_event(
+                        e.occurred_at,
                         event,
                         balls_per_over,
                         wide_is_extra_ball,
@@ -5225,6 +5226,7 @@ fn resolve_score_ids(
                                 }),
                                 None => None,
                             },
+                            occurred_at: d.occurred_at,
                         });
                     }
                     Some(out)
@@ -5267,6 +5269,7 @@ fn resolve_score_ids(
                             own_goal: g.own_goal,
                             penalty: g.penalty,
                             minute: g.minute,
+                            occurred_at: g.occurred_at,
                         });
                     }
                     Some(out)
@@ -5282,6 +5285,7 @@ fn resolve_score_ids(
                             player_id: pmap(&c.player_id)?,
                             color: c.color.clone(),
                             minute: c.minute,
+                            occurred_at: c.occurred_at,
                         });
                     }
                     Some(out)
@@ -5297,6 +5301,7 @@ fn resolve_score_ids(
                             player_in_id: pmap(&sub.player_in_id)?,
                             player_out_id: pmap(&sub.player_out_id)?,
                             minute: sub.minute,
+                            occurred_at: sub.occurred_at,
                         });
                     }
                     Some(out)

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -1400,6 +1400,9 @@ fn netball_goal_event_to_record(g: &NetballGoalEvent) -> NetballGoalEventRecord 
         scorer_position: g.scorer_position.as_ref().map(netball_position_to_record),
         two_points: g.two_points,
         minute: g.minute,
+        occurred_at: g
+            .occurred_at
+            .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
     }
 }
 
@@ -1413,6 +1416,7 @@ fn netball_goal_event_from_record(rec: &NetballGoalEventRecord) -> NetballGoalEv
             .map(netball_position_from_record),
         two_points: rec.two_points,
         minute: rec.minute,
+        occurred_at: parse_ts_opt(&rec.occurred_at),
     }
 }
 
@@ -1455,6 +1459,9 @@ fn netball_foul_event_to_record(fo: &NetballFoulEvent) -> NetballFoulEventRecord
             NetballFoulKind::Other => NetballFoulKindRecord::Other,
         },
         minute: fo.minute,
+        occurred_at: fo
+            .occurred_at
+            .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
     }
 }
 
@@ -1471,6 +1478,7 @@ fn netball_foul_event_from_record(rec: &NetballFoulEventRecord) -> NetballFoulEv
             NetballFoulKindRecord::Other => NetballFoulKind::Other,
         },
         minute: rec.minute,
+        occurred_at: parse_ts_opt(&rec.occurred_at),
     }
 }
 
@@ -1481,8 +1489,11 @@ fn netball_period_to_record(period: &NetballPeriod) -> NetballPeriodRecord {
     match period {
         NetballPeriod::Start => NetballPeriodRecord::Start,
         NetballPeriod::QuarterOneEnd => NetballPeriodRecord::QuarterOneEnd,
+        NetballPeriod::QuarterTwoStart => NetballPeriodRecord::QuarterTwoStart,
         NetballPeriod::QuarterTwoEnd => NetballPeriodRecord::QuarterTwoEnd,
+        NetballPeriod::QuarterThreeStart => NetballPeriodRecord::QuarterThreeStart,
         NetballPeriod::QuarterThreeEnd => NetballPeriodRecord::QuarterThreeEnd,
+        NetballPeriod::QuarterFourStart => NetballPeriodRecord::QuarterFourStart,
         NetballPeriod::FullTime => NetballPeriodRecord::FullTime,
         NetballPeriod::ExtraTimeStart => NetballPeriodRecord::ExtraTimeStart,
         NetballPeriod::ExtraTimeEnd => NetballPeriodRecord::ExtraTimeEnd,
@@ -1493,8 +1504,11 @@ fn netball_period_from_record(rec: &NetballPeriodRecord) -> NetballPeriod {
     match rec {
         NetballPeriodRecord::Start => NetballPeriod::Start,
         NetballPeriodRecord::QuarterOneEnd => NetballPeriod::QuarterOneEnd,
+        NetballPeriodRecord::QuarterTwoStart => NetballPeriod::QuarterTwoStart,
         NetballPeriodRecord::QuarterTwoEnd => NetballPeriod::QuarterTwoEnd,
+        NetballPeriodRecord::QuarterThreeStart => NetballPeriod::QuarterThreeStart,
         NetballPeriodRecord::QuarterThreeEnd => NetballPeriod::QuarterThreeEnd,
+        NetballPeriodRecord::QuarterFourStart => NetballPeriod::QuarterFourStart,
         NetballPeriodRecord::FullTime => NetballPeriod::FullTime,
         NetballPeriodRecord::ExtraTimeStart => NetballPeriod::ExtraTimeStart,
         NetballPeriodRecord::ExtraTimeEnd => NetballPeriod::ExtraTimeEnd,
@@ -2068,12 +2082,14 @@ mod tests {
                 scorer_position: Some(NetballPosition::GoalShooter),
                 two_points: false,
                 minute: Some(4),
+                occurred_at: Some(parse_ts("2024-05-01T20:04:00.000Z")),
             }),
             NetballLiveEvent::Foul(NetballFoulEvent {
                 side_id: "harriers".into(),
                 player_id: Some("defender_1".into()),
                 foul_kind: NetballFoulKind::Contact,
                 minute: Some(6),
+                occurred_at: Some(parse_ts("2024-05-01T20:06:00.000Z")),
             }),
             NetballLiveEvent::Period(NetballPeriodEvent {
                 period: NetballPeriod::QuarterOneEnd,
@@ -2336,6 +2352,7 @@ mod tests {
                         scorer_position: Some(NetballPosition::GoalShooter),
                         two_points: false,
                         minute: Some(3),
+                        occurred_at: Some(parse_ts("2024-05-01T20:03:00.000Z")),
                     },
                     NetballGoalEvent {
                         side_id: "kestrels".into(),
@@ -2343,6 +2360,7 @@ mod tests {
                         scorer_position: Some(NetballPosition::GoalAttack),
                         two_points: true,
                         minute: Some(7),
+                        occurred_at: Some(parse_ts("2024-05-01T20:07:00.000Z")),
                     },
                 ]),
                 fouls: Some(vec![NetballFoulEvent {
@@ -2350,6 +2368,7 @@ mod tests {
                     player_id: Some("player_3".into()),
                     foul_kind: NetballFoulKind::Obstruction,
                     minute: Some(5),
+                    occurred_at: Some(parse_ts("2024-05-01T20:05:00.000Z")),
                 }]),
                 period: Some(NetballPeriod::QuarterOneEnd),
                 period_times: Some(HashMap::from([(

--- a/agon_service/src/mapping.rs
+++ b/agon_service/src/mapping.rs
@@ -1243,6 +1243,9 @@ fn football_goal_event_to_record(g: &FootballGoalEvent) -> FootballGoalEventReco
         own_goal: g.own_goal,
         penalty: g.penalty,
         minute: g.minute,
+        occurred_at: g
+            .occurred_at
+            .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
     }
 }
 
@@ -1254,6 +1257,7 @@ fn football_goal_event_from_record(rec: &FootballGoalEventRecord) -> FootballGoa
         own_goal: rec.own_goal,
         penalty: rec.penalty,
         minute: rec.minute,
+        occurred_at: parse_ts_opt(&rec.occurred_at),
     }
 }
 
@@ -1268,6 +1272,9 @@ fn football_card_event_to_record(c: &FootballCardEvent) -> FootballCardEventReco
             FootballCardColor::Red => FootballCardColorRecord::Red,
         },
         minute: c.minute,
+        occurred_at: c
+            .occurred_at
+            .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
     }
 }
 
@@ -1280,6 +1287,7 @@ fn football_card_event_from_record(rec: &FootballCardEventRecord) -> FootballCar
             FootballCardColorRecord::Red => FootballCardColor::Red,
         },
         minute: rec.minute,
+        occurred_at: parse_ts_opt(&rec.occurred_at),
     }
 }
 
@@ -1291,6 +1299,9 @@ fn football_substitution_event_to_record(
         player_in_id: s.player_in_id.clone(),
         player_out_id: s.player_out_id.clone(),
         minute: s.minute,
+        occurred_at: s
+            .occurred_at
+            .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
     }
 }
 
@@ -1302,6 +1313,7 @@ fn football_substitution_event_from_record(
         player_in_id: rec.player_in_id.clone(),
         player_out_id: rec.player_out_id.clone(),
         minute: rec.minute,
+        occurred_at: parse_ts_opt(&rec.occurred_at),
     }
 }
 
@@ -1643,6 +1655,9 @@ fn cricket_delivery_to_record(d: &CricketDelivery) -> CricketDeliveryRecord {
         runs_off_bat: d.runs_off_bat,
         extra: d.extra.as_ref().map(cricket_delivery_extra_to_record),
         wicket: d.wicket.as_ref().map(cricket_delivery_wicket_to_record),
+        occurred_at: d
+            .occurred_at
+            .map(|t| t.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
     }
 }
 
@@ -1656,6 +1671,7 @@ fn cricket_delivery_from_record(rec: &CricketDeliveryRecord) -> CricketDelivery 
         runs_off_bat: rec.runs_off_bat,
         extra: rec.extra.as_ref().map(cricket_delivery_extra_from_record),
         wicket: rec.wicket.as_ref().map(cricket_delivery_wicket_from_record),
+        occurred_at: parse_ts_opt(&rec.occurred_at),
     }
 }
 
@@ -1796,10 +1812,12 @@ pub fn derive_live_score(
             Some(Score::Football(FootballScore::from_events(&events)))
         }
         "cricket" => {
-            let events: Vec<CricketLiveEvent> = records
+            let events: Vec<(chrono::DateTime<chrono::Utc>, CricketLiveEvent)> = records
                 .iter()
                 .filter_map(|r| match &r.payload {
-                    LiveEventPayloadRecord::Cricket(c) => Some(cricket_live_event_from_record(c)),
+                    LiveEventPayloadRecord::Cricket(c) => {
+                        Some((parse_ts(&r.occurred_at), cricket_live_event_from_record(c)))
+                    }
                     LiveEventPayloadRecord::Football(_) | LiveEventPayloadRecord::Netball(_) => {
                         None
                     }
@@ -1995,18 +2013,21 @@ mod tests {
                 own_goal: true,
                 penalty: false,
                 minute: Some(63),
+                occurred_at: Some(parse_ts("2024-05-01T20:03:00.000Z")),
             }),
             FootballLiveEvent::Card(FootballCardEvent {
                 side_id: "oak_park".into(),
                 player_id: "khan".into(),
                 color: FootballCardColor::Red,
                 minute: None,
+                occurred_at: None,
             }),
             FootballLiveEvent::Substitution(FootballSubstitutionEvent {
                 side_id: "oak_park".into(),
                 player_in_id: "moreno".into(),
                 player_out_id: "khan".into(),
                 minute: Some(70),
+                occurred_at: Some(parse_ts("2024-05-01T20:10:00.000Z")),
             }),
             FootballLiveEvent::Period(FootballPeriodEvent {
                 period: FootballPeriod::ExtraTimeKickOff,
@@ -2051,6 +2072,7 @@ mod tests {
                     bowler_player_id: Some("patel".into()),
                     fielder_player_id: Some("cole".into()),
                 }),
+                occurred_at: Some(parse_ts("2024-05-01T20:04:03.000Z")),
             }),
             CricketLiveEvent::Retire(CricketRetireEvent {
                 batter_player_id: "sharma".into(),
@@ -2245,6 +2267,7 @@ mod tests {
                     runs_off_bat: 1,
                     extra: None,
                     wicket: None,
+                    occurred_at: Some(parse_ts("2024-05-01T20:08:03.000Z")),
                 }]),
                 next_ball_context: Some(NextBallContext {
                     striker_player_id: Some("player_2".into()),
@@ -2281,6 +2304,7 @@ mod tests {
                         own_goal: false,
                         penalty: false,
                         minute: Some(23),
+                        occurred_at: Some(parse_ts("2024-05-01T20:23:00.000Z")),
                     },
                     FootballGoalEvent {
                         side_id: "side_blue".into(),
@@ -2289,6 +2313,7 @@ mod tests {
                         own_goal: true,
                         penalty: false,
                         minute: None,
+                        occurred_at: None,
                     },
                 ]),
                 cards: Some(vec![FootballCardEvent {
@@ -2296,12 +2321,14 @@ mod tests {
                     player_id: "player_3".into(),
                     color: FootballCardColor::Yellow,
                     minute: Some(60),
+                    occurred_at: Some(parse_ts("2024-05-01T21:00:00.000Z")),
                 }]),
                 substitutions: Some(vec![FootballSubstitutionEvent {
                     side_id: "side_red".into(),
                     player_in_id: "player_4".into(),
                     player_out_id: "player_1".into(),
                     minute: Some(75),
+                    occurred_at: Some(parse_ts("2024-05-01T21:15:00.000Z")),
                 }]),
                 period: Some(FootballPeriod::FullTime),
                 period_times: Some(HashMap::from([

--- a/agon_ui/src/components/agon/FootballScoreFields.tsx
+++ b/agon_ui/src/components/agon/FootballScoreFields.tsx
@@ -4,7 +4,7 @@ import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { RecordEventDialog, type EventKind } from '@/components/agon/live/RecordEventDialog'
-import { describeEvent, eventEmoji, goalEventsToViews, type FootballEventView } from '@/lib/liveScore'
+import { describeEvent, eventClockLabel, eventEmoji, goalEventsToViews, type FootballEventView } from '@/lib/liveScore'
 
 type Match = components['schemas']['Match']
 type MatchSide = components['schemas']['MatchSide']
@@ -183,8 +183,8 @@ export function FootballScoreFields({ sideA, sideB, players, initial, onChange }
                     className={`flex items-baseline gap-1.5 text-xs ${isSideB ? 'flex-row-reverse text-right' : ''}`}
                   >
                     <span aria-hidden>{eventEmoji(event.kind)}</span>
-                    {event.minute !== undefined && (
-                      <span className="font-medium text-foreground">{event.minute}'</span>
+                    {eventClockLabel(event) && (
+                      <span className="font-medium text-foreground">{eventClockLabel(event)}</span>
                     )}
                     <span className="truncate">{describeEvent(event, match)}</span>
                   </p>

--- a/agon_ui/src/components/agon/FootballScorecard.tsx
+++ b/agon_ui/src/components/agon/FootballScorecard.tsx
@@ -1,5 +1,5 @@
 import type { components } from '@/types/api'
-import { describeEvent, eventEmoji, eventsFromDetail, minuteLabel, type FootballEventSource } from '@/lib/liveScore'
+import { describeEvent, eventClockLabel, eventEmoji, eventsFromDetail, type FootballEventSource } from '@/lib/liveScore'
 
 type Match = components['schemas']['Match']
 
@@ -33,7 +33,7 @@ export function FootballScorecard({ match, detail }: { match: Match; detail: Foo
             >
               <span aria-hidden>{eventEmoji(event.kind)}</span>
               <span className="font-medium tabular-nums text-muted-foreground">
-                {minuteLabel(event.minute)}
+                {eventClockLabel(event, detail.period_times)}
               </span>
               <span>{describeEvent(event, match, detail.players)}</span>
             </p>

--- a/agon_ui/src/components/agon/FootballScorersBySide.tsx
+++ b/agon_ui/src/components/agon/FootballScorersBySide.tsx
@@ -1,6 +1,6 @@
 import type { components } from '@/types/api'
 import { cn } from '@/lib/utils'
-import { scorersBySide, type FootballScorerLine } from '@/lib/liveScore'
+import { scorersBySide, type FootballPeriodTimes, type FootballScorerLine } from '@/lib/liveScore'
 import type { ScorePlayers } from '@/lib/members'
 
 type FootballGoalEvent = components['schemas']['FootballGoalEvent']
@@ -24,6 +24,7 @@ export function FootballScorersBySide({
   goals,
   match,
   players,
+  periodTimes,
   sideA,
   sideB,
   className,
@@ -31,11 +32,14 @@ export function FootballScorersBySide({
   goals: FootballGoalEvent[]
   match: Match | FeedMatch | SearchMatch
   players?: ScorePlayers
+  /** Lets a live-scored goal's time show as a derived match minute — see
+   *  `scorersBySide`. */
+  periodTimes?: FootballPeriodTimes
   sideA: MatchSide | undefined
   sideB: MatchSide | undefined
   className?: string
 }) {
-  const bySide = scorersBySide(goals, match, players)
+  const bySide = scorersBySide(goals, match, players, periodTimes)
   const scorersA = bySide[sideA?.id ?? ''] ?? []
   const scorersB = bySide[sideB?.id ?? ''] ?? []
 
@@ -61,12 +65,10 @@ function ScorerColumn({
       {scorers.map((s) => (
         <p key={s.key} className="truncate">
           {s.name}
-          {s.minutes.length > 0 && (
+          {s.times.length > 0 && (
             <>
               {' '}
-              <span className="font-medium text-foreground">
-                {s.minutes.map((m) => `${m}'`).join(', ')}
-              </span>
+              <span className="font-medium text-foreground">{s.times.join(', ')}</span>
             </>
           )}
         </p>

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -257,6 +257,8 @@ export function MatchCard({
   // player roster to resolve scorer names from locally.
   const finishedFootballScorePlayers =
     scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
+  const finishedFootballPeriodTimes =
+    scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.period_times : undefined
   const finishedNetballScorePlayers =
     scoreInfo && !isCurrentlyLive ? netballScoreFrom(scoreInfo.score)?.players : undefined
   const finishedNetballPeriodTimes =
@@ -390,6 +392,7 @@ export function MatchCard({
                 goals={finishedFootballGoals}
                 match={match}
                 players={finishedFootballScorePlayers}
+                periodTimes={finishedFootballPeriodTimes}
                 sideA={sideA}
                 sideB={sideB}
                 className="mt-2.5 text-[11px]"

--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -259,6 +259,8 @@ export function MatchCard({
     scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
   const finishedNetballScorePlayers =
     scoreInfo && !isCurrentlyLive ? netballScoreFrom(scoreInfo.score)?.players : undefined
+  const finishedNetballPeriodTimes =
+    scoreInfo && !isCurrentlyLive ? netballScoreFrom(scoreInfo.score)?.period_times : undefined
   // A cricket match's confirmed score carries its own per-innings detail once
   // it's been live-scored (`Score::Cricket`; see `finishMatch` in
   // `CricketLiveScoringPage`) — a manually-logged result still degrades to
@@ -398,6 +400,7 @@ export function MatchCard({
                 goals={finishedNetballGoals}
                 match={match}
                 players={finishedNetballScorePlayers}
+                periodTimes={finishedNetballPeriodTimes}
                 sideA={sideA}
                 sideB={sideB}
                 className="mt-2.5 text-[11px]"

--- a/agon_ui/src/components/agon/NetballScoreFields.tsx
+++ b/agon_ui/src/components/agon/NetballScoreFields.tsx
@@ -4,7 +4,7 @@ import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { RecordNetballEventDialog, type NetballEventKind } from '@/components/agon/live/RecordNetballEventDialog'
-import { describeEvent, eventEmoji, goalEventsToViews, type NetballEventView } from '@/lib/netballScore'
+import { describeEvent, eventClockLabel, eventEmoji, goalEventsToViews, type NetballEventView } from '@/lib/netballScore'
 
 type Match = components['schemas']['Match']
 type MatchSide = components['schemas']['MatchSide']
@@ -122,7 +122,16 @@ export function NetballScoreFields({ sideA, sideB, players, initial, onChange }:
 
   const events: NetballEventView[] = [
     ...goalEventsToViews(goals),
-    ...fouls.map((f): NetballEventView => ({ kind: 'foul', side_id: f.side_id, minute: f.minute, player_id: f.player_id })),
+    ...fouls.map((f): NetballEventView => ({
+      kind: 'foul',
+      side_id: f.side_id,
+      minute: f.minute,
+      player_id: f.player_id,
+      foul_kind: f.foul_kind,
+    })),
+    // No live clock here (see this component's doc comment) — `minute` is
+    // the only time signal a manually entered event carries, so it's what
+    // interleaves goals and fouls into one list.
   ].sort((a, b) => (a.minute ?? Infinity) - (b.minute ?? Infinity))
 
   return (
@@ -171,8 +180,8 @@ export function NetballScoreFields({ sideA, sideB, players, initial, onChange }:
                     className={`flex items-baseline gap-1.5 text-xs ${isSideB ? 'flex-row-reverse text-right' : ''}`}
                   >
                     <span aria-hidden>{eventEmoji(event.kind)}</span>
-                    {event.minute !== undefined && (
-                      <span className="font-medium text-foreground">{event.minute}'</span>
+                    {eventClockLabel(event) && (
+                      <span className="font-medium text-foreground">{eventClockLabel(event)}</span>
                     )}
                     <span className="truncate">{describeEvent(event, match)}</span>
                   </p>

--- a/agon_ui/src/components/agon/NetballScorecard.tsx
+++ b/agon_ui/src/components/agon/NetballScorecard.tsx
@@ -1,5 +1,5 @@
 import type { components } from '@/types/api'
-import { describeEvent, eventEmoji, eventsFromDetail, minuteLabel, type NetballEventSource } from '@/lib/netballScore'
+import { describeEvent, eventClockLabel, eventEmoji, eventsFromDetail, type NetballEventSource } from '@/lib/netballScore'
 
 type Match = components['schemas']['Match']
 
@@ -32,7 +32,7 @@ export function NetballScorecard({ match, detail }: { match: Match; detail: Netb
             >
               <span aria-hidden>{eventEmoji(event.kind)}</span>
               <span className="font-medium tabular-nums text-muted-foreground">
-                {minuteLabel(event.minute)}
+                {eventClockLabel(event, detail.period_times)}
               </span>
               <span>{describeEvent(event, match, detail.players)}</span>
             </p>

--- a/agon_ui/src/components/agon/NetballScorersBySide.tsx
+++ b/agon_ui/src/components/agon/NetballScorersBySide.tsx
@@ -1,6 +1,6 @@
 import type { components } from '@/types/api'
 import { cn } from '@/lib/utils'
-import { scorersBySide, type NetballScorerLine } from '@/lib/netballScore'
+import { scorersBySide, type NetballPeriodTimes, type NetballScorerLine } from '@/lib/netballScore'
 import type { ScorePlayers } from '@/lib/members'
 
 type NetballGoalEvent = components['schemas']['NetballGoalEvent']
@@ -19,6 +19,7 @@ export function NetballScorersBySide({
   goals,
   match,
   players,
+  periodTimes,
   sideA,
   sideB,
   className,
@@ -26,11 +27,14 @@ export function NetballScorersBySide({
   goals: NetballGoalEvent[]
   match: Match | FeedMatch | SearchMatch
   players?: ScorePlayers
+  /** Lets a live-scored goal's time show as mm:ss-within-its-quarter — see
+   *  `scorersBySide`. */
+  periodTimes?: NetballPeriodTimes
   sideA: MatchSide | undefined
   sideB: MatchSide | undefined
   className?: string
 }) {
-  const bySide = scorersBySide(goals, match, players)
+  const bySide = scorersBySide(goals, match, players, periodTimes)
   const scorersA = bySide[sideA?.id ?? ''] ?? []
   const scorersB = bySide[sideB?.id ?? ''] ?? []
 
@@ -56,12 +60,10 @@ function ScorerColumn({
       {scorers.map((s) => (
         <p key={s.key} className="truncate">
           {s.name}
-          {s.minutes.length > 0 && (
+          {s.times.length > 0 && (
             <>
               {' '}
-              <span className="font-medium text-foreground">
-                {s.minutes.map((m) => `${m}'`).join(', ')}
-              </span>
+              <span className="font-medium text-foreground">{s.times.join(', ')}</span>
             </>
           )}
         </p>

--- a/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/LiveMatchBlock.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@/components/agon/Avatar'
 import { LiveIndicator } from './LiveIndicator'
 import {
   describeEvent,
+  eventClockLabel,
   eventEmoji,
   liveClockLabel,
   recentEvents,
@@ -93,8 +94,8 @@ export function LiveMatchBlock({
                 className={`flex items-baseline gap-1.5 truncate text-xs text-muted-foreground ${isSideB ? 'flex-row-reverse text-right' : ''}`}
               >
                 <span aria-hidden>{eventEmoji(event.kind)}</span>
-                {event.minute !== undefined && (
-                  <span className="font-medium text-foreground">{event.minute}'</span>
+                {eventClockLabel(event, state.period_times) && (
+                  <span className="font-medium text-foreground">{eventClockLabel(event, state.period_times)}</span>
                 )}
                 <span className="truncate">{describeEvent(event, match, state.players)}</span>
               </p>

--- a/agon_ui/src/components/agon/live/NetballMatchBlock.tsx
+++ b/agon_ui/src/components/agon/live/NetballMatchBlock.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '@/components/agon/Avatar'
 import { LiveIndicator } from './LiveIndicator'
 import {
   describeEvent,
+  eventClockLabel,
   eventEmoji,
   liveClockLabel,
   recentEvents,
@@ -94,8 +95,8 @@ export function NetballMatchBlock({
                 className={`flex items-baseline gap-1.5 truncate text-xs text-muted-foreground ${isSideB ? 'flex-row-reverse text-right' : ''}`}
               >
                 <span aria-hidden>{eventEmoji(event.kind)}</span>
-                {event.minute !== undefined && (
-                  <span className="font-medium text-foreground">{event.minute}'</span>
+                {eventClockLabel(event, state.period_times) && (
+                  <span className="font-medium text-foreground">{eventClockLabel(event, state.period_times)}</span>
                 )}
                 <span className="truncate">{describeEvent(event, match, state.players)}</span>
               </p>

--- a/agon_ui/src/components/agon/live/RecordEventDialog.tsx
+++ b/agon_ui/src/components/agon/live/RecordEventDialog.tsx
@@ -69,12 +69,27 @@ function toMinute(minute: string): number | undefined {
  * screen. One component covers all three recordable football event kinds
  * (goal / card / substitution) since they share the same side→details shape;
  * `kind` picks which fields step 2 asks for.
+ *
+ * Two callers, two time models (same split as netball's
+ * `RecordNetballEventDialog`):
+ * - Live scoring (`liveMode: true`, from `LiveScoringPage`) hides the minute
+ *   field entirely — the event is timestamped by the server's own clock the
+ *   instant it's submitted (see `FootballGoalEvent.occurred_at`'s backend
+ *   doc comment). This is deliberate: a free-text minute let a scorer
+ *   backdate an event into the middle of the log, ahead of things already
+ *   recorded; only appending to the top of the stack keeps the log an
+ *   honest record of what was tapped when.
+ * - Manual/historical entry (`liveMode` omitted/false, from
+ *   `FootballScoreFields`) has no live clock to timestamp against at all —
+ *   a free-text minute is the only way to say roughly when something
+ *   happened, so that field stays.
  */
 export function RecordEventDialog({
   open,
   kind,
   match,
-  initialMinute,
+  liveMode = false,
+  initialMinute = 0,
   onOpenChange,
   onSubmit,
   submitting,
@@ -85,7 +100,10 @@ export function RecordEventDialog({
    *  match yet (see `FootballScoreFields`) can pass a synthetic object with
    *  just these two fields. */
   match: Pick<Match, 'sides' | 'players'>
-  initialMinute: number
+  /** Live scoring only — see the component doc comment. */
+  liveMode?: boolean
+  /** Manual entry only; ignored (and the field hidden) when `liveMode`. */
+  initialMinute?: number
   onOpenChange: (open: boolean) => void
   onSubmit: (event: FootballLiveEvent) => void
   submitting: boolean
@@ -129,7 +147,7 @@ export function RecordEventDialog({
         assist_player_id: goal.own_goal ? undefined : goal.assist_player_id,
         own_goal: goal.own_goal,
         penalty: goal.penalty,
-        minute: toMinute(goal.minute),
+        minute: liveMode ? undefined : toMinute(goal.minute),
       } as FootballLiveEvent)
     } else if (kind === 'card' && card.side_id && card.player_id && card.color) {
       onSubmit({
@@ -137,7 +155,7 @@ export function RecordEventDialog({
         side_id: card.side_id,
         player_id: card.player_id,
         color: card.color,
-        minute: toMinute(card.minute),
+        minute: liveMode ? undefined : toMinute(card.minute),
       } as FootballLiveEvent)
     } else if (kind === 'substitution' && sub.side_id && sub.player_out_id && sub.player_in_id) {
       onSubmit({
@@ -145,7 +163,7 @@ export function RecordEventDialog({
         side_id: sub.side_id,
         player_in_id: sub.player_in_id,
         player_out_id: sub.player_out_id,
-        minute: toMinute(sub.minute),
+        minute: liveMode ? undefined : toMinute(sub.minute),
       } as FootballLiveEvent)
     }
   }
@@ -293,14 +311,16 @@ export function RecordEventDialog({
             </>
           )}
 
-          <MinuteField
-            value={kind === 'goal' ? goal.minute : kind === 'card' ? card.minute : sub.minute}
-            onChange={(v) => {
-              if (kind === 'goal') setGoal((d) => ({ ...d, minute: v }))
-              else if (kind === 'card') setCard((d) => ({ ...d, minute: v }))
-              else setSub((d) => ({ ...d, minute: v }))
-            }}
-          />
+          {!liveMode && (
+            <MinuteField
+              value={kind === 'goal' ? goal.minute : kind === 'card' ? card.minute : sub.minute}
+              onChange={(v) => {
+                if (kind === 'goal') setGoal((d) => ({ ...d, minute: v }))
+                else if (kind === 'card') setCard((d) => ({ ...d, minute: v }))
+                else setSub((d) => ({ ...d, minute: v }))
+              }}
+            />
+          )}
 
           <Button disabled={!canSubmit || submitting} onClick={submit}>
             {submitting ? 'Saving…' : `Add ${title.toLowerCase()}`}

--- a/agon_ui/src/components/agon/live/RecordNetballEventDialog.tsx
+++ b/agon_ui/src/components/agon/live/RecordNetballEventDialog.tsx
@@ -11,23 +11,13 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { playersOnSide } from '@/lib/members'
+import { FOUL_KINDS, foulKindLabel, type NetballFoulKind } from '@/lib/netballScore'
 import { PlayerPicker, SidePicker } from './Pickers'
 
 type Match = components['schemas']['Match']
 type NetballLiveEvent = components['schemas']['NetballLiveEvent']
-type NetballFoulKind = components['schemas']['NetballFoulKind']
 
 export type NetballEventKind = 'goal' | 'foul'
-
-const FOUL_KINDS: NetballFoulKind[] = ['contact', 'obstruction', 'footwork', 'offside', 'held_ball', 'other']
-const FOUL_KIND_LABEL: Record<NetballFoulKind, string> = {
-  contact: 'Contact',
-  obstruction: 'Obstruction',
-  footwork: 'Footwork',
-  offside: 'Offside',
-  held_ball: 'Held ball',
-  other: 'Other',
-}
 
 function MinuteField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
   return (
@@ -73,12 +63,26 @@ function toMinute(minute: string): number | undefined {
  * football's `RecordEventDialog`. Quarter-only scoring never opens this;
  * it records period-end scores directly (see `LiveScoringPage`'s netball
  * flow).
+ *
+ * Two callers, two time models:
+ * - Live scoring (`liveMode: true`, from `NetballLiveScoringPage`) hides the
+ *   minute field entirely — the event is timestamped by the server's own
+ *   clock the instant it's submitted (see `NetballGoalEvent.occurred_at`'s
+ *   backend doc comment). This is deliberate, not just simpler: a free-text
+ *   minute let a scorer backdate an event into the middle of the log, ahead
+ *   of things already recorded; only appending to the top of the stack keeps
+ *   the log an honest record of what was tapped when.
+ * - Manual/historical entry (`liveMode` omitted/false, from
+ *   `NetballScoreFields`) has no live clock to timestamp against at all — a
+ *   free-text minute is the only way to say roughly when a goal happened,
+ *   so that field stays.
  */
 export function RecordNetballEventDialog({
   open,
   kind,
   match,
-  initialMinute,
+  liveMode = false,
+  initialMinute = 0,
   onOpenChange,
   onSubmit,
   submitting,
@@ -89,7 +93,10 @@ export function RecordNetballEventDialog({
    *  match yet (see `NetballScoreFields`) can pass a synthetic object with
    *  just these two fields. */
   match: Pick<Match, 'sides' | 'players'>
-  initialMinute: number
+  /** Live scoring only — see the component doc comment. */
+  liveMode?: boolean
+  /** Manual entry only; ignored (and the field hidden) when `liveMode`. */
+  initialMinute?: number
   onOpenChange: (open: boolean) => void
   onSubmit: (event: NetballLiveEvent) => void
   submitting: boolean
@@ -120,7 +127,7 @@ export function RecordNetballEventDialog({
         side_id: goal.side_id,
         scorer_player_id: goal.scorer_player_id,
         two_points: goal.two_points,
-        minute: toMinute(goal.minute),
+        minute: liveMode ? undefined : toMinute(goal.minute),
       } as NetballLiveEvent)
     } else if (kind === 'foul' && foul.side_id && foul.foul_kind) {
       onSubmit({
@@ -128,7 +135,7 @@ export function RecordNetballEventDialog({
         side_id: foul.side_id,
         player_id: foul.player_id,
         foul_kind: foul.foul_kind,
-        minute: toMinute(foul.minute),
+        minute: liveMode ? undefined : toMinute(foul.minute),
       } as NetballLiveEvent)
     }
   }
@@ -211,20 +218,22 @@ export function RecordNetballEventDialog({
                         : 'text-muted-foreground hover:bg-muted',
                     )}
                   >
-                    {FOUL_KIND_LABEL[fk]}
+                    {foulKindLabel(fk)}
                   </button>
                 ))}
               </div>
             </>
           )}
 
-          <MinuteField
-            value={kind === 'goal' ? goal.minute : foul.minute}
-            onChange={(v) => {
-              if (kind === 'goal') setGoal((d) => ({ ...d, minute: v }))
-              else setFoul((d) => ({ ...d, minute: v }))
-            }}
-          />
+          {!liveMode && (
+            <MinuteField
+              value={kind === 'goal' ? goal.minute : foul.minute}
+              onChange={(v) => {
+                if (kind === 'goal') setGoal((d) => ({ ...d, minute: v }))
+                else setFoul((d) => ({ ...d, minute: v }))
+              }}
+            />
+          )}
 
           <Button disabled={!canSubmit || submitting} onClick={submit}>
             {submitting ? 'Saving…' : `Add ${title.toLowerCase()}`}

--- a/agon_ui/src/lib/liveScore.ts
+++ b/agon_ui/src/lib/liveScore.ts
@@ -6,6 +6,11 @@ export type FootballGoalEvent = components['schemas']['FootballGoalEvent']
 type FootballCardEvent = components['schemas']['FootballCardEvent']
 type FootballSubstitutionEvent = components['schemas']['FootballSubstitutionEvent']
 type Score = components['schemas']['Score']
+/** A period-marker timestamp map, straight off `FootballScore.period_times`
+ *  — the schema widens the key to a bare string, so this is what every
+ *  helper below that just needs the timestamps (not the rest of a
+ *  `FootballScore`) accepts. Same role as netball's `NetballPeriodTimes`. */
+export type FootballPeriodTimes = Record<string, string>
 type MatchPlayer = components['schemas']['MatchPlayer']
 type FeedMatch = components['schemas']['FeedMatch']
 type SearchMatch = components['schemas']['SearchMatch']
@@ -39,6 +44,7 @@ export type FootballEventSource = {
   cards: FootballCardEvent[]
   substitutions: FootballSubstitutionEvent[]
   players: ScorePlayers
+  period_times?: FootballPeriodTimes
 }
 
 /** A football match's event timeline straight off its score — `null` if
@@ -54,6 +60,7 @@ export function footballEventSourceFromScore(score: Score | null | undefined): F
     cards: score.cards ?? [],
     substitutions: score.substitutions ?? [],
     players: score.players,
+    period_times: score.period_times,
   }
 }
 
@@ -67,7 +74,15 @@ export type FootballEventKind = 'goal' | 'own_goal' | 'penalty' | 'yellow_card' 
 export interface FootballEventView {
   kind: FootballEventKind
   side_id: string
+  /** Free-text minutes-into-the-match — only ever set on a manually logged
+   *  historical event (no live clock). A live-scored event's minute is
+   *  derived from `occurred_at` instead; see `eventClockLabel`. */
   minute?: number
+  /** Wall-clock time, set on every live-scored event (and unset on a
+   *  manually logged one) — the source of truth for both display (via
+   *  `eventClockLabel`) and chronological order (via `eventsFromDetail`'s
+   *  sort). */
+  occurred_at?: string
   player_id?: string
   assist_player_id?: string
   substituted_player_id?: string
@@ -91,16 +106,26 @@ export function goalEventsToViews(goals: FootballGoalEvent[]): FootballEventView
     kind: goalKind(g),
     side_id: g.side_id,
     minute: g.minute,
+    occurred_at: g.occurred_at,
     player_id: g.scorer_player_id,
     assist_player_id: g.assist_player_id,
   }))
 }
 
+/** Sort key for ordering events chronologically: `occurred_at` (a
+ *  live-scored event's wall-clock time) when present, else a coarse
+ *  fallback off the free-text `minute` a manually logged event carries
+ *  instead, else last. Same reasoning as netball's `eventSortKey`. */
+function eventSortKey(view: { occurred_at?: string; minute?: number }): number {
+  if (view.occurred_at) return new Date(view.occurred_at).getTime()
+  if (view.minute !== undefined) return view.minute * 60_000
+  return Infinity
+}
+
 /** All of a football score's goals/cards/substitutions merged into one
- *  timeline, ordered by minute (undated events last — the scorer always
- *  fills in a minute in practice, so this only matters for edge cases).
- *  Takes just `FootballEventSource` (not the full `FootballScore`) so a
- *  finished match's `Score.Football` can feed it too — see
+ *  timeline, in true chronological order (undated events last). Takes just
+ *  `FootballEventSource` (not the full `FootballScore`) so a finished
+ *  match's `Score.Football` can feed it too — see
  *  `footballEventSourceFromScore`. */
 export function eventsFromDetail(detail: FootballEventSource): FootballEventView[] {
   const events: FootballEventView[] = [
@@ -109,17 +134,19 @@ export function eventsFromDetail(detail: FootballEventSource): FootballEventView
       kind: cardKind(c),
       side_id: c.side_id,
       minute: c.minute,
+      occurred_at: c.occurred_at,
       player_id: c.player_id,
     })),
     ...detail.substitutions.map((s): FootballEventView => ({
       kind: 'substitution',
       side_id: s.side_id,
       minute: s.minute,
+      occurred_at: s.occurred_at,
       player_id: s.player_in_id,
       substituted_player_id: s.player_out_id,
     })),
   ]
-  return events.sort((a, b) => (a.minute ?? Infinity) - (b.minute ?? Infinity))
+  return events.sort((a, b) => eventSortKey(a) - eventSortKey(b))
 }
 
 /** Label + emoji for each football live-event kind, for the event log/ticker. */
@@ -149,7 +176,10 @@ export function eventEmoji(kind: FootballEventKind): string {
   return EVENT_EMOJI[kind]
 }
 
-/** "63'" for a recorded minute, else a blank string. */
+/** "63'" for a recorded free-text minute (manual entry only — see
+ *  `FootballGoalEvent.minute`'s backend doc comment), else a blank string. A
+ *  live-scored event should use `eventClockLabel` instead, which prefers
+ *  `occurred_at`. */
 export function minuteLabel(minute: number | undefined): string {
   return minute === undefined ? '' : `${minute}'`
 }
@@ -177,6 +207,7 @@ export function recentEvents(detail: FootballScore, limit: number): FootballEven
     cards: detail.cards ?? [],
     substitutions: detail.substitutions ?? [],
     players: detail.players,
+    period_times: detail.period_times,
   })
     .reverse()
     .slice(0, limit)
@@ -190,7 +221,9 @@ export function recentEvents(detail: FootballScore, limit: number): FootballEven
 export interface FootballScorerLine {
   key: string
   name: string
-  minutes: number[]
+  /** Already display-formatted (mm' or the legacy bare-minute label — see
+   *  `eventClockLabel`), one per goal, in chronological order. */
+  times: string[]
 }
 
 /** All of a football match's goals, grouped by crediting side and then by
@@ -211,22 +244,33 @@ export function scorersBySide(
   goals: FootballGoalEvent[],
   match: MatchLike,
   scorePlayers?: ScorePlayers,
+  periodTimes?: FootballPeriodTimes,
 ): Record<string, FootballScorerLine[]> {
-  const bySide: Record<string, Map<string, FootballScorerLine>> = {}
+  const bySide: Record<string, Map<string, { name: string; entries: { key: number; label: string }[] }>> = {}
   for (const g of goals) {
     const lines = (bySide[g.side_id] ??= new Map())
     const scorer = playerNameFor(match, g.scorer_player_id, scorePlayers)
     const key = g.own_goal ? `own_goal:${g.scorer_player_id ?? 'unknown'}` : (g.scorer_player_id ?? 'unknown')
     const name = g.own_goal ? (scorer ? `Own goal (${scorer})` : 'Own goal') : (scorer ?? 'Unknown')
-    const line = lines.get(key) ?? { key, name, minutes: [] }
-    if (g.minute !== undefined) line.minutes.push(g.minute)
+    const line = lines.get(key) ?? { name, entries: [] }
+    const view: FootballEventView = { kind: goalKind(g), side_id: g.side_id, minute: g.minute, occurred_at: g.occurred_at }
+    line.entries.push({ key: eventSortKey(view), label: eventClockLabel(view, periodTimes) })
     lines.set(key, line)
   }
   const out: Record<string, FootballScorerLine[]> = {}
   for (const [sideId, lines] of Object.entries(bySide)) {
-    out[sideId] = [...lines.values()]
-      .map((line) => ({ ...line, minutes: [...line.minutes].sort((a, b) => a - b) }))
-      .sort((a, b) => (a.minutes[0] ?? Infinity) - (b.minutes[0] ?? Infinity))
+    out[sideId] = [...lines.entries()]
+      .map(([key, line]) => {
+        const sorted = [...line.entries].sort((a, b) => a.key - b.key)
+        return {
+          key,
+          name: line.name,
+          times: sorted.filter((e) => e.label).map((e) => e.label),
+          firstKey: sorted[0]?.key ?? Infinity,
+        }
+      })
+      .sort((a, b) => a.firstKey - b.firstKey)
+      .map(({ key, name, times }) => ({ key, name, times }))
   }
   return out
 }
@@ -346,6 +390,14 @@ export function periodTime(detail: FootballScore, period: FootballPeriod): strin
   return detail.period_times?.[period]
 }
 
+/** Same lookup as `periodTime`, but off a bare `FootballPeriodTimes` map
+ *  instead of a full `FootballScore` — for helpers (`minuteAt`,
+ *  `eventClockLabel`) that need to work from just the timestamps, e.g. a
+ *  finished match's `FootballEventSource`, which doesn't carry a full score. */
+function periodTimeFrom(periodTimes: FootballPeriodTimes | undefined, period: FootballPeriod): string | undefined {
+  return periodTimes?.[period]
+}
+
 export type ClockPhase =
   | 'not_started'
   | 'first_half'
@@ -401,25 +453,23 @@ function minutesBetween(from: string, to: Date | string): number {
   return Math.max(0, Math.floor((new Date(to).getTime() - new Date(from).getTime()) / 60_000))
 }
 
-/**
- * The current match minute, e.g. for the live clock display or to prefill an
- * event's minute field (still overridable — see `RecordEventDialog`). `null`
- * before kickoff or during an unclocked phase (penalties). Added time in a
- * half carries over automatically into the next one — first half into
- * second half, and normal time into extra time — so the clock counts up
- * continuously (e.g. 94', then 106' once extra time starts) rather than
- * resetting to a fixed 45'/90' each time.
- */
-export function currentMinute(state: FootballScore, now: Date = new Date()): number | null {
-  const phase = phaseFromState(state)
-  const kickoffAt = periodTime(state, 'kick_off')
-  const halfTimeAt = periodTime(state, 'half_time')
-  const secondHalfKickoffAt = periodTime(state, 'second_half_kick_off')
-  const fullTimeAt = periodTime(state, 'full_time')
-  const etKickoffAt = periodTime(state, 'extra_time_kick_off')
-  const etHalfTimeAt = periodTime(state, 'extra_time_half_time')
-  const etSecondHalfKickoffAt = periodTime(state, 'extra_time_second_half_kick_off')
-  const etFullTimeAt = periodTime(state, 'extra_time_full_time')
+/** The cumulative-minute baselines each live-play bracket starts from —
+ *  shared by `currentMinute` (evaluated at "now") and `minuteAt` (evaluated
+ *  at an arbitrary past instant, e.g. a recorded event's `occurred_at`) so
+ *  the two can never disagree about where the clock resumes after a break.
+ *  Added time in a half carries over automatically into the next one —
+ *  first half into second half, and normal time into extra time — so the
+ *  clock counts up continuously (e.g. 94', then 106' once extra time
+ *  starts) rather than resetting to a fixed 45'/90' each time. */
+function clockBaselines(periodTimes: FootballPeriodTimes | undefined) {
+  const kickoffAt = periodTimeFrom(periodTimes, 'kick_off')
+  const halfTimeAt = periodTimeFrom(periodTimes, 'half_time')
+  const secondHalfKickoffAt = periodTimeFrom(periodTimes, 'second_half_kick_off')
+  const fullTimeAt = periodTimeFrom(periodTimes, 'full_time')
+  const etKickoffAt = periodTimeFrom(periodTimes, 'extra_time_kick_off')
+  const etHalfTimeAt = periodTimeFrom(periodTimes, 'extra_time_half_time')
+  const etSecondHalfKickoffAt = periodTimeFrom(periodTimes, 'extra_time_second_half_kick_off')
+  const etFullTimeAt = periodTimeFrom(periodTimes, 'extra_time_full_time')
 
   const firstHalfMinutes = kickoffAt && halfTimeAt ? minutesBetween(kickoffAt, halfTimeAt) : 0
   const normalTimeMinutes = fullTimeAt
@@ -430,6 +480,42 @@ export function currentMinute(state: FootballScore, now: Date = new Date()): num
         : 0
     : 0
   const etFirstHalfMinutes = etKickoffAt && etHalfTimeAt ? minutesBetween(etKickoffAt, etHalfTimeAt) : 0
+
+  return {
+    kickoffAt,
+    halfTimeAt,
+    secondHalfKickoffAt,
+    fullTimeAt,
+    etKickoffAt,
+    etHalfTimeAt,
+    etSecondHalfKickoffAt,
+    etFullTimeAt,
+    firstHalfMinutes,
+    normalTimeMinutes,
+    etFirstHalfMinutes,
+  }
+}
+
+/**
+ * The current match minute, e.g. for the live clock display. `null` before
+ * kickoff or during an unclocked phase (penalties). See `clockBaselines` for
+ * how added time/extra time carry over.
+ */
+export function currentMinute(state: FootballScore, now: Date = new Date()): number | null {
+  const phase = phaseFromState(state)
+  const {
+    kickoffAt,
+    halfTimeAt,
+    secondHalfKickoffAt,
+    fullTimeAt,
+    etKickoffAt,
+    etHalfTimeAt,
+    etSecondHalfKickoffAt,
+    etFullTimeAt,
+    firstHalfMinutes,
+    normalTimeMinutes,
+    etFirstHalfMinutes,
+  } = clockBaselines(state.period_times)
 
   switch (phase) {
     case 'first_half':
@@ -463,6 +549,51 @@ export function currentMinute(state: FootballScore, now: Date = new Date()): num
     case 'other':
       return null
   }
+}
+
+/** The match minute a past instant (`occurredAt`) fell in — the same
+ *  bracket-and-carry-over math as `currentMinute`, but bracketing an
+ *  arbitrary timestamp against the recorded markers instead of dispatching
+ *  on the match's *current* phase. This is what a live-scored event's
+ *  displayed minute is derived from (see `eventClockLabel`), rather than
+ *  trusting a stored/typed number: extra time layers on top of normal time
+ *  automatically, and a break's duration is never counted, exactly like the
+ *  live clock itself. `null` if `occurredAt` predates kickoff (shouldn't
+ *  happen for a real event, but keeps this total rather than guessing). */
+export function minuteAt(periodTimes: FootballPeriodTimes | undefined, occurredAt: string): number | null {
+  const b = clockBaselines(periodTimes)
+  const t = new Date(occurredAt).getTime()
+  const since = (marker: string) => minutesBetween(marker, occurredAt)
+
+  // Checked from the latest bracket backward — an event's `occurred_at`
+  // should never predate the marker that started its own bracket, so the
+  // first (latest) marker it's at-or-after is the one it belongs to.
+  if (b.etSecondHalfKickoffAt && t >= new Date(b.etSecondHalfKickoffAt).getTime()) {
+    return b.normalTimeMinutes + b.etFirstHalfMinutes + since(b.etSecondHalfKickoffAt)
+  }
+  if (b.etKickoffAt && t >= new Date(b.etKickoffAt).getTime()) {
+    return b.normalTimeMinutes + since(b.etKickoffAt)
+  }
+  if (b.secondHalfKickoffAt && t >= new Date(b.secondHalfKickoffAt).getTime()) {
+    return b.firstHalfMinutes + since(b.secondHalfKickoffAt)
+  }
+  if (b.kickoffAt && t >= new Date(b.kickoffAt).getTime()) {
+    return since(b.kickoffAt)
+  }
+  return null
+}
+
+/** Display label for one event's time — "63'" for a live-scored event,
+ *  derived from `occurred_at` plus the match's recorded period markers
+ *  (`minuteAt`); the legacy free-text minute label (`minuteLabel`) for a
+ *  manually logged one. Blank if neither is known (e.g. `periodTimes` wasn't
+ *  available to bracket a live event against). */
+export function eventClockLabel(event: FootballEventView, periodTimes?: FootballPeriodTimes): string {
+  if (event.occurred_at) {
+    const minute = minuteAt(periodTimes, event.occurred_at)
+    if (minute !== null) return `${minute}'`
+  }
+  return minuteLabel(event.minute)
 }
 
 /** Whether the ball is actually in play right now — the phases where a goal

--- a/agon_ui/src/lib/netballScore.ts
+++ b/agon_ui/src/lib/netballScore.ts
@@ -1,9 +1,11 @@
 import type { components } from '@/types/api'
 import { memberName, type ScorePlayers } from './members'
+import type { NetballFormat } from './matchFormat'
 
 export type NetballPeriod = components['schemas']['NetballPeriod']
 export type NetballGoalEvent = components['schemas']['NetballGoalEvent']
 type NetballFoulEvent = components['schemas']['NetballFoulEvent']
+export type NetballFoulKind = components['schemas']['NetballFoulKind']
 type Score = components['schemas']['Score']
 type MatchPlayer = components['schemas']['MatchPlayer']
 type FeedMatch = components['schemas']['FeedMatch']
@@ -19,6 +21,12 @@ type MatchLike = { players?: MatchPlayer[] } | FeedMatch | SearchMatch
  *  back on a PATCH, same as `FootballScore` in `lib/liveScore.ts`. */
 export type NetballScore = Extract<Score, { type: 'Netball' }>
 
+/** A period-marker timestamp map, straight off `NetballScore.period_times` —
+ *  the schema widens the key to a bare string, so this is what every helper
+ *  below that just needs the timestamps (not the rest of a `NetballScore`)
+ *  accepts. */
+export type NetballPeriodTimes = Record<string, string>
+
 /** Narrows a match's score to its netball variant, or `null` when there's
  *  none yet or it's for a different sport. */
 export function netballScoreFrom(score: Score | null | undefined): NetballScore | null {
@@ -30,17 +38,27 @@ export function netballScoreFrom(score: Score | null | undefined): NetballScore 
  *  finished match's `Score.Netball` and a live one can both feed the same
  *  timeline (same pattern as `FootballEventSource`). `null` for a
  *  quarter-only-scored or manually-entered result, which carries no
- *  goal-by-goal detail at all. */
+ *  goal-by-goal detail at all. `period_times` is optional — a manually
+ *  entered result (see `NetballScoreFields`) has no live clock, so there's
+ *  nothing to bracket an event's quarter-relative time against; those events
+ *  fall back to their own free-text `minute` instead (see
+ *  `eventClockLabel`). */
 export type NetballEventSource = {
   goals: NetballGoalEvent[]
   fouls: NetballFoulEvent[]
   players: ScorePlayers
+  period_times?: NetballPeriodTimes
 }
 
 export function netballEventSourceFromScore(score: Score | null | undefined): NetballEventSource | null {
   if (!score || score.type !== 'Netball') return null
   if (!score.goals && !score.fouls) return null
-  return { goals: score.goals ?? [], fouls: score.fouls ?? [], players: score.players }
+  return {
+    goals: score.goals ?? [],
+    fouls: score.fouls ?? [],
+    players: score.players,
+    period_times: score.period_times,
+  }
 }
 
 /** A client-side view of one netball event, merging `NetballScore`'s
@@ -50,8 +68,18 @@ export type NetballEventKind = 'goal' | 'two_point_goal' | 'foul'
 export interface NetballEventView {
   kind: NetballEventKind
   side_id: string
+  /** Free-text minutes-into-the-match — only ever set on a manually logged
+   *  historical event (no live clock). A live-scored event's time comes from
+   *  `occurred_at` instead; see `eventClockLabel`. */
   minute?: number
+  /** Wall-clock time, set on every live-scored event (and unset on a
+   *  manually logged one) — the source of truth for both display (via
+   *  `eventClockLabel`) and chronological order (via `eventsFromDetail`'s
+   *  sort), unlike `minute`, which resets every quarter. */
+  occurred_at?: string
   player_id?: string
+  /** Present for `kind: 'foul'` only. */
+  foul_kind?: NetballFoulKind
 }
 
 function goalKind(g: NetballGoalEvent): NetballEventKind {
@@ -66,14 +94,30 @@ export function goalEventsToViews(goals: NetballGoalEvent[]): NetballEventView[]
     kind: goalKind(g),
     side_id: g.side_id,
     minute: g.minute,
+    occurred_at: g.occurred_at,
     player_id: g.scorer_player_id,
   }))
 }
 
-/** All of a netball score's goals/fouls merged into one timeline, ordered by
- *  minute (undated events last). Takes just `NetballEventSource` (not the
- *  full `NetballScore`) so a finished match's `Score.Netball` can feed it
- *  too — see `netballEventSourceFromScore`. */
+/** Sort key for ordering events chronologically: `occurred_at` (a live-scored
+ *  event's wall-clock time) when present, else a coarse fallback off the
+ *  free-text `minute` a manually logged event carries instead, else last.
+ *  `minute` alone is *not* usable for a live-scored match — it resets every
+ *  quarter, so two events from different quarters can carry the same (or an
+ *  inverted) `minute` even though one strictly happened after the other; see
+ *  `NetballGoalEvent.occurred_at`'s backend doc comment. In practice a given
+ *  match's events come from one source or the other, never a mix, so this
+ *  fallback never has to reconcile the two within the same list. */
+function eventSortKey(view: { occurred_at?: string; minute?: number }): number {
+  if (view.occurred_at) return new Date(view.occurred_at).getTime()
+  if (view.minute !== undefined) return view.minute * 60_000
+  return Infinity
+}
+
+/** All of a netball score's goals/fouls merged into one timeline, in true
+ *  chronological order (undated events last). Takes just `NetballEventSource`
+ *  (not the full `NetballScore`) so a finished match's `Score.Netball` can
+ *  feed it too — see `netballEventSourceFromScore`. */
 export function eventsFromDetail(detail: NetballEventSource): NetballEventView[] {
   const events: NetballEventView[] = [
     ...goalEventsToViews(detail.goals),
@@ -81,10 +125,12 @@ export function eventsFromDetail(detail: NetballEventSource): NetballEventView[]
       kind: 'foul',
       side_id: f.side_id,
       minute: f.minute,
+      occurred_at: f.occurred_at,
       player_id: f.player_id,
+      foul_kind: f.foul_kind,
     })),
   ]
-  return events.sort((a, b) => (a.minute ?? Infinity) - (b.minute ?? Infinity))
+  return events.sort((a, b) => eventSortKey(a) - eventSortKey(b))
 }
 
 const EVENT_LABEL: Record<NetballEventKind, string> = {
@@ -107,18 +153,104 @@ export function eventEmoji(kind: NetballEventKind): string {
   return EVENT_EMOJI[kind]
 }
 
-/** "12'" for a recorded minute (minutes into the *current quarter*, not
- *  match-wide — see `NetballGoalEvent.minute`'s backend doc comment), else a
- *  blank string. */
+const FOUL_KIND_LABEL: Record<NetballFoulKind, string> = {
+  contact: 'Contact',
+  obstruction: 'Obstruction',
+  footwork: 'Footwork',
+  offside: 'Offside',
+  held_ball: 'Held ball',
+  other: 'Other',
+}
+
+/** Every foul kind, in the order offered on `RecordNetballEventDialog`'s
+ *  picker. */
+export const FOUL_KINDS: NetballFoulKind[] = [
+  'contact',
+  'obstruction',
+  'footwork',
+  'offside',
+  'held_ball',
+  'other',
+]
+
+export function foulKindLabel(kind: NetballFoulKind): string {
+  return FOUL_KIND_LABEL[kind]
+}
+
+/** "12'" for a recorded free-text minute (minutes into the *current
+ *  quarter*, manual entry only — see `NetballGoalEvent.minute`'s backend doc
+ *  comment), else a blank string. A live-scored event should use
+ *  `eventClockLabel` instead, which prefers `occurred_at`. */
 export function minuteLabel(minute: number | undefined): string {
   return minute === undefined ? '' : `${minute}'`
+}
+
+/** "3:45" for a whole number of seconds — the live clock's display format,
+ *  seconds included (see `NetballGoalEvent.occurred_at`'s backend doc
+ *  comment for why the app moved off minute-only granularity). */
+export function formatClock(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60)
+  const s = totalSeconds % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+/** The quarter/segment-start markers, in play order — what an arbitrary
+ *  timestamp gets bracketed against to find which quarter it fell in (see
+ *  `elapsedInQuarterAt`) and what the live clock counts minutes from (see
+ *  `currentQuarterStartedAt`). `start` covers the 1st quarter; every quarter
+ *  after that (and extra time) has its own explicit start marker — see
+ *  `ClockPhase`'s doc comment. */
+const QUARTER_START_MARKERS: NetballPeriod[] = [
+  'start',
+  'quarter_two_start',
+  'quarter_three_start',
+  'quarter_four_start',
+  'extra_time_start',
+]
+
+/** Seconds elapsed within whichever quarter/segment was running when
+ *  `occurredAt` happened, found by bracketing it against the recorded
+ *  quarter-start markers — the live equivalent of `currentQuarterElapsedSeconds`
+ *  but for an arbitrary past instant instead of "now". `null` if `occurredAt`
+ *  predates every recorded quarter start (shouldn't happen for a real event,
+ *  but keeps this total instead of guessing). */
+export function elapsedInQuarterAt(
+  periodTimes: NetballPeriodTimes | undefined,
+  occurredAt: string,
+): number | null {
+  const t = new Date(occurredAt).getTime()
+  let bracketStart: number | null = null
+  for (const marker of QUARTER_START_MARKERS) {
+    const markerTime = periodTimes?.[marker]
+    if (!markerTime) continue
+    const ms = new Date(markerTime).getTime()
+    if (ms <= t && (bracketStart === null || ms > bracketStart)) bracketStart = ms
+  }
+  if (bracketStart === null) return null
+  return Math.max(0, Math.floor((t - bracketStart) / 1000))
+}
+
+/** Display label for one event's time — "3:45" (mm:ss within its quarter)
+ *  for a live-scored event, derived from `occurred_at` plus the match's
+ *  recorded quarter-start markers; the legacy bare-minute label
+ *  (`minuteLabel`) for a manually logged one. Blank if neither is known
+ *  (e.g. `periodTimes` wasn't available to bracket a live event against). */
+export function eventClockLabel(event: NetballEventView, periodTimes?: NetballPeriodTimes): string {
+  if (event.occurred_at) {
+    const elapsed = elapsedInQuarterAt(periodTimes, event.occurred_at)
+    if (elapsed !== null) return formatClock(elapsed)
+  }
+  return minuteLabel(event.minute)
 }
 
 const PERIOD_LABEL: Record<NetballPeriod, string> = {
   start: 'Start',
   quarter_one_end: 'End of Q1',
+  quarter_two_start: 'Start of Q2',
   quarter_two_end: 'Half-time',
+  quarter_three_start: 'Start of 2nd half',
   quarter_three_end: 'End of Q3',
+  quarter_four_start: 'Start of Q4',
   full_time: 'Full-time',
   extra_time_start: 'Extra time',
   extra_time_end: 'Extra time complete',
@@ -134,6 +266,7 @@ export function recentEvents(detail: NetballScore, limit: number): NetballEventV
     goals: detail.goals ?? [],
     fouls: detail.fouls ?? [],
     players: detail.players,
+    period_times: detail.period_times,
   })
     .reverse()
     .slice(0, limit)
@@ -155,66 +288,77 @@ function playerNameFor(
 }
 
 /** One-line human description of a netball event, e.g. "Goal — J. Elgar" or
- *  "2pt goal — A. Silva". Which side it belongs to isn't repeated in the
- *  text; callers convey that by aligning/positioning the row using
- *  `event.side_id` instead (see football's `describeEvent`). */
+ *  "Foul (Contact) — A. Silva". A foul always names its kind (falling back to
+ *  the bare "Foul" only if somehow unset) — which isn't repeated in the text
+ *  is which side it belongs to; callers convey that by aligning/positioning
+ *  the row using `event.side_id` instead (see football's `describeEvent`). */
 export function describeEvent(
   event: NetballEventView,
   match: MatchLike,
   scorePlayers?: ScorePlayers,
 ): string {
   const scorer = playerNameFor(match, event.player_id, scorePlayers)
-  return scorer ? `${eventLabel(event.kind)} — ${scorer}` : eventLabel(event.kind)
+  const label =
+    event.kind === 'foul' && event.foul_kind
+      ? `Foul (${foulKindLabel(event.foul_kind)})`
+      : eventLabel(event.kind)
+  return scorer ? `${label} — ${scorer}` : label
 }
 
 /** One goalscorer's line for a side's scorer list — same shape/role as
- *  football's `FootballScorerLine`. */
+ *  football's `FootballScorerLine`. `times` is already display-formatted
+ *  (mm:ss or the legacy bare-minute label — see `eventClockLabel`), one per
+ *  goal, in chronological order. */
 export interface NetballScorerLine {
   key: string
   name: string
-  minutes: number[]
+  times: string[]
 }
 
 /** All of a netball match's goals, grouped by crediting side and then by
  *  scorer — same construction as football's `scorersBySide`, minus the
- *  own-goal handling netball has no equivalent of. */
+ *  own-goal handling netball has no equivalent of. `periodTimes` lets a
+ *  live-scored goal's time show as mm:ss-within-its-quarter instead of
+ *  falling back to its (usually unset) free-text `minute` — see
+ *  `eventClockLabel`. */
 export function scorersBySide(
   goals: NetballGoalEvent[],
   match: MatchLike,
   scorePlayers?: ScorePlayers,
+  periodTimes?: NetballPeriodTimes,
 ): Record<string, NetballScorerLine[]> {
-  const bySide: Record<string, Map<string, NetballScorerLine>> = {}
+  const bySide: Record<string, Map<string, { name: string; entries: { key: number; label: string }[] }>> = {}
   for (const g of goals) {
     const lines = (bySide[g.side_id] ??= new Map())
     const key = g.scorer_player_id ?? 'unknown'
     const name = playerNameFor(match, g.scorer_player_id, scorePlayers) ?? 'Unknown'
-    const line = lines.get(key) ?? { key, name, minutes: [] }
-    if (g.minute !== undefined) line.minutes.push(g.minute)
+    const line = lines.get(key) ?? { name, entries: [] }
+    const view: NetballEventView = {
+      kind: goalKind(g),
+      side_id: g.side_id,
+      minute: g.minute,
+      occurred_at: g.occurred_at,
+      player_id: g.scorer_player_id,
+    }
+    line.entries.push({ key: eventSortKey(view), label: eventClockLabel(view, periodTimes) })
     lines.set(key, line)
   }
   const out: Record<string, NetballScorerLine[]> = {}
   for (const [sideId, lines] of Object.entries(bySide)) {
-    out[sideId] = [...lines.values()]
-      .map((line) => ({ ...line, minutes: [...line.minutes].sort((a, b) => a - b) }))
-      .sort((a, b) => (a.minutes[0] ?? Infinity) - (b.minutes[0] ?? Infinity))
+    out[sideId] = [...lines.entries()]
+      .map(([key, line]) => {
+        const sorted = [...line.entries].sort((a, b) => a.key - b.key)
+        return {
+          key,
+          name: line.name,
+          times: sorted.filter((e) => e.label).map((e) => e.label),
+          firstKey: sorted[0]?.key ?? Infinity,
+        }
+      })
+      .sort((a, b) => a.firstKey - b.firstKey)
+      .map(({ key, name, times }) => ({ key, name, times }))
   }
   return out
-}
-
-/** The score as of a given quarter marker, straight off
- *  `NetballScore.period_scores` — the same map both of netball's
- *  live-scoring methods populate (see its backend doc comment), so this
- *  works identically whichever produced the score. */
-export function periodScore(
-  detail: NetballScore,
-  period: NetballPeriod,
-): Record<string, number> | undefined {
-  return detail.period_scores?.[period]
-}
-
-/** When a given period marker was recorded, if at all. */
-export function periodTime(detail: NetballScore, period: NetballPeriod): string | undefined {
-  return detail.period_times?.[period]
 }
 
 /**
@@ -234,72 +378,133 @@ export type NetballScoringMethod = 'event_by_event' | 'quarter_only'
 // Match clock — derived from `NetballScore.period_times`, the same "shared
 // server data, not a per-device stopwatch" approach as football's clock (see
 // `lib/liveScore.ts`'s module doc comment). Unlike football, a goal's
-// `minute` is scoped to the *current quarter* (it resets each quarter), so
-// the clock here doesn't need to accumulate across periods the way
-// football's does — it's just time since whichever marker started the
-// current quarter.
+// on-quarter time resets each quarter, so the clock here doesn't need to
+// accumulate across periods the way football's does — it's just time since
+// whichever marker started the current quarter.
 // ---------------------------------------------------------------------------
 
 export type ClockPhase =
   | 'not_started'
   | 'quarter_1'
+  | 'break_1'
   | 'quarter_2'
+  | 'break_2'
   | 'quarter_3'
+  | 'break_3'
   | 'quarter_4'
   | 'full_time'
   | 'extra_time'
   | 'finished'
 
-/** Which phase the match is in right now, purely from recorded markers. Each
- *  marker doubles as the start of the next quarter — netball's breaks are
- *  too short to need a separate "quarter N start" event (see
- *  `NetballPeriod`'s backend doc comment). */
+/** Which phase the match is in right now, purely from recorded markers.
+ *  Every quarter after the first (and extra time) needs its own explicit
+ *  *start* marker before play resumes — an *end* marker alone drops the
+ *  match into a `break_*` phase, not straight into the next quarter, so the
+ *  scorer has to tap "start" once the break is actually over (of whatever
+ *  length — nothing here assumes how long it runs). See `NetballPeriod`'s
+ *  backend doc comment for why this mirrors the pattern `full_time` →
+ *  `extra_time_start` already used. */
 export function phaseFromState(state: NetballScore): ClockPhase {
   if (periodTime(state, 'extra_time_end')) return 'finished'
   if (periodTime(state, 'extra_time_start')) return 'extra_time'
   if (periodTime(state, 'full_time')) return 'full_time'
-  if (periodTime(state, 'quarter_three_end')) return 'quarter_4'
-  if (periodTime(state, 'quarter_two_end')) return 'quarter_3'
-  if (periodTime(state, 'quarter_one_end')) return 'quarter_2'
+  if (periodTime(state, 'quarter_four_start')) return 'quarter_4'
+  if (periodTime(state, 'quarter_three_end')) return 'break_3'
+  if (periodTime(state, 'quarter_three_start')) return 'quarter_3'
+  if (periodTime(state, 'quarter_two_end')) return 'break_2'
+  if (periodTime(state, 'quarter_two_start')) return 'quarter_2'
+  if (periodTime(state, 'quarter_one_end')) return 'break_1'
   if (periodTime(state, 'start')) return 'quarter_1'
   return 'not_started'
 }
 
-/** The marker that starts the *current* quarter — what the clock counts
- *  minutes from (`currentMinute`) — `undefined` for a phase with no clock
- *  running (`not_started`, `full_time`, `finished`). */
+/** The score as of a given quarter marker, straight off
+ *  `NetballScore.period_scores` — the same map both of netball's
+ *  live-scoring methods populate (see its backend doc comment), so this
+ *  works identically whichever produced the score. */
+export function periodScore(
+  detail: NetballScore,
+  period: NetballPeriod,
+): Record<string, number> | undefined {
+  return detail.period_scores?.[period]
+}
+
+/** When a given period marker was recorded, if at all. */
+export function periodTime(detail: NetballScore, period: NetballPeriod): string | undefined {
+  return detail.period_times?.[period]
+}
+
+/** The marker that starts the *current* quarter — what the live clock counts
+ *  from (`currentQuarterElapsedSeconds`) — `undefined` for a phase with no
+ *  clock running (`not_started`, any `break_*`, `full_time`, `finished`): the
+ *  ball isn't live during a break, so there's nothing to time. */
 function currentQuarterStartedAt(state: NetballScore, phase: ClockPhase): string | undefined {
   switch (phase) {
     case 'quarter_1':
       return periodTime(state, 'start')
     case 'quarter_2':
-      return periodTime(state, 'quarter_one_end')
+      return periodTime(state, 'quarter_two_start')
     case 'quarter_3':
-      return periodTime(state, 'quarter_two_end')
+      return periodTime(state, 'quarter_three_start')
     case 'quarter_4':
-      return periodTime(state, 'quarter_three_end')
+      return periodTime(state, 'quarter_four_start')
     case 'extra_time':
       return periodTime(state, 'extra_time_start')
     case 'not_started':
+    case 'break_1':
+    case 'break_2':
+    case 'break_3':
     case 'full_time':
     case 'finished':
       return undefined
   }
 }
 
-/** Minutes elapsed in the current quarter — matches the scope of
- *  `NetballGoalEvent.minute`, so this can prefill a new goal's minute field
- *  directly. `null` when there's no quarter currently running. */
-export function currentMinute(state: NetballScore, now: Date = new Date()): number | null {
+/** Seconds elapsed in the current quarter — the live clock's tick, with
+ *  second precision (see `NetballGoalEvent.occurred_at`'s backend doc
+ *  comment). `null` when there's no quarter currently running (including
+ *  during a break — see `currentQuarterStartedAt`). */
+export function currentQuarterElapsedSeconds(state: NetballScore, now: Date = new Date()): number | null {
   const phase = phaseFromState(state)
   const startedAt = currentQuarterStartedAt(state, phase)
   if (!startedAt) return null
-  return Math.max(0, Math.floor((now.getTime() - new Date(startedAt).getTime()) / 60_000))
+  return Math.max(0, Math.floor((now.getTime() - new Date(startedAt).getTime()) / 1000))
+}
+
+/** Minutes elapsed in the current quarter — matches the scope of the legacy
+ *  `NetballGoalEvent.minute`. `null` when there's no quarter currently
+ *  running. Prefer `currentQuarterElapsedSeconds` for anything that should
+ *  tick with second precision (e.g. the live scoring page's own clock). */
+export function currentMinute(state: NetballScore, now: Date = new Date()): number | null {
+  const seconds = currentQuarterElapsedSeconds(state, now)
+  return seconds === null ? null : Math.floor(seconds / 60)
+}
+
+const QUARTER_PLAY_PHASES: ClockPhase[] = ['quarter_1', 'quarter_2', 'quarter_3', 'quarter_4']
+
+/** Whether the current quarter has run past the format's quarter length —
+ *  the live scoring page's cue to turn the clock red so it's obvious time's
+ *  up, even though nothing stops the clock (or scoring) automatically; the
+ *  scorer still decides when to actually end the quarter. Extra time has no
+ *  configured length (`NetballFormat` doesn't carry one), so it never flags
+ *  as over time here. */
+export function isQuarterOvertime(
+  state: NetballScore,
+  format: NetballFormat,
+  now: Date = new Date(),
+): boolean {
+  const phase = phaseFromState(state)
+  if (!QUARTER_PLAY_PHASES.includes(phase)) return false
+  const seconds = currentQuarterElapsedSeconds(state, now)
+  return seconds !== null && seconds >= format.quarter_length_minutes * 60
 }
 
 /** Whether the ball is live right now — the phases a goal/foul can
- *  meaningfully be recorded in. Used to gate the live scoring screen's quick
- *  actions on the current phase, same role as football's `isLivePlayPhase`. */
+ *  meaningfully be recorded in. A `break_*` phase is deliberately excluded:
+ *  nothing happens on court between the whistle ending a quarter and the
+ *  scorer tapping "start" on the next one, so there's no event to record
+ *  there either. Used to gate the live scoring screen's quick actions on the
+ *  current phase, same role as football's `isLivePlayPhase`. */
 export function isLivePlayPhase(phase: ClockPhase): boolean {
   return phase === 'quarter_1' || phase === 'quarter_2' || phase === 'quarter_3' || phase === 'quarter_4' || phase === 'extra_time'
 }
@@ -311,10 +516,16 @@ export function phaseLabel(phase: ClockPhase): string {
       return 'Not started'
     case 'quarter_1':
       return '1st quarter'
+    case 'break_1':
+      return 'Break'
     case 'quarter_2':
       return '2nd quarter'
+    case 'break_2':
+      return 'Half-time'
     case 'quarter_3':
       return '3rd quarter'
+    case 'break_3':
+      return 'Break'
     case 'quarter_4':
       return '4th quarter'
     case 'full_time':
@@ -330,6 +541,7 @@ export function phaseLabel(phase: ClockPhase): string {
 export function liveClockLabel(state: NetballScore, now: Date = new Date()): string {
   const phase = phaseFromState(state)
   if (phase === 'full_time' || phase === 'finished') return 'FT'
+  if (phase === 'break_1' || phase === 'break_2' || phase === 'break_3') return phaseLabel(phase).toUpperCase()
   const minute = currentMinute(state, now)
   return minute === null ? 'LIVE' : `${minute}'`
 }
@@ -343,10 +555,11 @@ export interface NetballProgressionContext {
 }
 
 /** The `NetballPeriod` marker to record for "the next thing that happens"
- *  from the current phase — what the live scoring screen's quarter-end quick
- *  action should send. `null` once the match is done, or before it's
- *  started (the first event any live-scoring method records is `Start`
- *  itself, so there's no "next marker" to prefill before that). */
+ *  from the current phase — what the live scoring screen's single advance
+ *  action should send, whether that's ending the current quarter or
+ *  starting the next one after a break. `null` once the match is done, or
+ *  before it's started (the first event any live-scoring method records is
+ *  `Start` itself, so there's no "next marker" to prefill before that). */
 export function nextPeriodForPhase(
   phase: ClockPhase,
   ctx: NetballProgressionContext,
@@ -356,10 +569,16 @@ export function nextPeriodForPhase(
       return 'start'
     case 'quarter_1':
       return 'quarter_one_end'
+    case 'break_1':
+      return 'quarter_two_start'
     case 'quarter_2':
       return 'quarter_two_end'
+    case 'break_2':
+      return 'quarter_three_start'
     case 'quarter_3':
       return 'quarter_three_end'
+    case 'break_3':
+      return 'quarter_four_start'
     case 'quarter_4':
       return 'full_time'
     case 'full_time':
@@ -381,10 +600,16 @@ export function nextPhaseActionLabel(
       return 'Start match'
     case 'quarter_1':
       return 'End 1st quarter'
+    case 'break_1':
+      return 'Start 2nd quarter'
     case 'quarter_2':
       return 'End 2nd quarter (half-time)'
+    case 'break_2':
+      return 'Start 2nd half'
     case 'quarter_3':
       return 'End 3rd quarter'
+    case 'break_3':
+      return 'Start 4th quarter'
     case 'quarter_4':
       return ctx.isDraw && ctx.extraTime ? 'Full-time — start extra time' : 'Full-time'
     case 'extra_time':

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -16,6 +16,7 @@ import { footballFormat } from '@/lib/matchFormat'
 import {
   currentMinute,
   describeEvent,
+  eventClockLabel,
   eventEmoji,
   eventsFromDetail,
   footballScoreFrom,
@@ -263,6 +264,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
         cards: state.cards ?? [],
         substitutions: state.substitutions ?? [],
         players: state.players,
+        period_times: state.period_times,
       }).reverse()
     : []
 
@@ -432,8 +434,8 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
                   key={i}
                   className={`flex items-baseline gap-2 text-sm ${isSideB ? 'flex-row-reverse text-right' : ''}`}
                 >
-                  <span className="w-8 shrink-0 text-xs text-muted-foreground">
-                    {event.minute !== undefined ? `${event.minute}'` : ''}
+                  <span className="w-10 shrink-0 text-xs text-muted-foreground">
+                    {eventClockLabel(event, state?.period_times)}
                   </span>
                   <span aria-hidden>{eventEmoji(event.kind)}</span>
                   <span className="min-w-0 truncate">{describeEvent(event, match, state?.players)}</span>
@@ -454,7 +456,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
         open={dialogKind !== null}
         kind={dialogKind}
         match={match}
-        initialMinute={minute ?? 0}
+        liveMode
         onOpenChange={(open) => !open && setDialogKind(null)}
         submitting={append.isPending}
         onSubmit={(event) => {

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -166,6 +166,8 @@ function MatchDetail({
   const finishedFootballGoals = scoreInfo && !isCurrentlyLive ? footballGoalsFromScore(scoreInfo.score) : null
   const finishedFootballScorePlayers =
     scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.players : undefined
+  const finishedFootballPeriodTimes =
+    scoreInfo && !isCurrentlyLive ? footballScoreFrom(scoreInfo.score)?.period_times : undefined
   const finishedNetballGoals = scoreInfo && !isCurrentlyLive ? netballGoalsFromScore(scoreInfo.score) : null
   const finishedNetballScorePlayers =
     scoreInfo && !isCurrentlyLive ? netballScoreFrom(scoreInfo.score)?.players : undefined
@@ -308,6 +310,7 @@ function MatchDetail({
               goals={finishedFootballGoals}
               match={match}
               players={finishedFootballScorePlayers}
+              periodTimes={finishedFootballPeriodTimes}
               sideA={sideA}
               sideB={sideB}
               className="mt-2 text-xs"

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -169,6 +169,8 @@ function MatchDetail({
   const finishedNetballGoals = scoreInfo && !isCurrentlyLive ? netballGoalsFromScore(scoreInfo.score) : null
   const finishedNetballScorePlayers =
     scoreInfo && !isCurrentlyLive ? netballScoreFrom(scoreInfo.score)?.players : undefined
+  const finishedNetballPeriodTimes =
+    scoreInfo && !isCurrentlyLive ? netballScoreFrom(scoreInfo.score)?.period_times : undefined
   // Same "live while in progress, else confirmed/pending" source as
   // `cricketScoreInnings` below — needed here just for `.players` (the
   // score's resolved-name map), passed to `CricketScorecard`.
@@ -317,6 +319,7 @@ function MatchDetail({
               goals={finishedNetballGoals}
               match={match}
               players={finishedNetballScorePlayers}
+              periodTimes={finishedNetballPeriodTimes}
               sideA={sideA}
               sideB={sideB}
               className="mt-2 text-xs"

--- a/agon_ui/src/pages/NetballLiveScoringPage.tsx
+++ b/agon_ui/src/pages/NetballLiveScoringPage.tsx
@@ -6,6 +6,7 @@ import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
 import { useAppendNetballEvent, useLiveSeq } from '@/hooks/useLiveScore'
 import { matchScoreQueryKey, useMatchScore } from '@/hooks/useMatchScore'
 import {
@@ -17,11 +18,14 @@ import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { UndoLastEventButton } from '@/components/agon/live/UndoLastEventButton'
 import { netballFormat } from '@/lib/matchFormat'
 import {
-  currentMinute,
+  currentQuarterElapsedSeconds,
   describeEvent,
+  eventClockLabel,
   eventEmoji,
   eventsFromDetail,
+  formatClock,
   isLivePlayPhase,
+  isQuarterOvertime,
   netballScoreFrom,
   nextPeriodForPhase,
   nextPhaseActionLabel,
@@ -190,8 +194,11 @@ function useFinishNetballMatch(match: Match) {
   })
 }
 
-/** How often the on-screen clock re-renders while a quarter is running. */
-const CLOCK_TICK_MS = 15_000
+/** How often the on-screen clock re-renders while a quarter is running —
+ *  every second, so the scorer sees it actually ticking (not just jumping a
+ *  minute at a time) and notices promptly once it goes red (see
+ *  `isQuarterOvertime`). */
+const CLOCK_TICK_MS = 1_000
 
 /**
  * Event-by-event netball scoring: quick actions to log goals/fouls as they
@@ -234,17 +241,32 @@ function NetballEventByEventScoringPage({
 
   const format = netballFormat(match.format)
   const phase: ClockPhase = state ? phaseFromState(state) : 'not_started'
-  const minute = state ? currentMinute(state, now) : null
+  const elapsedSeconds = state ? currentQuarterElapsedSeconds(state, now) : null
+  const overtime = !!state && isQuarterOvertime(state, format, now)
   const isDraw = !!state && goalsFor(aId) === goalsFor(bId)
   const progressionCtx = { isDraw, extraTime: format.extra_time }
 
-  const handleQuarterEnd = () => {
+  const handleAdvancePhase = () => {
     const period = nextPeriodForPhase(phase, progressionCtx)
     if (!period) return
     append.mutate({ kind: 'Period', period, score: state?.score ?? {} })
   }
 
-  const advanceClockPhases: ClockPhase[] = ['not_started', 'quarter_1', 'quarter_2', 'quarter_3', 'quarter_4', 'extra_time']
+  // Every phase with an advance action: ending the current quarter, or
+  // (from a `break_*` phase) starting the next one once the scorer taps
+  // "start" — see `phaseFromState`'s doc comment for why a break doesn't
+  // advance on its own.
+  const advanceClockPhases: ClockPhase[] = [
+    'not_started',
+    'quarter_1',
+    'break_1',
+    'quarter_2',
+    'break_2',
+    'quarter_3',
+    'break_3',
+    'quarter_4',
+    'extra_time',
+  ]
   const showAdvanceClockTile = advanceClockPhases.includes(phase)
 
   const actions: { key: string; label: string; icon: React.ReactNode; onClick: () => void; disabled?: boolean }[] = [
@@ -257,10 +279,10 @@ function NetballEventByEventScoringPage({
     ...(showAdvanceClockTile
       ? [
           {
-            key: 'quarter_end',
+            key: 'advance_phase',
             label: nextPhaseActionLabel(phase, progressionCtx),
             icon: <TimerReset className="size-5" />,
-            onClick: handleQuarterEnd,
+            onClick: handleAdvancePhase,
             disabled: nextPeriodForPhase(phase, progressionCtx) === null,
           },
         ]
@@ -272,7 +294,12 @@ function NetballEventByEventScoringPage({
   const readyToFinish = (decidingPhase && !continuationAvailable) || phase === 'finished'
 
   const events = state
-    ? eventsFromDetail({ goals: state.goals ?? [], fouls: state.fouls ?? [], players: state.players }).reverse()
+    ? eventsFromDetail({
+        goals: state.goals ?? [],
+        fouls: state.fouls ?? [],
+        players: state.players,
+        period_times: state.period_times,
+      }).reverse()
     : []
 
   return (
@@ -313,8 +340,8 @@ function NetballEventByEventScoringPage({
               <span className="text-muted-foreground">–</span>
               {goalsFor(bId)}
             </div>
-            <div className="mt-0.5 text-xs text-primary">
-              {minute !== null && `${minute}' · `}
+            <div className={cn('mt-0.5 text-xs', overtime ? 'font-semibold text-destructive' : 'text-primary')}>
+              {elapsedSeconds !== null && `${formatClock(elapsedSeconds)} · `}
               {phaseLabel(phase)}
             </div>
           </div>
@@ -341,7 +368,7 @@ function NetballEventByEventScoringPage({
 
       {continuationAvailable && (
         <div className="flex flex-col gap-2">
-          <Button size="lg" disabled={append.isPending} onClick={handleQuarterEnd}>
+          <Button size="lg" disabled={append.isPending} onClick={handleAdvancePhase}>
             {nextPhaseActionLabel(phase, progressionCtx)}
           </Button>
           <Button variant="ghost" size="sm" disabled={finishMatch.isPending} onClick={() => finishMatch.mutate()}>
@@ -372,8 +399,8 @@ function NetballEventByEventScoringPage({
               const isSideB = event.side_id === match.sides[1]?.id
               return (
                 <div key={i} className={`flex items-baseline gap-2 text-sm ${isSideB ? 'flex-row-reverse text-right' : ''}`}>
-                  <span className="w-8 shrink-0 text-xs text-muted-foreground">
-                    {event.minute !== undefined ? `${event.minute}'` : ''}
+                  <span className="w-10 shrink-0 text-xs text-muted-foreground">
+                    {eventClockLabel(event, state?.period_times)}
                   </span>
                   <span aria-hidden>{eventEmoji(event.kind)}</span>
                   <span className="min-w-0 truncate">{describeEvent(event, match, state?.players)}</span>
@@ -390,7 +417,7 @@ function NetballEventByEventScoringPage({
         open={dialogKind !== null}
         kind={dialogKind}
         match={match}
-        initialMinute={minute ?? 0}
+        liveMode
         onOpenChange={(open) => !open && setDialogKind(null)}
         submitting={append.isPending}
         onSubmit={(event) => {
@@ -459,11 +486,19 @@ function NetballQuarterOnlyScoringPage({
     append.mutate({ kind: 'Period', period: nextPeriod, score: { [aId]: a, [bId]: b } })
   }
 
+  // Quarter-only mode has no live clock, so it never records the explicit
+  // `*Start` markers event-by-event mode's breaks use (see `NetballPeriod`'s
+  // backend doc comment) — `quarter_two_start`/`quarter_three_start`/
+  // `quarter_four_start` are listed here only because `NetballPeriod` needs
+  // every variant covered, not because this screen ever looks them up.
   const QUARTER_LABEL: Record<NetballPeriod, string> = {
     start: 'Start',
     quarter_one_end: 'End of 1st quarter',
+    quarter_two_start: 'Start of 2nd quarter',
     quarter_two_end: 'End of 2nd quarter (half-time)',
+    quarter_three_start: 'Start of 3rd quarter',
     quarter_three_end: 'End of 3rd quarter',
+    quarter_four_start: 'Start of 4th quarter',
     full_time: 'Full-time',
     extra_time_start: 'Extra time',
     extra_time_end: 'End of extra time',


### PR DESCRIPTION
## Summary
Extends netball event recording with wall-clock timestamps (`occurred_at`) for live-scored events and foul kind classification, enabling accurate chronological ordering and richer event details. Live-scored events are now timestamped by the server's clock at submission time, while manually entered historical results continue to use free-text minutes.

## Key Changes

### Backend (agon_service & agon_core)
- **NetballGoalEvent & NetballFoulEvent**: Added `occurred_at` field (RFC3339 wall-clock timestamp) to both event types. For live-scored events, the server overwrites this from the envelope's own clock, ensuring authoritative ordering independent of quarter-relative `minute` values.
- **NetballPeriod enum**: Added explicit `*Start` markers (`QuarterTwoStart`, `QuarterThreeStart`, `QuarterFourStart`) to distinguish quarter-start from quarter-end events. Breaks are now explicit phases requiring a "start" action before play resumes, rather than end-markers implicitly starting the next quarter.
- **NetballScore.apply_event()**: Stamps goals and fouls with `occurred_at` from the live event envelope, overriding any client-provided value to maintain server-side ordering authority.
- **Database records**: Updated `NetballGoalEventRecord` and `NetballFoulEventRecord` to persist `occurred_at` as RFC3339 strings.

### Frontend (agon_ui)
- **Event sorting & display**: Replaced minute-only sorting with `eventSortKey()` that prefers `occurred_at` (wall-clock) for live events, falls back to `minute * 60_000` for manual entries, and places undated events last. This fixes scrambling of later quarters when sorting on quarter-relative minutes alone.
- **Clock display**: Changed from minute granularity to second precision via `formatClock()` and `currentQuarterElapsedSeconds()`. Live clock now ticks every second (1s interval) instead of every 15s.
- **Quarter-relative time calculation**: Added `elapsedInQuarterAt()` to bracket an arbitrary `occurred_at` timestamp against recorded quarter-start markers, computing seconds elapsed within that quarter.
- **Event time labels**: New `eventClockLabel()` unifies display logic — shows "mm:ss" (within-quarter) for live events with `occurred_at`, falls back to legacy "m'" format for manual entries, blank if neither is available.
- **Foul kinds**: Exported `FOUL_KINDS` array and `foulKindLabel()` from `netballScore.ts` (moved from component-local); `NetballEventView` now includes optional `foul_kind` field; `describeEvent()` includes foul kind in output (e.g., "Foul (Contact)").
- **Phase model**: `ClockPhase` now includes explicit `break_1`, `break_2`, `break_3` states. `phaseFromState()` and `nextPeriodForPhase()` updated to handle break phases and their transitions to quarter starts.
- **Scorer list**: `NetballScorerLine.minutes` renamed to `times` (display-formatted strings); `scorersBySide()` now accepts optional `periodTimes` to format goal times as mm:ss when available.
- **Live scoring UI**: Renamed "quarter end" action to "advance phase" (handles both quarter-end and break-start transitions); overtime detection via `isQuarterOvertime()` turns clock red when quarter exceeds format's configured length.

### Dialog & Manual Entry
- **RecordNetballEventDialog**: Added `liveMode` prop to hide minute field in live scoring (server timestamps instead) while keeping it visible for manual/historical entry. Updated to handle foul kind selection and pass it through.
- **NetballScoreFields**: Updated to include `foul_kind` in manually entered fouls; no `period_times` available (no live clock), so event times fall back to free-text minutes.

## Notable Implementation Details
- **Ordering invariant**: `occurred_at` is the authoritative sort key for live-scored events; `minute` alone is insufficient because it resets every quarter, causing chronological scrambling. The server stamps

https://claude.ai/code/session_013z27XWmkwh1Y5Qhxdj825s