### PR TITLE
Put the viewer's own team on the left in match views

### DIFF
--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -37,7 +37,7 @@ import {
   headlineLabel,
   setLine,
 } from '@/lib/score'
-import { myPendingInvitation } from '@/lib/members'
+import { myPendingInvitation, mySideId, orderSidesForViewer } from '@/lib/members'
 
 type Match = components['schemas']['Match']
 type FeedMatch = components['schemas']['FeedMatch']
@@ -204,10 +204,19 @@ export function MatchCard({
   className,
   ...props
 }: MatchCardProps) {
-  const [sideA, sideB] = match.sides
+  // The viewer's own side, when resolvable, always renders first (left) —
+  // both here and on the match detail page. `orderedMatch` carries the same
+  // reordering into the live-score/scorer sub-components below, which each
+  // derive their own sideA/sideB straight off `match.sides` — passing this
+  // instead of `match` keeps them in sync with the score box without
+  // touching their internals (everything they key off is side id, not
+  // array position).
+  const orderedSides = orderSidesForViewer(match.sides, mySideId(match, currentUserId))
+  const orderedMatch = { ...match, sides: orderedSides }
+  const [sideA, sideB] = orderedSides
   const scoreInfo = displayScore(match)
   const headline = scoreInfo ? headlineBySide(scoreInfo.score) : {}
-  const sets = scoreInfo ? setLine(scoreInfo.score, match.sides) : []
+  const sets = scoreInfo ? setLine(scoreInfo.score, orderedSides) : []
 
   const nameA = sideName(sideA, 'Side A')
   const nameB = sideName(sideB, 'Side B')
@@ -336,19 +345,19 @@ export function MatchCard({
           per-innings detail gets its own tile too. */}
       {footballState ? (
         <div className="mx-3.5 mb-3">
-          <LiveMatchBlock match={match} state={footballState} />
+          <LiveMatchBlock match={orderedMatch} state={footballState} />
         </div>
       ) : netballState ? (
         <div className="mx-3.5 mb-3">
-          <NetballMatchBlock match={match} state={netballState} />
+          <NetballMatchBlock match={orderedMatch} state={netballState} />
         </div>
       ) : cricketState ? (
         <div className="mx-3.5 mb-3">
-          <CricketMatchBlock match={match} state={cricketState} showDescription={false} />
+          <CricketMatchBlock match={orderedMatch} state={cricketState} showDescription={false} />
         </div>
       ) : cricketScore ? (
         <div className="mx-3.5 mb-3">
-          <CricketScoreBlock match={match} score={cricketScore} showDescription={false} />
+          <CricketScoreBlock match={orderedMatch} score={cricketScore} showDescription={false} />
         </div>
       ) : (
         scoreInfo && (
@@ -386,7 +395,7 @@ export function MatchCard({
             {finishedFootballGoals && (
               <FootballScorersBySide
                 goals={finishedFootballGoals}
-                match={match}
+                match={orderedMatch}
                 players={finishedFootballScorePlayers}
                 sideA={sideA}
                 sideB={sideB}
@@ -396,7 +405,7 @@ export function MatchCard({
             {finishedNetballGoals && (
               <NetballScorersBySide
                 goals={finishedNetballGoals}
-                match={match}
+                match={orderedMatch}
                 players={finishedNetballScorePlayers}
                 sideA={sideA}
                 sideB={sideB}

--- a/agon_ui/src/lib/members.ts
+++ b/agon_ui/src/lib/members.ts
@@ -134,6 +134,57 @@ export function isParticipant(
 }
 
 /**
+ * The side the viewer themselves plays on, if they're a participant — so
+ * match views can put the viewer's own side on the left regardless of the
+ * order the server happens to store `sides` in (see `orderSidesForViewer`).
+ *
+ * A feed's `FeedMatch` already resolves this server-side (`viewer_side_id`,
+ * cheaper there than a roster scan — see its backend doc comment); a full
+ * `Match` carries the roster to look it up directly, mirroring
+ * `isParticipant`'s accepted/no-invitation check. `SearchMatch` has neither,
+ * so this is always `undefined` there — search/profile-activity cards keep
+ * the server's stored side order.
+ */
+export function mySideId(
+  match: MatchLike,
+  currentUserId: string | undefined,
+): string | undefined {
+  if (!currentUserId) return undefined
+  if ('viewer_side_id' in match) return match.viewer_side_id ?? undefined
+  const players = ('players' in match && match.players) || []
+  for (const player of players) {
+    if (player.member.type !== 'User') continue
+    if (player.member.user_id !== currentUserId) continue
+    const invitation = player.member.invitation
+    if (invitation && invitation.status !== 'accepted') continue
+    if (player.side_id) return player.side_id
+  }
+  return undefined
+}
+
+/**
+ * `sides` reordered so the viewer's own side (`mySideId`) comes first —
+ * "my team on the left" in the feed card and match detail score boxes.
+ * Everything downstream (headline/score lookups, scorer columns, roster
+ * columns) keys off side id rather than array position, so reordering here
+ * is enough to flip the whole view. Falls back to the given order when the
+ * viewer has no resolvable side (not a participant, not yet assigned, or a
+ * `SearchMatch` with nothing to resolve from).
+ */
+export function orderSidesForViewer(
+  sides: MatchSide[],
+  viewerSideId: string | undefined,
+): MatchSide[] {
+  if (!viewerSideId) return sides
+  const index = sides.findIndex((s) => s.id === viewerSideId)
+  if (index <= 0) return sides
+  const reordered = [...sides]
+  const [mine] = reordered.splice(index, 1)
+  reordered.unshift(mine)
+  return reordered
+}
+
+/**
  * Display name for a match player: a linked Agon user's name is hydrated onto
  * the member server-side, an external player carries a display name directly.
  */

--- a/agon_ui/src/pages/MatchDetailPage.tsx
+++ b/agon_ui/src/pages/MatchDetailPage.tsx
@@ -41,6 +41,8 @@ import {
   memberInviteToken,
   memberName,
   myPendingInvitation,
+  mySideId,
+  orderSidesForViewer,
   withInvitationStatus,
 } from '@/lib/members'
 import { CopyInviteButton } from '@/components/agon/CopyInviteButton'
@@ -131,13 +133,22 @@ function MatchDetail({
   const isLiveSport =
     match.match_type === 'football' || match.match_type === 'cricket' || match.match_type === 'netball'
 
-  const [sideA, sideB] = match.sides
+  // The viewer's own side, when they're playing, always renders first (left)
+  // — mirrors the feed card (`MatchCard`). `orderedMatch` carries the same
+  // reordering into the live-score/scorecard sub-components below, which
+  // each derive their own sideA/sideB straight off `match.sides` — passing
+  // this instead of `match` keeps them in sync with the score box without
+  // touching their internals (everything they key off is side id, not
+  // array position).
+  const orderedSides = orderSidesForViewer(match.sides, mySideId(match, currentUserId))
+  const orderedMatch = { ...match, sides: orderedSides }
+  const [sideA, sideB] = orderedSides
   const nameA = sideName(sideA, 'Side A')
   const nameB = sideName(sideB, 'Side B')
 
   const scoreInfo = displayScore(match)
   const headline = scoreInfo ? headlineBySide(scoreInfo.score) : {}
-  const sets = scoreInfo ? setLine(scoreInfo.score, match.sides) : []
+  const sets = scoreInfo ? setLine(scoreInfo.score, orderedSides) : []
   const aWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideA?.id
   const bWon = scoreInfo?.winnerSideId && scoreInfo.winnerSideId === sideB?.id
 
@@ -250,19 +261,19 @@ function MatchDetail({
               the usual confirmed/pending result. */}
           {footballState ? (
             <div className="mt-3">
-              <LiveMatchBlock match={match} state={footballState} tickerLimit={3} />
+              <LiveMatchBlock match={orderedMatch} state={footballState} tickerLimit={3} />
             </div>
           ) : netballState ? (
             <div className="mt-3">
-              <NetballMatchBlock match={match} state={netballState} tickerLimit={3} />
+              <NetballMatchBlock match={orderedMatch} state={netballState} tickerLimit={3} />
             </div>
           ) : cricketState ? (
             <div className="mt-3">
-              <CricketMatchBlock match={match} state={cricketState} />
+              <CricketMatchBlock match={orderedMatch} state={cricketState} />
             </div>
           ) : cricketScore ? (
             <div className="mt-3">
-              <CricketScoreBlock match={match} score={cricketScore} />
+              <CricketScoreBlock match={orderedMatch} score={cricketScore} />
             </div>
           ) : scoreInfo ? (
             <div className="mt-3 flex items-center justify-between">
@@ -304,7 +315,7 @@ function MatchDetail({
           {finishedFootballGoals && (
             <FootballScorersBySide
               goals={finishedFootballGoals}
-              match={match}
+              match={orderedMatch}
               players={finishedFootballScorePlayers}
               sideA={sideA}
               sideB={sideB}
@@ -315,7 +326,7 @@ function MatchDetail({
           {finishedNetballGoals && (
             <NetballScorersBySide
               goals={finishedNetballGoals}
-              match={match}
+              match={orderedMatch}
               players={finishedNetballScorePlayers}
               sideA={sideA}
               sideB={sideB}
@@ -410,13 +421,13 @@ function MatchDetail({
           once there's per-innings detail recorded (live-scored or entered
           directly). */}
       {cricketInnings && cricketInnings.length > 0 && (
-        <CricketScorecard match={match} innings={cricketInnings} players={cricketScore?.players} />
+        <CricketScorecard match={orderedMatch} innings={cricketInnings} players={cricketScore?.players} />
       )}
 
       {/* Football event timeline: goals/cards/subs, once there's detail
           recorded (live-scored or entered directly) — stays visible after
           the match finishes, unlike the live score header above. */}
-      {footballEventSource && <FootballScorecard match={match} detail={footballEventSource} />}
+      {footballEventSource && <FootballScorecard match={orderedMatch} detail={footballEventSource} />}
 
       {/* Netball quarter breakdown — reads the same regardless of which
           live-scoring method produced the score (see
@@ -429,7 +440,7 @@ function MatchDetail({
       {/* Netball event timeline: goals/fouls, only present for an
           event-by-event-scored match — stays visible after the match
           finishes, unlike the live score header above. */}
-      {netballEventSource && <NetballScorecard match={match} detail={netballEventSource} />}
+      {netballEventSource && <NetballScorecard match={orderedMatch} detail={netballEventSource} />}
 
       {/* Invite more people (participants only). */}
       {canEdit && !cancelled && (


### PR DESCRIPTION
Adds mySideId/orderSidesForViewer in lib/members.ts: resolve which side
the signed-in viewer plays on (FeedMatch's server-resolved viewer_side_id,
or a roster scan for a full Match) and reorder match.sides so that side
renders first.

Wires this into MatchCard (feed/profile cards) and MatchDetailPage (the
detail view's score header, rosters, and live/finished scorecards), all
of which key off side id rather than array position, so reordering
propagates consistently through the score box, scorer breakdowns, live
tickers, and event timelines.