### PR TITLE
Fix match side lookup in test to use team_id instead of index

### DIFF
--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -670,7 +670,15 @@ async fn patch_match_rename_team_side_without_shared_team_is_rejected() {
     let created = matches_post(&owner_config, input)
         .await
         .expect("create match");
-    let team_side = created.sides[0].id.clone();
+    // Sides come back sorted by their server-assigned id, not input order, so
+    // find the team-linked side by its `team_id` rather than assuming index 0.
+    let team_side = created
+        .sides
+        .iter()
+        .find(|s| s.team_id.as_deref() == Some(team.id.as_str()))
+        .expect("team side present")
+        .id
+        .clone();
 
     let response = matches_match_id_patch(
         &owner_config,


### PR DESCRIPTION
## Summary
Fixed a test assertion that was making an incorrect assumption about the order of match sides returned from the API.

## Changes
- Updated `patch_match_rename_team_side_without_shared_team_is_rejected` test to find the team-linked side by its `team_id` rather than assuming it's at index 0
- Added a comment explaining that sides are returned sorted by server-assigned id, not input order

## Implementation Details
The test was previously accessing `created.sides[0]` directly, but the API returns sides sorted by their server-assigned id rather than in input order. The fix uses an iterator to find the side where `team_id` matches the test team's id, making the test more robust and less dependent on implementation details of side ordering.

https://claude.ai/code/session_014kf6qgWZyMFxyA5ukYyeo1