### PR TITLE
Fix undo to allow continued scoring after deletion

### DIFF
--- a/agon_core/src/dao/live_score_ops.rs
+++ b/agon_core/src/dao/live_score_ops.rs
@@ -11,9 +11,9 @@
 //! layered "this is void" marker to filter out on every read.
 
 use aws_sdk_dynamodb::error::SdkError;
-use aws_sdk_dynamodb::operation::delete_item::DeleteItemError;
+use aws_sdk_dynamodb::operation::transact_write_items::TransactWriteItemsError;
 use aws_sdk_dynamodb::operation::update_item::UpdateItemError;
-use aws_sdk_dynamodb::types::{AttributeValue, Put, TransactWriteItem, Update};
+use aws_sdk_dynamodb::types::{AttributeValue, Delete, Put, TransactWriteItem, Update};
 
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
@@ -136,29 +136,70 @@ impl Dao {
     }
 
     /// Delete a single live event outright — a correction for "this never
-    /// happened" (a duplicate, a wrong-match entry), not an edit. `NotFound`
-    /// if it's already gone. Doesn't touch `live_seq`: that counter only
-    /// ever tracks the highest seq ever assigned, which stays a valid fact
-    /// regardless of which earlier seqs still physically exist.
+    /// happened" (a duplicate, a wrong-match entry), not an edit — but only
+    /// when it's still the log's current tip. In one `TransactWriteItems`,
+    /// atomically deletes the item *and* bumps `live_seq` by one, with the
+    /// bump's own condition (`live_seq = :seq`) doubling as the "only the tip
+    /// can be undone" guard — enforced against the live counter at commit
+    /// time, not a value the caller read a moment earlier the way a plain
+    /// read-then-check-then-delete would.
+    ///
+    /// `live_seq` is bumped rather than left untouched on purpose: `seq`
+    /// itself is never reused for a new event either way (an append always
+    /// reserves a fresh number above whatever `live_seq` currently reads —
+    /// see `append_live_events`), but bumping it here additionally means any
+    /// device whose last-known tip predates this delete gets its next append
+    /// rejected with `Conflict` instead of silently building on top of an
+    /// event that's no longer there. Same "the log moved on since you last
+    /// looked" guarantee `append_live_events` gives against a racing append,
+    /// now also given against a racing delete.
+    ///
+    /// Returns the new tip (`seq + 1`) on success.
     #[tracing::instrument(skip(self))]
-    pub async fn delete_live_event(&self, match_id: &str, seq: u32) -> DaoResult<()> {
-        let result = self
-            .client
-            .delete_item()
+    pub async fn delete_live_event(&self, match_id: &str, seq: u32) -> DaoResult<u32> {
+        let new_tip = seq + 1;
+
+        let delete_event = Delete::builder()
             .table_name(self.table())
             .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
             .key(ATTR_SK, s(Sk::LiveEvent(seq).to_string()))
             .condition_expression("attribute_exists(#pk)")
             .expression_attribute_names("#pk", ATTR_PK)
+            .build()
+            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+
+        let bump_tip = Update::builder()
+            .table_name(self.table())
+            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
+            .key(ATTR_SK, s(Sk::Meta.to_string()))
+            .update_expression("SET live_seq = live_seq + :one")
+            .condition_expression("live_seq = :seq")
+            .expression_attribute_values(":one", AttributeValue::N("1".into()))
+            .expression_attribute_values(":seq", AttributeValue::N(seq.to_string()))
+            .build()
+            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+
+        // Order matters: `delete_live_event_failure` below reads position
+        // 0/1 off the cancellation reasons to tell which condition failed.
+        let result = self
+            .client
+            .transact_write_items()
+            .transact_items(TransactWriteItem::builder().delete(delete_event).build())
+            .transact_items(TransactWriteItem::builder().update(bump_tip).build())
             .send()
             .await;
 
         match result {
-            Ok(_) => Ok(()),
-            Err(e) if is_delete_conditional_failure(&e) => Err(DaoError::NotFound(format!(
-                "live event {seq} on match {match_id}"
-            ))),
-            Err(e) => Err(DaoError::Dynamo(e.to_string())),
+            Ok(_) => Ok(new_tip),
+            Err(e) => match delete_live_event_failure(&e) {
+                Some(DeleteLiveEventFailure::EventMissing) => Err(DaoError::NotFound(format!(
+                    "live event {seq} on match {match_id}"
+                ))),
+                Some(DeleteLiveEventFailure::NotTip) => Err(DaoError::Conflict(format!(
+                    "match {match_id} live log has moved on: seq {seq} is no longer the tip"
+                ))),
+                None => Err(DaoError::Dynamo(e.to_string())),
+            },
         }
     }
 
@@ -241,12 +282,48 @@ fn to_attr<T: serde::Serialize>(value: &T) -> DaoResult<AttributeValue> {
     Ok(serde_dynamo::to_attribute_value(value)?)
 }
 
-fn is_delete_conditional_failure(err: &SdkError<DeleteItemError>) -> bool {
-    matches!(
-        err,
-        SdkError::ServiceError(se)
-            if matches!(se.err(), DeleteItemError::ConditionalCheckFailedException(_))
-    )
+/// Which of `delete_live_event`'s two guarded writes caused a
+/// `TransactWriteItems` cancellation, if either did.
+enum DeleteLiveEventFailure {
+    /// The delete's own condition failed — nothing exists at that seq
+    /// (never did, or a concurrent delete already removed it).
+    EventMissing,
+    /// The tip-bump's condition failed — `seq` wasn't `live_seq` at commit
+    /// time (a mid-log seq, or the tip moved on since the caller last saw
+    /// it).
+    NotTip,
+}
+
+/// Checked by position in the cancellation-reasons list (0 = the event
+/// delete, 1 = the tip bump — the same order `delete_live_event` submits
+/// them in) rather than by inspecting each reason's `item` payload, the same
+/// way `super::is_transaction_conditional_failure` treats the list
+/// elsewhere in this crate — just distinguishing *which* item failed instead
+/// of collapsing straight to a bool. `EventMissing` takes priority when both
+/// conditions failed at once: the event being gone outright is the more
+/// fundamental fact to report.
+fn delete_live_event_failure(
+    err: &SdkError<TransactWriteItemsError>,
+) -> Option<DeleteLiveEventFailure> {
+    let SdkError::ServiceError(se) = err else {
+        return None;
+    };
+    let TransactWriteItemsError::TransactionCanceledException(e) = se.err() else {
+        return None;
+    };
+    let reasons = e.cancellation_reasons();
+    let failed = |i: usize| {
+        reasons
+            .get(i)
+            .is_some_and(|r| r.code() == Some("ConditionalCheckFailed"))
+    };
+    if failed(0) {
+        Some(DeleteLiveEventFailure::EventMissing)
+    } else if failed(1) {
+        Some(DeleteLiveEventFailure::NotTip)
+    } else {
+        None
+    }
 }
 
 fn is_update_conditional_failure(err: &SdkError<UpdateItemError>) -> bool {

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2987,14 +2987,16 @@ impl Api {
                         "match has no score".into(),
                     )));
                 }
-                let last_seq = records.iter().map(|r| r.seq).max().unwrap_or(0);
                 let Some(score) = derive_live_score(sport, &records, agg.match_.format.as_ref())
                 else {
                     return Ok(GetMatchScoreResponse::NotFound(PlainText(
                         "match has no score".into(),
                     )));
                 };
-                self.persist_score(dao, &match_id, &score, Some(last_seq))
+                // `agg.match_.live_seq`, not `max(records.seq)` — see
+                // `derive_live_snapshot`'s doc comment for why the latter can
+                // undercount once an undo has removed the log's former tip.
+                self.persist_score(dao, &match_id, &score, Some(agg.match_.live_seq))
                     .await;
                 score
             }
@@ -3236,8 +3238,14 @@ impl Api {
         {
             Some(snapshot) => Some(snapshot),
             None => {
-                self.derive_live_snapshot(dao, &match_id, &sport, agg.match_.format.as_ref())
-                    .await?
+                self.derive_live_snapshot(
+                    dao,
+                    &match_id,
+                    &sport,
+                    agg.match_.format.as_ref(),
+                    new_last_seq,
+                )
+                .await?
             }
         };
 
@@ -3416,6 +3424,9 @@ impl Api {
                 &match_id,
                 &agg.match_.match_type,
                 agg.match_.format.as_ref(),
+                // Unchanged by the delete (see `Dao::delete_live_event`'s doc
+                // comment) — still the correct tip for the next append.
+                agg.match_.live_seq,
             )
             .await?
         {
@@ -3460,24 +3471,39 @@ impl Api {
     /// Persists the result so subsequent reads and the next incremental
     /// append have a fresh checkpoint to build on. Returns `None` if `sport`
     /// doesn't support live scoring.
+    ///
+    /// `live_seq` is the authoritative tip — the match's `live_seq` counter,
+    /// which (per `Dao::delete_live_event`'s doc comment) only ever tracks
+    /// the highest seq ever assigned and is never reused, even once an undo
+    /// physically removes that event. It must come from the caller rather
+    /// than be recomputed as `max(records.seq)` here: after an undo, that
+    /// max is one behind the counter (the deleted tip's seq no longer
+    /// appears among the remaining records), and persisting that lower value
+    /// as the checkpoint's `last_seq` — the same value the client then caches
+    /// as its next `expected_last_seq` — would desync it from the real
+    /// counter, so every subsequent append's conditional update fails with a
+    /// `Conflict` (see `append_live_events`'s `live_seq = :expected` check).
     async fn derive_live_snapshot(
         &self,
         dao: &dao::Dao,
         match_id: &str,
         sport: &str,
         format: Option<&dao::records::MatchFormatRecord>,
+        live_seq: u32,
     ) -> Result<Option<LiveScoreSnapshot>> {
         let records = dao.list_live_events(match_id).await.map_err(dao_internal)?;
-        let last_seq = records.iter().map(|r| r.seq).max().unwrap_or(0);
 
         let Some(score) = derive_live_score(sport, &records, format) else {
             return Ok(None);
         };
 
-        self.persist_score(dao, match_id, &score, Some(last_seq))
+        self.persist_score(dao, match_id, &score, Some(live_seq))
             .await;
 
-        Ok(Some(LiveScoreSnapshot { last_seq, score }))
+        Ok(Some(LiveScoreSnapshot {
+            last_seq: live_seq,
+            score,
+        }))
     }
 
     /// Best-effort persisted-record write, shared by the incremental append

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -3382,6 +3382,12 @@ impl Api {
     /// been built on the thing being removed. History is genuinely removed,
     /// not marked; the returned detail reflects the log as if the event had
     /// never been recorded.
+    ///
+    /// The tip check itself now lives entirely in `Dao::delete_live_event`
+    /// (atomic against the live `live_seq` counter, not a value read a
+    /// moment earlier here) — a `Conflict` back from it means `seq` wasn't
+    /// the tip at commit time, surfaced the same way as any other "the log
+    /// moved on" case.
     #[oai(path = "/matches/:match_id/live/events/:seq", method = "delete")]
     async fn delete_live_event(
         &self,
@@ -3402,21 +3408,20 @@ impl Api {
             }
         };
 
-        if seq != agg.match_.live_seq {
-            return Ok(DeleteLiveEventResponse::ValidationError(PlainText(
-                "only the most recently recorded event can be undone".into(),
-            )));
-        }
-
-        match dao.delete_live_event(&match_id, seq).await {
-            Ok(()) => {}
+        let new_tip = match dao.delete_live_event(&match_id, seq).await {
+            Ok(new_tip) => new_tip,
             Err(dao::DaoError::NotFound(_)) => {
                 return Ok(DeleteLiveEventResponse::NotFound(PlainText(
                     "live event not found".into(),
                 )));
             }
+            Err(dao::DaoError::Conflict(_)) => {
+                return Ok(DeleteLiveEventResponse::ValidationError(PlainText(
+                    "only the most recently recorded event can be undone".into(),
+                )));
+            }
             Err(e) => return Err(dao_internal(e)),
-        }
+        };
 
         match self
             .derive_live_snapshot(
@@ -3424,9 +3429,10 @@ impl Api {
                 &match_id,
                 &agg.match_.match_type,
                 agg.match_.format.as_ref(),
-                // Unchanged by the delete (see `Dao::delete_live_event`'s doc
-                // comment) — still the correct tip for the next append.
-                agg.match_.live_seq,
+                // The DAO's freshly-bumped counter, not `agg.match_.live_seq`
+                // (fetched before the delete — now stale, since the delete
+                // itself advances the counter).
+                new_tip,
             )
             .await?
         {
@@ -3472,17 +3478,18 @@ impl Api {
     /// append have a fresh checkpoint to build on. Returns `None` if `sport`
     /// doesn't support live scoring.
     ///
-    /// `live_seq` is the authoritative tip — the match's `live_seq` counter,
-    /// which (per `Dao::delete_live_event`'s doc comment) only ever tracks
-    /// the highest seq ever assigned and is never reused, even once an undo
-    /// physically removes that event. It must come from the caller rather
-    /// than be recomputed as `max(records.seq)` here: after an undo, that
-    /// max is one behind the counter (the deleted tip's seq no longer
-    /// appears among the remaining records), and persisting that lower value
-    /// as the checkpoint's `last_seq` — the same value the client then caches
-    /// as its next `expected_last_seq` — would desync it from the real
-    /// counter, so every subsequent append's conditional update fails with a
-    /// `Conflict` (see `append_live_events`'s `live_seq = :expected` check).
+    /// `live_seq` is the authoritative tip — the match's `live_seq` counter —
+    /// and must come from the caller rather than be recomputed as
+    /// `max(records.seq)` here. An append and a delete (see
+    /// `Dao::delete_live_event`) both advance the real counter without
+    /// necessarily leaving a matching physical event at every number (a
+    /// delete's own seq, and the number it bumps past, are both permanently
+    /// skipped), so the physical log's max can lag behind it. Persisting
+    /// that lower, recomputed value as the checkpoint's `last_seq` — the
+    /// same value the client then caches as its next `expected_last_seq` —
+    /// would desync it from the real counter, so every subsequent append's
+    /// conditional update would fail with a `Conflict` (see
+    /// `append_live_events`'s `live_seq = :expected` check).
     async fn derive_live_snapshot(
         &self,
         dao: &dao::Dao,

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -3588,16 +3588,16 @@ async fn netball_quarter_only_scoring_uses_period_marker_score_directly() {
 /// Regression test for the bug where undoing the tip event left the client
 /// unable to record anything else afterward.
 ///
-/// `delete_live_event` deliberately never rewinds the match's `live_seq`
-/// counter (it's a high-water mark, so a seq is never reused — see that
-/// DAO method's doc comment), but the snapshot handed back from the delete
-/// call must still report that same counter as `last_seq`, since that's the
-/// value the caller then sends back as `expected_last_seq` on its very next
-/// append. If it instead reported one less (the deleted tip's seq no longer
-/// physically present), every append after an undo would send a stale
-/// `expected_last_seq` that could never satisfy the server's optimistic-
-/// concurrency check, and would 409 forever — exactly what was reported:
-/// undo appears to succeed, then every subsequent event fails to record.
+/// `delete_live_event` bumps the match's `live_seq` counter by one on every
+/// undo (see that DAO method's doc comment) — so the snapshot handed back
+/// from delete must report `seq + 1` as `last_seq`, the value the caller
+/// then sends back as `expected_last_seq` on its very next append. Before
+/// this, the endpoint instead reported one *less* than that (the deleted
+/// tip's seq no longer physically present among the remaining events), so
+/// every append after an undo sent a stale `expected_last_seq` that could
+/// never satisfy the server's optimistic-concurrency check, and 409'd
+/// forever — exactly what was reported: undo appears to succeed, then every
+/// subsequent event fails to record.
 #[tokio::test]
 async fn undoing_the_tip_lets_scoring_continue_without_reusing_its_seq() {
     let (owner_config, _owner) = new_user().await;
@@ -3629,11 +3629,12 @@ async fn undoing_the_tip_lets_scoring_continue_without_reusing_its_seq() {
         .await
         .expect("undo tip event");
 
-    // The counter doesn't rewind on delete — this is the value the client
-    // caches as its next `expected_last_seq`, so it must still read 3, not 2.
+    // The counter advances *past* the deleted seq (3 -> 4) rather than
+    // staying put — this is the value the client caches as its next
+    // `expected_last_seq`.
     assert_eq!(
-        after_undo.last_seq, 3,
-        "last_seq after undoing the tip must stay at the (never-reused) counter value"
+        after_undo.last_seq, 4,
+        "last_seq after undoing seq 3 must be the bumped counter (4)"
     );
     match *after_undo.score {
         models::Score::Netball(s) => {
@@ -3655,17 +3656,19 @@ async fn undoing_the_tip_lets_scoring_continue_without_reusing_its_seq() {
         vec![netball_goal_event_json(&side_b, false)],
     )
     .await;
-    // The new event lands at seq 4, not the freed-up seq 3 — seq numbers are
-    // never reused once assigned, even across an undo.
-    assert_eq!(after_append.last_seq, 4);
+    // The new event lands at seq 5, not the freed-up seq 3 or the burned
+    // seq 4 — seq numbers are never reused once assigned, even across an
+    // undo.
+    assert_eq!(after_append.last_seq, 5);
 
-    // The physical log confirms the gap: 1, 2, 4 — seq 3 stays deleted for
-    // good, not reused by the new event.
+    // The physical log confirms the (two-number) gap: 1, 2, 5 — seq 3
+    // (deleted) and seq 4 (burned by the undo's counter bump) both stay
+    // permanently absent, never reused by the new event.
     let page = matches_match_id_live_events_get(&owner_config, &created.id, None, None)
         .await
         .expect("list live events");
     let seqs: Vec<i32> = page.items.iter().map(|e| e.seq).collect();
-    assert_eq!(seqs, vec![1, 2, 4]);
+    assert_eq!(seqs, vec![1, 2, 5]);
 
     let score = matches_match_id_score_get(&owner_config, &created.id)
         .await
@@ -3681,8 +3684,11 @@ async fn undoing_the_tip_lets_scoring_continue_without_reusing_its_seq() {
 }
 
 /// Only the current tip can be undone — a mid-log seq is rejected with a 400
-/// rather than silently reordering the log (see `delete_live_event`'s doc
-/// comment on the backend). The tip itself stays intact after the rejection.
+/// rather than silently reordering the log. This check is now enforced
+/// atomically inside `Dao::delete_live_event`'s transaction (against the
+/// live counter at commit time) rather than as a separate read-then-check in
+/// the handler, but the outward behavior is unchanged: the tip itself stays
+/// intact after the rejection.
 #[tokio::test]
 async fn undoing_a_non_tip_event_is_rejected() {
     let (owner_config, _owner) = new_user().await;
@@ -3723,13 +3729,12 @@ async fn undoing_a_non_tip_event_is_rejected() {
     }
 }
 
-/// Undoing the same (only) event twice: the counter doesn't rewind on
-/// delete (see `Dao::delete_live_event`'s doc comment), so seq 1 still reads
-/// as the tip and passes that check the second time too — the rejection
-/// this time comes from the delete itself finding nothing left at that seq,
-/// a 404 rather than the 400 a genuinely non-tip seq gets.
+/// Retrying an undo with the *same, now-stale* seq 400s just like any other
+/// non-tip delete: the counter has already moved past it (see the previous
+/// test's sibling scenario), so a second call with that same number no
+/// longer matches the current tip.
 #[tokio::test]
-async fn undoing_the_same_event_twice_404s_on_the_second_attempt() {
+async fn retrying_an_undo_with_the_same_seq_is_rejected_as_non_tip() {
     let (owner_config, _owner) = new_user().await;
     let (_invitee_config, invitee) = new_user().await;
 
@@ -3750,6 +3755,52 @@ async fn undoing_the_same_event_twice_404s_on_the_second_attempt() {
         .await
         .expect("undo the only event");
 
+    // seq 1 was the tip a moment ago, but the counter has since bumped to 2
+    // (see `undoing_the_tip_lets_scoring_continue_without_reusing_its_seq`)
+    // — a repeat call with the same stale seq is exactly the "not the tip
+    // anymore" case, same as a genuinely non-tip seq.
     let response = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 1).await;
+    assert_status_with_content(
+        response,
+        reqwest::StatusCode::BAD_REQUEST,
+        "only the most recently recorded event can be undone",
+    );
+}
+
+/// Undoing *the counter's current value* when nothing physically lives
+/// there — the realistic "hit undo twice in a row" case, since a client
+/// caches the server's returned (bumped) `last_seq` as its next tip and
+/// would retry against that, not the original seq. The tip check passes
+/// (it genuinely is the current counter value), but there's nothing left to
+/// delete: `live_seq` having advanced past the log's last real event
+/// doesn't mean a real event lives at that new number.
+#[tokio::test]
+async fn undoing_the_bumped_tip_with_nothing_left_to_delete_is_not_found() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+
+    append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![netball_goal_event_json(&side_a, false)],
+    )
+    .await;
+
+    let after_undo = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 1)
+        .await
+        .expect("undo the only event");
+    assert_eq!(after_undo.last_seq, 2);
+
+    // A client would cache `2` (the response above) as its next tip and
+    // retry undo against that, exactly like this.
+    let response =
+        matches_match_id_live_events_seq_delete(&owner_config, &created.id, after_undo.last_seq)
+            .await;
     assert_not_found(response);
 }

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -3804,3 +3804,108 @@ async fn undoing_the_bumped_tip_with_nothing_left_to_delete_is_not_found() {
             .await;
     assert_not_found(response);
 }
+
+/// Two, then three, successful undos in a row — each one targeting the log's
+/// *real* physical tip at that point (2, then 1), not the previous undo's
+/// bumped `last_seq`. This is the scenario the UI's `useUndoTargetSeq` split
+/// exists for (see that hook's doc comment): every undo advances `live_seq`
+/// by one past the deleted event, so consecutive undos land on a strictly
+/// increasing sequence of `last_seq` values (4, then 3, then 2) even while
+/// the *targets* count down (3, then 2, then 1). Also confirms the derived
+/// score and physical log both end up completely empty once every event
+/// has been undone, not just "missing the most recent one".
+#[tokio::test]
+async fn undoing_multiple_times_in_a_row_removes_each_real_tip_in_turn() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+    let side_b = created.sides[1].id.clone();
+
+    // Three events: two goals for A (seq 1, 2), then a foul on B (seq 3).
+    let snapshot = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![
+            netball_goal_event_json(&side_a, false),
+            netball_goal_event_json(&side_a, false),
+            netball_foul_event_json(&side_b),
+        ],
+    )
+    .await;
+    assert_eq!(snapshot.last_seq, 3);
+
+    // Undo #1: the foul (seq 3, the real tip). Counter bumps 3 -> 4.
+    let after_first = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 3)
+        .await
+        .expect("undo the foul");
+    assert_eq!(after_first.last_seq, 4);
+    match *after_first.score {
+        models::Score::Netball(s) => {
+            assert_eq!(s.fouls.as_ref().map(Vec::len), Some(0));
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(2));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+
+    // Undo #2: the real tip is now seq 2 (the second goal) — NOT
+    // `after_first.last_seq` (4), which is the bumped, phantom counter. A
+    // client sending 4 here would 404 (see the previous test); the real
+    // target is 2.
+    let after_second = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 2)
+        .await
+        .expect("undo the second goal");
+    // The counter keeps climbing (3 -> 4 was undo #1's bump; this one bumps
+    // 4 -> 5)... but note the *target* seq (2) is nowhere near the counter
+    // (5): `live_seq` tracks "how many mutations have ever happened", not
+    // "how many events currently exist".
+    assert_eq!(after_second.last_seq, 5);
+    match *after_second.score {
+        models::Score::Netball(s) => {
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(1));
+            assert_eq!(s.score.get(&side_a), Some(&1));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+
+    // Undo #3: the real tip is now seq 1 (the first, and last remaining,
+    // goal) — the log goes fully empty.
+    let after_third = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 1)
+        .await
+        .expect("undo the first goal");
+    assert_eq!(after_third.last_seq, 2);
+    match *after_third.score {
+        models::Score::Netball(s) => {
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(0));
+            assert_eq!(
+                s.score.get(&side_a),
+                None,
+                "absence means zero, same as never scored"
+            );
+            assert_eq!(s.score.get(&side_b), None);
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+
+    // Nothing physically left in the log at all.
+    let page = matches_match_id_live_events_get(&owner_config, &created.id, None, None)
+        .await
+        .expect("list live events");
+    assert!(page.items.is_empty());
+
+    // ...and the fully-recomputed score agrees.
+    let score = matches_match_id_score_get(&owner_config, &created.id)
+        .await
+        .expect("get score");
+    match score {
+        models::Score::Netball(s) => {
+            assert!(s.score.is_empty());
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(0));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+}

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -3934,3 +3934,86 @@ async fn undoing_multiple_times_in_a_row_removes_each_real_tip_in_turn() {
         other => panic!("expected a netball score, got {other:?}"),
     }
 }
+
+/// Undo, then append (log not empty — covered by
+/// `undoing_the_tip_lets_scoring_continue_without_reusing_its_seq`), then
+/// undo *again* — this time undoing the event that append just added. Checks
+/// that a freshly-appended event becomes a correctly-deletable tip in its
+/// own right, i.e. that appending after an undo doesn't leave the counter
+/// and the physical log in some inconsistent state that only tolerates
+/// further appends, not a subsequent real undo too.
+#[tokio::test]
+async fn undoing_then_appending_then_undoing_the_new_event_stays_consistent() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+    let side_b = created.sides[1].id.clone();
+
+    // Two goals for A (seq 1, 2).
+    let snapshot = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![
+            netball_goal_event_json(&side_a, false),
+            netball_goal_event_json(&side_a, false),
+        ],
+    )
+    .await;
+    assert_eq!(snapshot.last_seq, 2);
+
+    // Undo the tip (seq 2) — one goal remains (seq 1), log not empty.
+    let after_undo = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 2)
+        .await
+        .expect("undo the second goal");
+    assert_eq!(after_undo.last_seq, 3);
+
+    // Append a goal for B — lands at seq 4 (the bumped counter + 1), not
+    // seq 2 (the deleted goal's old, never-reused identity).
+    let after_append = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        after_undo.last_seq,
+        vec![netball_goal_event_json(&side_b, false)],
+    )
+    .await;
+    assert_eq!(after_append.last_seq, 4);
+    match *after_append.score {
+        models::Score::Netball(s) => {
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(2));
+            assert_eq!(s.score.get(&side_a), Some(&1));
+            assert_eq!(s.score.get(&side_b), Some(&1));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+
+    // Now undo the *newly appended* event (seq 4) — the real question this
+    // test asks: does the append above leave seq 4 undoable, same as any
+    // other tip?
+    let after_second_undo = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 4)
+        .await
+        .expect("undo the newly appended goal");
+    assert_eq!(after_second_undo.last_seq, 5);
+    match *after_second_undo.score {
+        models::Score::Netball(s) => {
+            // Back to just the one surviving original goal.
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(1));
+            assert_eq!(s.score.get(&side_a), Some(&1));
+            assert_eq!(s.score.get(&side_b), None);
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+
+    // The physical log agrees: only seq 1 (the first goal) survives all of
+    // this — 2 and 4 were both undone, 3 was never a real event (just a
+    // burned counter value).
+    let page = matches_match_id_live_events_get(&owner_config, &created.id, None, None)
+        .await
+        .expect("list live events");
+    let seqs: Vec<i32> = page.items.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![1]);
+}

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -3576,3 +3576,180 @@ async fn netball_quarter_only_scoring_uses_period_marker_score_directly() {
         other => panic!("expected a netball score, got {other:?}"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Undo (`DELETE /matches/:id/live/events/:seq`) — restricted to the log's
+// current tip. Exercised against netball's event vocabulary since the
+// underlying append/delete/seq machinery under test is shared by every sport
+// (see `Dao::append_live_events`/`delete_live_event`); nothing here is
+// netball-specific.
+// ---------------------------------------------------------------------------
+
+/// Regression test for the bug where undoing the tip event left the client
+/// unable to record anything else afterward.
+///
+/// `delete_live_event` deliberately never rewinds the match's `live_seq`
+/// counter (it's a high-water mark, so a seq is never reused — see that
+/// DAO method's doc comment), but the snapshot handed back from the delete
+/// call must still report that same counter as `last_seq`, since that's the
+/// value the caller then sends back as `expected_last_seq` on its very next
+/// append. If it instead reported one less (the deleted tip's seq no longer
+/// physically present), every append after an undo would send a stale
+/// `expected_last_seq` that could never satisfy the server's optimistic-
+/// concurrency check, and would 409 forever — exactly what was reported:
+/// undo appears to succeed, then every subsequent event fails to record.
+#[tokio::test]
+async fn undoing_the_tip_lets_scoring_continue_without_reusing_its_seq() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+    let side_b = created.sides[1].id.clone();
+
+    // Three events: two goals for A (seq 1, 2), then a foul on B (seq 3) that
+    // we'll undo.
+    let snapshot = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![
+            netball_goal_event_json(&side_a, false),
+            netball_goal_event_json(&side_a, true),
+            netball_foul_event_json(&side_b),
+        ],
+    )
+    .await;
+    assert_eq!(snapshot.last_seq, 3);
+
+    // Undo the tip (the foul, seq 3).
+    let after_undo = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 3)
+        .await
+        .expect("undo tip event");
+
+    // The counter doesn't rewind on delete — this is the value the client
+    // caches as its next `expected_last_seq`, so it must still read 3, not 2.
+    assert_eq!(
+        after_undo.last_seq, 3,
+        "last_seq after undoing the tip must stay at the (never-reused) counter value"
+    );
+    match *after_undo.score {
+        models::Score::Netball(s) => {
+            // The foul is gone from the derived score...
+            assert_eq!(s.fouls.as_ref().map(Vec::len), Some(0));
+            // ...but the two goals that preceded it are untouched.
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(2));
+            assert_eq!(s.score.get(&side_a), Some(&3));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+
+    // The very next append — this is the call that used to 409 forever after
+    // an undo — using the `last_seq` the delete just handed back.
+    let after_append = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        after_undo.last_seq,
+        vec![netball_goal_event_json(&side_b, false)],
+    )
+    .await;
+    // The new event lands at seq 4, not the freed-up seq 3 — seq numbers are
+    // never reused once assigned, even across an undo.
+    assert_eq!(after_append.last_seq, 4);
+
+    // The physical log confirms the gap: 1, 2, 4 — seq 3 stays deleted for
+    // good, not reused by the new event.
+    let page = matches_match_id_live_events_get(&owner_config, &created.id, None, None)
+        .await
+        .expect("list live events");
+    let seqs: Vec<i32> = page.items.iter().map(|e| e.seq).collect();
+    assert_eq!(seqs, vec![1, 2, 4]);
+
+    let score = matches_match_id_score_get(&owner_config, &created.id)
+        .await
+        .expect("get score");
+    match score {
+        models::Score::Netball(s) => {
+            assert_eq!(s.score.get(&side_a), Some(&3));
+            assert_eq!(s.score.get(&side_b), Some(&1));
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(3));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+}
+
+/// Only the current tip can be undone — a mid-log seq is rejected with a 400
+/// rather than silently reordering the log (see `delete_live_event`'s doc
+/// comment on the backend). The tip itself stays intact after the rejection.
+#[tokio::test]
+async fn undoing_a_non_tip_event_is_rejected() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+
+    let snapshot = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![
+            netball_goal_event_json(&side_a, false),
+            netball_goal_event_json(&side_a, false),
+        ],
+    )
+    .await;
+    assert_eq!(snapshot.last_seq, 2);
+
+    // seq 1 is no longer the tip (seq 2 is) — rejected.
+    let response = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 1).await;
+    assert_status_with_content(
+        response,
+        reqwest::StatusCode::BAD_REQUEST,
+        "only the most recently recorded event can be undone",
+    );
+
+    // Confirmed untouched: both goals are still there, and the tip is still 2.
+    let score = matches_match_id_score_get(&owner_config, &created.id)
+        .await
+        .expect("get score");
+    match score {
+        models::Score::Netball(s) => assert_eq!(s.goals.as_ref().map(Vec::len), Some(2)),
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+}
+
+/// Undoing the same (only) event twice: the counter doesn't rewind on
+/// delete (see `Dao::delete_live_event`'s doc comment), so seq 1 still reads
+/// as the tip and passes that check the second time too — the rejection
+/// this time comes from the delete itself finding nothing left at that seq,
+/// a 404 rather than the 400 a genuinely non-tip seq gets.
+#[tokio::test]
+async fn undoing_the_same_event_twice_404s_on_the_second_attempt() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+
+    append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![netball_goal_event_json(&side_a, false)],
+    )
+    .await;
+
+    matches_match_id_live_events_seq_delete(&owner_config, &created.id, 1)
+        .await
+        .expect("undo the only event");
+
+    let response = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 1).await;
+    assert_not_found(response);
+}

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -3811,9 +3811,12 @@ async fn undoing_the_bumped_tip_with_nothing_left_to_delete_is_not_found() {
 /// exists for (see that hook's doc comment): every undo advances `live_seq`
 /// by one past the deleted event, so consecutive undos land on a strictly
 /// increasing sequence of `last_seq` values (4, then 3, then 2) even while
-/// the *targets* count down (3, then 2, then 1). Also confirms the derived
-/// score and physical log both end up completely empty once every event
-/// has been undone, not just "missing the most recent one".
+/// the *targets* count down (3, then 2, then 1). Confirms the derived score
+/// and physical log both end up completely empty once every event has been
+/// undone, not just "missing the most recent one" — and, the actual point
+/// of the original bug report this whole chain of fixes started from,
+/// confirms scoring can still continue afterward: one final append,
+/// `expected_last_seq` all the way down at the fully-undone counter value.
 #[tokio::test]
 async fn undoing_multiple_times_in_a_row_removes_each_real_tip_in_turn() {
     let (owner_config, _owner) = new_user().await;
@@ -3905,6 +3908,28 @@ async fn undoing_multiple_times_in_a_row_removes_each_real_tip_in_turn() {
         models::Score::Netball(s) => {
             assert!(s.score.is_empty());
             assert_eq!(s.goals.as_ref().map(Vec::len), Some(0));
+        }
+        other => panic!("expected a netball score, got {other:?}"),
+    }
+
+    // The actual point of all this: scoring can still continue afterward.
+    // `expected_last_seq` must be `after_third.last_seq` (2) — the climbed
+    // counter, not 0 — even though every event ever recorded has now been
+    // undone.
+    let after_append = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        after_third.last_seq,
+        vec![netball_goal_event_json(&side_a, false)],
+    )
+    .await;
+    // Lands at seq 3, continuing on from the counter — not seq 1, which
+    // would silently collide with the (deleted) first goal's old identity.
+    assert_eq!(after_append.last_seq, 3);
+    match *after_append.score {
+        models::Score::Netball(s) => {
+            assert_eq!(s.goals.as_ref().map(Vec::len), Some(1));
+            assert_eq!(s.score.get(&side_a), Some(&1));
         }
         other => panic!("expected a netball score, got {other:?}"),
     }

--- a/agon_ui/src/components/agon/live/RecordEventDialog.tsx
+++ b/agon_ui/src/components/agon/live/RecordEventDialog.tsx
@@ -128,6 +128,12 @@ export function RecordEventDialog({
     (s) => s.id === (kind === 'goal' ? goal.side_id : kind === 'card' ? card.side_id : sub.side_id),
   )
   const roster = side ? playersOnSide(match.players, side) : []
+  // An own goal counts for `side` (the benefiting side — see
+  // `FootballGoalEvent`'s backend doc comment) but is physically put in by a
+  // player on the *other* side, so the scorer picker for that case draws
+  // from the opposing roster, not `side`'s own.
+  const otherSide = kind === 'goal' ? match.sides.find((s) => s.id !== goal.side_id) : undefined
+  const otherRoster = otherSide ? playersOnSide(match.players, otherSide) : []
 
   const title = kind === 'goal' ? 'Goal' : kind === 'card' ? 'Card' : 'Substitution'
 
@@ -143,7 +149,7 @@ export function RecordEventDialog({
       onSubmit({
         kind: 'Goal',
         side_id: goal.side_id,
-        scorer_player_id: goal.own_goal ? undefined : goal.scorer_player_id,
+        scorer_player_id: goal.scorer_player_id,
         assist_player_id: goal.own_goal ? undefined : goal.assist_player_id,
         own_goal: goal.own_goal,
         penalty: goal.penalty,
@@ -198,7 +204,20 @@ export function RecordEventDialog({
                   <input
                     type="checkbox"
                     checked={goal.own_goal}
-                    onChange={(e) => setGoal((d) => ({ ...d, own_goal: e.target.checked }))}
+                    onChange={(e) =>
+                      setGoal((d) => ({
+                        ...d,
+                        own_goal: e.target.checked,
+                        // The scorer picker switches rosters (this side's ↔
+                        // the opposing side's) when this flips, so a
+                        // previously picked player is very unlikely to still
+                        // be valid — clear it rather than silently keep a
+                        // scorer from the wrong roster. Own goals never carry
+                        // an assist.
+                        scorer_player_id: undefined,
+                        assist_player_id: undefined,
+                      }))
+                    }
                   />
                   Own goal
                 </label>
@@ -212,18 +231,16 @@ export function RecordEventDialog({
                   Penalty
                 </label>
               </div>
-              {!goal.own_goal && (
-                <div>
-                  <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                    Scorer
-                  </p>
-                  <PlayerPicker
-                    players={roster}
-                    value={goal.scorer_player_id}
-                    onChange={(id) => setGoal((d) => ({ ...d, scorer_player_id: id }))}
-                  />
-                </div>
-              )}
+              <div>
+                <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                  {goal.own_goal ? 'Own goal by (optional)' : 'Scorer'}
+                </p>
+                <PlayerPicker
+                  players={goal.own_goal ? otherRoster : roster}
+                  value={goal.scorer_player_id}
+                  onChange={(id) => setGoal((d) => ({ ...d, scorer_player_id: id }))}
+                />
+              </div>
               {!goal.own_goal && goal.scorer_player_id && roster.length > 1 && (
                 <div>
                   <p className="mb-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">

--- a/agon_ui/src/components/agon/live/UndoLastEventButton.tsx
+++ b/agon_ui/src/components/agon/live/UndoLastEventButton.tsx
@@ -22,8 +22,10 @@ export function UndoLastEventButton({
   seq,
 }: {
   matchId: string
-  /** The log's current tip, e.g. from `useLiveSeq` — `undefined` while
-   *  still loading, `0` before anything's been recorded. */
+  /** The log's real physical tip, from `useUndoTargetSeq` — NOT
+   *  `useLiveSeq` (that one's the append concurrency token, which points
+   *  past a real event once an undo has happened — see its doc comment).
+   *  `undefined` while still loading, `0` before anything's been recorded. */
   seq: number | undefined
 }) {
   const [confirmOpen, setConfirmOpen] = useState(false)

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -45,28 +45,70 @@ export function useLiveEvents(matchId: string | undefined, options?: { enabled?:
   })
 }
 
+/** The log's real physical tip — the highest `seq` an event actually exists
+ *  at, 0 if none yet — by draining the raw event log and taking the max.
+ *  Shared queryFn logic for `useLiveSeq` and `useUndoTargetSeq`, which start
+ *  out reading the same value but diverge from there (see
+ *  `useUndoTargetSeq`'s doc comment). */
+async function fetchLivePhysicalTip(matchId: string): Promise<number> {
+  const events = await drainLiveEvents(matchId)
+  return events.reduce((max, e) => Math.max(max, e.seq), 0)
+}
+
 export function liveSeqQueryKey(matchId: string | undefined) {
   return ['live-seq', matchId] as const
 }
 
 /**
- * The event log's current tip (`seq` of the most recently recorded event, 0
- * if none yet) — needed only for the optimistic-concurrency
- * `expected_last_seq` on the next append, not a read of the score itself
- * (see `useMatchScore` for that; there's no separate "live state" endpoint
- * anymore). Seeded once by draining the raw event log, the same
- * one-shot-fetch pattern as `useLiveEvents`; every append after that updates
- * the cached value directly from its own response instead of refetching.
+ * The optimistic-concurrency token for the *next append* — `expected_last_seq`
+ * — not a read of the score itself (see `useMatchScore` for that; there's no
+ * separate "live state" endpoint anymore). Seeded once by draining the raw
+ * event log (the real physical tip, same as `useUndoTargetSeq`); every
+ * append or undo after that updates the cached value directly from its own
+ * response's `last_seq` instead of refetching.
+ *
+ * That response `last_seq` is always the match's `live_seq` counter, not
+ * necessarily a seq any event still physically exists at (see
+ * `Dao::delete_live_event`'s doc comment on the backend: undoing bumps the
+ * counter past the deleted event) — correct for gating the next append, but
+ * NOT the value to hand `UndoLastEventButton` for undo; use
+ * `useUndoTargetSeq` for that instead.
  */
 export function useLiveSeq(matchId: string | undefined, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: liveSeqQueryKey(matchId),
     enabled: !!matchId && (options?.enabled ?? true),
     staleTime: Infinity,
-    queryFn: async (): Promise<number> => {
-      const events = await drainLiveEvents(matchId!)
-      return events.reduce((max, e) => Math.max(max, e.seq), 0)
-    },
+    queryFn: () => fetchLivePhysicalTip(matchId!),
+  })
+}
+
+export function undoTargetSeqQueryKey(matchId: string | undefined) {
+  return ['live-undo-target-seq', matchId] as const
+}
+
+/**
+ * The seq to send `UndoLastEventButton`'s next `DELETE
+ * .../live/events/:seq` at — the log's real physical tip, deliberately
+ * tracked apart from `useLiveSeq`'s append token even though the two start
+ * out equal and an append keeps them in lockstep (neither ever creates a
+ * gap). They diverge the moment an undo happens: the append token jumps to
+ * the bumped `live_seq` counter (see that hook's doc comment), which no
+ * longer points at a real event — sending *that* to a second consecutive
+ * undo 404s ("nothing there"), it isn't the next thing to delete.
+ *
+ * So unlike `useLiveSeq`, an undo's response is never trusted here directly
+ * — `useUndoLastLiveEvent`'s `onSuccess` invalidates this instead, forcing a
+ * real re-derivation from the event log rather than guessing. An append's
+ * response *is* trusted directly here too, same as `useLiveSeq`, since it
+ * never creates a gap.
+ */
+export function useUndoTargetSeq(matchId: string | undefined, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: undoTargetSeqQueryKey(matchId),
+    enabled: !!matchId && (options?.enabled ?? true),
+    staleTime: Infinity,
+    queryFn: () => fetchLivePhysicalTip(matchId!),
   })
 }
 
@@ -109,6 +151,11 @@ function useAppendLiveEvent<T extends { kind: string }>(
     },
     onSuccess: (data) => {
       queryClient.setQueryData(liveSeqQueryKey(matchId), data.last_seq)
+      // An append never creates a gap — its own new event is always the
+      // fresh physical tip too, same value as the append token above. Safe
+      // to write directly, sparing `useUndoTargetSeq` an extra refetch on
+      // the common (append) path.
+      queryClient.setQueryData(undoTargetSeqQueryKey(matchId), data.last_seq)
       queryClient.setQueryData(matchScoreQueryKey(matchId), data.score)
       queryClient.invalidateQueries({ queryKey: ['match', matchId] })
       queryClient.invalidateQueries({ queryKey: ['feed'] })
@@ -133,14 +180,19 @@ export function useAppendNetballEvent(matchId: string) {
  * /matches/:match_id/live/events/:seq`, which the server restricts to the
  * current log tip (see `delete_live_event` on the backend): pass anything
  * else and it 400s rather than deleting mid-log. Callers pass the `seq`
- * they believe is the tip (typically straight off `useLiveSeq`) rather than
- * this hook reading the cache itself, so a stale button — rendered before an
- * in-flight append's response lands — surfaces that mismatch as an error
- * instead of silently undoing the wrong thing.
+ * they believe is the tip (from `useUndoTargetSeq`, NOT `useLiveSeq` — see
+ * that hook's doc comment for why the two aren't interchangeable) rather
+ * than this hook reading the cache itself, so a stale button — rendered
+ * before an in-flight append's response lands — surfaces that mismatch as
+ * an error instead of silently undoing the wrong thing.
  *
- * On success, updates the tip/score caches the same way `useAppendLiveEvent`
+ * On success, updates the score cache the same way `useAppendLiveEvent`
  * does, from the response's already-recomputed snapshot rather than an
- * extra refetch.
+ * extra refetch. The two tip caches split here: the append token
+ * (`liveSeqQueryKey`) trusts the response's `last_seq` directly, same as an
+ * append; the undo target (`undoTargetSeqQueryKey`) does not, since an undo
+ * always leaves that response value pointing past a real event — it's
+ * invalidated instead, forcing a real re-derivation from the event log.
  */
 export function useUndoLastLiveEvent(matchId: string) {
   const queryClient = useQueryClient()
@@ -159,6 +211,7 @@ export function useUndoLastLiveEvent(matchId: string) {
     },
     onSuccess: (data) => {
       queryClient.setQueryData(liveSeqQueryKey(matchId), data.last_seq)
+      queryClient.invalidateQueries({ queryKey: undoTargetSeqQueryKey(matchId) })
       queryClient.setQueryData(matchScoreQueryKey(matchId), data.score)
       queryClient.invalidateQueries({ queryKey: ['match', matchId] })
       queryClient.invalidateQueries({ queryKey: ['feed'] })

--- a/agon_ui/src/pages/CricketLiveScoringPage.tsx
+++ b/agon_ui/src/pages/CricketLiveScoringPage.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
-import { useAppendCricketEvent, useLiveSeq } from '@/hooks/useLiveScore'
+import { useAppendCricketEvent, useLiveSeq, useUndoTargetSeq } from '@/hooks/useLiveScore'
 import { matchScoreQueryKey, useMatchScore } from '@/hooks/useMatchScore'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
 import { UndoLastEventButton } from '@/components/agon/live/UndoLastEventButton'
@@ -59,6 +59,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
 
   const scoreQuery = useMatchScore(match.id, { refetchInterval: 8000 })
   const seq = useLiveSeq(match.id)
+  const undoSeq = useUndoTargetSeq(match.id)
   const appendEvent = useAppendCricketEvent(match.id)
   const state = cricketScoreFrom(scoreQuery.data)
   const innings = state ? currentInnings(state) : null
@@ -249,7 +250,7 @@ export function CricketLiveScoringPage({ match }: { match: Match }) {
         <ChevronLeft className="size-4" /> Back
       </Button>
       <div className="flex items-center gap-1">
-        <UndoLastEventButton matchId={match.id} seq={seq.data} />
+        <UndoLastEventButton matchId={match.id} seq={undoSeq.data} />
         <LiveIndicator />
       </div>
     </div>

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, CircleDot, Flag, Repeat2, TimerReset } from 'lucide-react'
 import { fetchClient } from '@/lib/api-client'
 import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
-import { useAppendFootballEvent, useLiveSeq } from '@/hooks/useLiveScore'
+import { useAppendFootballEvent, useLiveSeq, useUndoTargetSeq } from '@/hooks/useLiveScore'
 import { matchScoreQueryKey, useMatchScore } from '@/hooks/useMatchScore'
 import { RecordEventDialog, type EventKind } from '@/components/agon/live/RecordEventDialog'
 import { LiveIndicator } from '@/components/agon/live/LiveIndicator'
@@ -106,6 +106,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
 
   const scoreQuery = useMatchScore(match.id, { refetchInterval: 8000 })
   const seq = useLiveSeq(match.id)
+  const undoSeq = useUndoTargetSeq(match.id)
   const append = useAppendFootballEvent(match.id)
 
   const [now, setNow] = useState(() => new Date())
@@ -275,7 +276,7 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
           <ChevronLeft className="size-4" /> Back
         </Button>
         <div className="flex items-center gap-1">
-          <UndoLastEventButton matchId={match.id} seq={seq.data} />
+          <UndoLastEventButton matchId={match.id} seq={undoSeq.data} />
           <LiveIndicator />
         </div>
       </div>

--- a/agon_ui/src/pages/NetballLiveScoringPage.tsx
+++ b/agon_ui/src/pages/NetballLiveScoringPage.tsx
@@ -7,7 +7,7 @@ import type { components } from '@/types/api'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { cn } from '@/lib/utils'
-import { useAppendNetballEvent, useLiveSeq } from '@/hooks/useLiveScore'
+import { useAppendNetballEvent, useLiveSeq, useUndoTargetSeq } from '@/hooks/useLiveScore'
 import { matchScoreQueryKey, useMatchScore } from '@/hooks/useMatchScore'
 import {
   RecordNetballEventDialog,
@@ -221,7 +221,11 @@ function NetballEventByEventScoringPage({
 }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const seq = useLiveSeq(match.id)
+  // Not read directly here (only `undoSeq` feeds `UndoLastEventButton`) —
+  // called for its side effect of seeding the append-token cache
+  // `useAppendNetballEvent`'s mutation reads `expected_last_seq` from.
+  useLiveSeq(match.id)
+  const undoSeq = useUndoTargetSeq(match.id)
   const append = useAppendNetballEvent(match.id)
   const finishMatch = useFinishNetballMatch(match)
 
@@ -309,7 +313,7 @@ function NetballEventByEventScoringPage({
           Back
         </Button>
         <div className="flex items-center gap-1">
-          <UndoLastEventButton matchId={match.id} seq={seq.data} />
+          <UndoLastEventButton matchId={match.id} seq={undoSeq.data} />
           <LiveIndicator />
         </div>
       </div>
@@ -454,7 +458,11 @@ function NetballQuarterOnlyScoringPage({
 }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const seq = useLiveSeq(match.id)
+  // Not read directly here (only `undoSeq` feeds `UndoLastEventButton`) —
+  // called for its side effect of seeding the append-token cache
+  // `useAppendNetballEvent`'s mutation reads `expected_last_seq` from.
+  useLiveSeq(match.id)
+  const undoSeq = useUndoTargetSeq(match.id)
   const append = useAppendNetballEvent(match.id)
   const finishMatch = useFinishNetballMatch(match)
 
@@ -517,7 +525,7 @@ function NetballQuarterOnlyScoringPage({
           Back
         </Button>
         <div className="flex items-center gap-1">
-          <UndoLastEventButton matchId={match.id} seq={seq.data} />
+          <UndoLastEventButton matchId={match.id} seq={undoSeq.data} />
           <LiveIndicator />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixes a critical bug where undoing a live event prevented any subsequent events from being recorded. The issue was that the undo operation didn't properly advance the match's `live_seq` counter, causing all subsequent appends to fail the optimistic concurrency check.

## Key Changes

**Backend (agon_core & agon_service):**
- `Dao::delete_live_event` now atomically deletes the event AND bumps `live_seq` by one in a single `TransactWriteItems` transaction, rather than just deleting
- The tip-bump's condition (`live_seq = :seq`) serves as the "only the tip can be undone" guard, enforced at commit time against the live counter
- Returns the new tip (`seq + 1`) instead of `()`, so callers know the bumped counter value
- Distinguishes between two failure modes: `EventMissing` (event doesn't exist) and `NotTip` (seq isn't the current tip), mapped to `NotFound` and `Conflict` HTTP responses respectively
- Handler no longer does a separate read-then-check; the atomic transaction replaces that pattern
- `derive_live_snapshot` now takes `live_seq` as a parameter (the authoritative counter) rather than recomputing it from `max(records.seq)`, since the physical log can have gaps after an undo

**Frontend (agon_ui):**
- New `useUndoTargetSeq` hook tracks the log's real physical tip separately from `useLiveSeq`
- `useLiveSeq` is the append concurrency token (`expected_last_seq`), which points to the bumped counter after an undo (no longer a real event)
- `useUndoTargetSeq` is what `UndoLastEventButton` uses — the actual physical tip to delete
- After an undo, `useUndoTargetSeq` is invalidated (forcing a refetch from the event log) while `useLiveSeq` trusts the response's `last_seq` directly
- After an append, both caches are updated from the response (appends never create gaps)
- Updated all live-scoring pages to use the correct hook for undo

**Tests:**
- Comprehensive regression test suite for undo behavior:
  - Undoing the tip allows continued scoring without reusing its seq
  - Undoing a non-tip event is rejected with 400
  - Retrying an undo with the same (now-stale) seq is rejected as non-tip
  - Undoing the bumped counter value when nothing exists there returns 404

## Notable Implementation Details

- Seq numbers are never reused once assigned, even across an undo — the deleted seq and the bumped counter both stay permanently absent
- The `live_seq` counter is the authoritative tip, not the max of physical event seqs — this distinction matters once gaps exist
- The atomic transaction approach (condition on the update, not a separate read) prevents race conditions where the tip moves between a read and the delete
- Own goals in football now properly allow selecting a player from the opposing roster, with UI improvements to handle the roster switch when toggling the own-goal checkbox

https://claude.ai/code/session_01ReVeiAMtni666JW3Xrybfo