### PR TITLE
Add Playwright-based UI end-to-end tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,6 @@ jobs:
     uses: JElgar/agon/.github/workflows/test-ui-e2e.yml@main
     with:
       base-url: ${{ needs.deploy.outputs.agon-url }}
+      stack-name: staging
     secrets:
-      e2e-test-email: ${{ secrets.E2E_TEST_EMAIL }}
-      e2e-test-password: ${{ secrets.E2E_TEST_PASSWORD }}
+      pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,12 @@ jobs:
       stack-name: staging
     secrets:
       pulumi-access-token: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+
+  test-ui-e2e:
+    needs: deploy
+    uses: JElgar/agon/.github/workflows/test-ui-e2e.yml@main
+    with:
+      base-url: ${{ needs.deploy.outputs.agon-url }}
+    secrets:
+      e2e-test-email: ${{ secrets.E2E_TEST_EMAIL }}
+      e2e-test-password: ${{ secrets.E2E_TEST_PASSWORD }}

--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -1,0 +1,47 @@
+on:
+  workflow_call:
+    inputs:
+      base-url:
+        description: The deployed UI to test against (e.g. https://agon.staging.get-agon.com).
+        required: true
+        type: string
+    secrets:
+      # The fixed Supabase test account the suite logs in as — see
+      # agon_ui/e2e/README.md#provisioning-the-test-user. Not sourced from
+      # Pulumi (unlike the API tests' signing key): it's a real Supabase user,
+      # not a locally-trusted key.
+      e2e-test-email:
+        required: true
+      e2e-test-password:
+        required: true
+
+jobs:
+  test-ui-e2e:
+    name: UI e2e
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./agon_ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+        env:
+          E2E_BASE_URL: ${{ inputs.base-url }}
+          E2E_TEST_EMAIL: ${{ secrets.e2e-test-email }}
+          E2E_TEST_PASSWORD: ${{ secrets.e2e-test-password }}
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: agon_ui/playwright-report/
+          retention-days: 14

--- a/.github/workflows/test-ui-e2e.yml
+++ b/.github/workflows/test-ui-e2e.yml
@@ -5,14 +5,16 @@ on:
         description: The deployed UI to test against (e.g. https://agon.staging.get-agon.com).
         required: true
         type: string
-    secrets:
-      # The fixed Supabase test account the suite logs in as — see
-      # agon_ui/e2e/README.md#provisioning-the-test-user. Not sourced from
-      # Pulumi (unlike the API tests' signing key): it's a real Supabase user,
-      # not a locally-trusted key.
-      e2e-test-email:
+      stack-name:
         required: true
-      e2e-test-password:
+        type: string
+    secrets:
+      # Only the Pulumi access token — the e2e test account's own credentials
+      # live in Pulumi config (`e2eTestEmail`/`e2eTestPassword`, see
+      # agon_infra/index.ts), fetched below the same way test.yml fetches
+      # `agonTestJwtPrivateKey`, so there's one encrypted source of truth
+      # instead of a value duplicated into a GitHub secret too.
+      pulumi-access-token:
         required: true
 
 jobs:
@@ -22,21 +24,43 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./agon_ui
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+      - run: pnpm install
+        working-directory: agon_infra
+
+      - name: Read e2e test account from Pulumi
+        working-directory: agon_infra
+        run: |
+          pulumi stack select ${{ inputs.stack-name }}
+          EMAIL="$(pulumi config get e2eTestEmail)"
+          PASSWORD="$(pulumi config get e2eTestPassword)"
+          echo "::add-mask::$EMAIL"
+          echo "::add-mask::$PASSWORD"
+          echo "E2E_TEST_EMAIL=$EMAIL" >> "$GITHUB_ENV"
+          echo "E2E_TEST_PASSWORD=$PASSWORD" >> "$GITHUB_ENV"
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.pulumi-access-token }}
+
       - run: npm install
+        working-directory: agon_ui
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
+        working-directory: agon_ui
 
       - name: Run e2e tests
         run: npm run test:e2e
+        working-directory: agon_ui
         env:
           E2E_BASE_URL: ${{ inputs.base-url }}
-          E2E_TEST_EMAIL: ${{ secrets.e2e-test-email }}
-          E2E_TEST_PASSWORD: ${{ secrets.e2e-test-password }}
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,19 @@ run:
 	cargo run -p agon_service -- run-server abc.com
 
 # Full browser UI end-to-end tests (Playwright) — see agon_ui/e2e/README.md
-# for what's covered, how the test account works, and env var setup
-# (E2E_TEST_EMAIL / E2E_TEST_PASSWORD, optionally E2E_BASE_URL).
+# for what's covered and how the test account works. Reads E2E_TEST_EMAIL /
+# E2E_TEST_PASSWORD / E2E_BASE_URL from the environment (or .env); use
+# test-ui-e2e-staging below to pull the test account from Pulumi instead.
 test-ui-e2e:
-	cd agon_ui && npm run test:e2e
+	npm --prefix agon_ui run test:e2e
+
+# Same, against the deployed staging UI, fetching the fixed test account from
+# Pulumi config (single source of truth — see e2eTestEmail/e2eTestPassword in
+# agon_infra/index.ts, same pattern as test-staging's signing key above).
+UI_STAGING_URL ?= https://agon.staging.get-agon.com
+
+test-ui-e2e-staging:
+	E2E_BASE_URL=$(UI_STAGING_URL) \
+	E2E_TEST_EMAIL="$$(cd agon_infra && pulumi config get e2eTestEmail --stack $(STACK))" \
+	E2E_TEST_PASSWORD="$$(cd agon_infra && pulumi config get e2eTestPassword --stack $(STACK))" \
+	npm --prefix agon_ui run test:e2e

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,9 @@ test-staging:
 
 run:
 	cargo run -p agon_service -- run-server abc.com
+
+# Full browser UI end-to-end tests (Playwright) — see agon_ui/e2e/README.md
+# for what's covered, how the test account works, and env var setup
+# (E2E_TEST_EMAIL / E2E_TEST_PASSWORD, optionally E2E_BASE_URL).
+test-ui-e2e:
+	cd agon_ui && npm run test:e2e

--- a/agon_infra/index.ts
+++ b/agon_infra/index.ts
@@ -844,6 +844,20 @@ const awsSecret = new k8s.core.v1.Secret("aws-credentials", {
 //   pulumi config set --secret agonTestJwtPrivateKey "$(cat test_ec_pkcs8.pem)"
 export const agonTestJwtPrivateKey = config.requireSecret("agonTestJwtPrivateKey");
 
+// ── UI e2e test account ──────────────────────────────────────────────────────
+// The fixed Supabase user the UI e2e suite (agon_ui/e2e) logs in as through the
+// real login form — a real Supabase account, not a locally-trusted key, so it
+// has to be created once by hand (Supabase dashboard or admin API — see
+// agon_ui/e2e/README.md#provisioning-the-test-user). Its credentials live here
+// (not a GitHub secret) for the same reason as `agonTestJwtPrivateKey` above:
+// one encrypted source of truth that CI reads live via `pulumi config get`
+// (see .github/workflows/test-ui-e2e.yml), rather than a value duplicated
+// between two secret stores that can drift out of sync.
+//   pulumi config set e2eTestEmail agon-e2e-bot@example.com
+//   pulumi config set --secret e2eTestPassword '<a real password>'
+export const e2eTestEmail = config.require("e2eTestEmail");
+export const e2eTestPassword = config.requireSecret("e2eTestPassword");
+
 // ───────────────────────────────────────────────────────────────────────────
 // Meilisearch: search / discovery index
 // Self-hosted search engine backing the discovery endpoints (users / teams /

--- a/agon_ui/.gitignore
+++ b/agon_ui/.gitignore
@@ -24,3 +24,10 @@ dist-ssr
 *.sw?
 
 src/types/api.ts
+
+# Playwright e2e (see e2e/README.md)
+/e2e/.auth
+/test-results
+/playwright-report
+/blob-report
+/playwright/.cache

--- a/agon_ui/README.md
+++ b/agon_ui/README.md
@@ -109,6 +109,13 @@ cd agon_ui
 npx openapi-typescript-codegen --input ../schema.json --output ./src/api --client axios
 ```
 
+## Testing
+
+Full browser end-to-end tests live in `e2e/` (Playwright) — see
+`e2e/README.md` for what they cover and how to run them. They're separate
+from `agon_tests` at the repo root, which tests the API directly and doesn't
+touch the browser.
+
 ## Adding shadcn/ui Components
 
 To add more shadcn/ui components:

--- a/agon_ui/e2e/README.md
+++ b/agon_ui/e2e/README.md
@@ -98,13 +98,18 @@ Opposition …` etc. so they're easy to spot.
 
 ## Notes for adding more tests
 
-- There are no `data-testid` hooks in the app — the codebase doesn't use
-  them, and existing markup is accessible enough (labelled inputs, buttons
-  with real text) that role/label/text locators work throughout. Prefer
-  those (`getByRole`, `getByLabel`, `getByPlaceholder`) over CSS selectors;
-  the couple of spots in `support/` that fall back to a class selector do so
-  because the element genuinely has no accessible name (e.g. the bare score
-  digits) — keep that the exception, not the pattern.
+- Locator priority, in order: `getByRole` / `getByLabel` / `getByPlaceholder`
+  first — most of the app's markup is accessible enough (labelled inputs,
+  buttons with real text) that these work throughout and stay meaningful if
+  the visual design changes. Where an element genuinely has no accessible
+  name (e.g. the bare live-score digits, a tagged player's name — which is
+  just text, not a control), add a `data-testid` to the source component
+  instead of reaching for a CSS selector — see `live-score`/`live-phase` in
+  `LiveScoringPage.tsx` and `tagged-player-name` in `PlayerSideEditor.tsx`
+  for the pattern. **Never** select on Tailwind utility classes (`text-xs`,
+  `text-3xl`, `mt-0.5`, …): those are styling, not identity — a font-size or
+  spacing tweak in a totally unrelated redesign would silently break the
+  test. A `data-testid` only changes if someone deliberately renames it.
 - Tests run serially against one shared account and one shared backend
   (`fullyParallel: false`, `workers: 1` in `playwright.config.ts`) — two
   tests racing live-scoring mutations on the same match would be flaky by

--- a/agon_ui/e2e/README.md
+++ b/agon_ui/e2e/README.md
@@ -39,13 +39,35 @@ it, so the suite doesn't repeat a real Supabase password grant per test.
 ### Provisioning the test user
 
 Create the account once, in whichever Supabase project the target
-environment's `VITE_SUPABASE_URL` points at (staging, typically):
+environment's `VITE_SUPABASE_URL` points at (staging, typically) — either
+Supabase dashboard → Authentication → Users → **Add user**, with email
+confirmed, or the [Admin API](https://supabase.com/docs/reference/api/introduction)
+directly:
 
-- Supabase dashboard → Authentication → Users → **Add user**, with email
-  confirmed, or
-- the [Supabase Admin API](https://supabase.com/docs/reference/api/introduction)
-  (`POST /auth/v1/admin/users` with `email_confirm: true`) using the
-  project's service role key.
+```bash
+curl -X POST "https://gkebmzhvdbsktamfdsil.supabase.co/auth/v1/admin/users" \
+  -H "apikey: $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "email": "agon-e2e-bot@example.com",
+    "password": "<a real password>",
+    "email_confirm": true
+  }'
+```
+
+`email_confirm: true` is what makes the account usable immediately, without
+clicking a confirmation link `signUp` would otherwise send. The URL above is
+staging's project (`supabaseUrl` in `Pulumi.staging.yaml`) — swap it for
+whichever project the target environment actually uses.
+
+`SUPABASE_SERVICE_ROLE_KEY` is the project's **service role key** (Supabase
+dashboard → Project Settings → API), not the anon key — it bypasses every
+RLS policy and has full admin auth access. Export it in your shell just for
+this one call; **don't** put it in Pulumi config, a `.env` file, or anywhere
+else persistent — nothing in this codebase needs it on an ongoing basis,
+only this one-off account bootstrap, so there's no case for storing it
+long-term.
 
 Pick a password, then store both in **Pulumi config** on the target stack —
 not a GitHub secret, and not committed anywhere. This is the same pattern

--- a/agon_ui/e2e/README.md
+++ b/agon_ui/e2e/README.md
@@ -47,13 +47,25 @@ environment's `VITE_SUPABASE_URL` points at (staging, typically):
   (`POST /auth/v1/admin/users` with `email_confirm: true`) using the
   project's service role key.
 
-Pick a password, then set both as env vars wherever the suite runs (a local
-`.env`, or CI secrets) — **not** committed anywhere:
+Pick a password, then store both in **Pulumi config** on the target stack —
+not a GitHub secret, and not committed anywhere. This is the same pattern
+`agonTestJwtPrivateKey` already uses (see `agon_infra/index.ts`): one
+encrypted source of truth that CI reads live via `pulumi config get`
+(`.github/workflows/test-ui-e2e.yml`), rather than duplicating the value into
+a second secret store that can drift out of sync:
 
+```bash
+cd agon_infra
+pulumi stack select staging
+pulumi config set e2eTestEmail agon-e2e-bot@example.com
+pulumi config set --secret e2eTestPassword '<a real password>'
 ```
-E2E_TEST_EMAIL=agon-e2e-bot@example.com
-E2E_TEST_PASSWORD=<a real password>
-```
+
+`e2eTestEmail`/`e2eTestPassword` are `config.require`/`requireSecret`d in
+`index.ts` (exported, like `agonTestJwtPrivateKey`, purely so CI can fetch
+them — nothing deploys them anywhere), which means **`pulumi up`/`preview`
+on a stack fails until it has both set**. Set them on staging before the
+next deploy after pulling in this change.
 
 The very first login creates the account's Agon profile too (via
 `CreateProfileForm`, driven automatically by `auth.setup.ts`) — nothing else
@@ -61,11 +73,22 @@ to provision by hand.
 
 ## Running
 
+Locally, the suite just reads plain env vars — Pulumi is only wired into the
+CI job (`test-ui-e2e.yml`), not into `npm run test:e2e` itself:
+
 ```bash
 cd agon_ui
 npm install
 npx playwright install --with-deps chromium   # once, to fetch the browser
 E2E_TEST_EMAIL=... E2E_TEST_PASSWORD=... npm run test:e2e
+```
+
+Pull the values straight from Pulumi instead of retyping them:
+
+```bash
+E2E_TEST_EMAIL="$(cd ../agon_infra && pulumi config get e2eTestEmail --stack staging)" \
+E2E_TEST_PASSWORD="$(cd ../agon_infra && pulumi config get e2eTestPassword --stack staging)" \
+npm run test:e2e
 ```
 
 By default this starts the local Vite dev server (`npm run dev`), which

--- a/agon_ui/e2e/README.md
+++ b/agon_ui/e2e/README.md
@@ -1,0 +1,112 @@
+# UI end-to-end tests
+
+Full browser tests: [Playwright](https://playwright.dev) drives the real UI
+against a real running Agon environment — real Supabase login, real API
+calls, real DynamoDB/Meilisearch on the far end. This is deliberately
+different from `agon_tests`, which talks to the API directly via the
+generated OpenAPI client and never touches a browser or Supabase at all (see
+`agon_tests/tests/api.rs`'s doc comment) — that suite is faster and covers
+far more of the API surface, but can't catch a UI bug (wrong endpoint called,
+a broken form, a gate that doesn't unlock). This suite exists for the things
+only a real browser session can catch: login → profile gate → the actual
+click-through flows a player would use.
+
+## How auth works here
+
+`LoginForm` already offers a real email/password path
+(`supabase.auth.signInWithPassword`) alongside Google OAuth — Google isn't
+the only way in, just the primary one for real users. OAuth needs a real
+Google account and an interactive consent screen a headless browser can't
+complete, so these tests drive the email/password path instead, against a
+**fixed test account that actually exists in the target Supabase project**.
+That's a deliberate choice over the alternatives:
+
+- **Not** a locally-minted JWT (what `agon_tests` does via a static JWKS the
+  service trusts — see `AGON_TEST_JWT_PRIVATE_KEY` in the root
+  `.env.example`). That bypasses Supabase entirely, which means it also
+  bypasses the browser-side auth code this suite is here to exercise
+  (`useAuth`, the profile gate, `supabase.auth.getSession()` wiring in
+  `lib/api-client.ts`). Fine for testing the API; not for testing the UI.
+- **Not** injecting a fabricated Supabase session into `localStorage`. That
+  would skip `LoginForm` (and the profile-gate screen on a fresh account)
+  altogether — the exact surface this suite exists to cover.
+
+A single Playwright **setup project** (`tests/auth.setup.ts`) logs in once
+via the real form and saves the resulting storage state (Supabase persists
+its session in `localStorage`) to `.auth/user.json`; every other test reuses
+it, so the suite doesn't repeat a real Supabase password grant per test.
+
+### Provisioning the test user
+
+Create the account once, in whichever Supabase project the target
+environment's `VITE_SUPABASE_URL` points at (staging, typically):
+
+- Supabase dashboard → Authentication → Users → **Add user**, with email
+  confirmed, or
+- the [Supabase Admin API](https://supabase.com/docs/reference/api/introduction)
+  (`POST /auth/v1/admin/users` with `email_confirm: true`) using the
+  project's service role key.
+
+Pick a password, then set both as env vars wherever the suite runs (a local
+`.env`, or CI secrets) — **not** committed anywhere:
+
+```
+E2E_TEST_EMAIL=agon-e2e-bot@example.com
+E2E_TEST_PASSWORD=<a real password>
+```
+
+The very first login creates the account's Agon profile too (via
+`CreateProfileForm`, driven automatically by `auth.setup.ts`) — nothing else
+to provision by hand.
+
+## Running
+
+```bash
+cd agon_ui
+npm install
+npx playwright install --with-deps chromium   # once, to fetch the browser
+E2E_TEST_EMAIL=... E2E_TEST_PASSWORD=... npm run test:e2e
+```
+
+By default this starts the local Vite dev server (`npm run dev`), which
+already proxies `/api` to `https://agon.staging.get-agon.com` and points at
+staging Supabase via `.env` (see `vite.config.ts`) — so against staging,
+that's all you need. To test an already-deployed UI instead of spawning a
+local server, set `E2E_BASE_URL` (e.g. a preview URL):
+
+```bash
+E2E_BASE_URL=https://agon.staging.get-agon.com \
+E2E_TEST_EMAIL=... E2E_TEST_PASSWORD=... \
+npm run test:e2e
+```
+
+`npm run test:e2e:ui` opens Playwright's UI mode for interactively stepping
+through a run.
+
+## What's covered
+
+- `tests/match-feed.spec.ts` — logging a match through the real "Log a
+  match" form and confirming it shows up in the feed and opens correctly.
+- `tests/football-live-scoring.spec.ts` — a full football live-scoring pass:
+  recording a goal with an assist, undoing it, half-time (and that scoring
+  is unavailable while the clock is stopped), resuming the second half, a
+  second goal, full-time, and finishing the match.
+
+Test data isn't cleaned up afterwards — created matches accumulate against
+the test account like any other match would, named `E2E football …` / `E2E
+Opposition …` etc. so they're easy to spot.
+
+## Notes for adding more tests
+
+- There are no `data-testid` hooks in the app — the codebase doesn't use
+  them, and existing markup is accessible enough (labelled inputs, buttons
+  with real text) that role/label/text locators work throughout. Prefer
+  those (`getByRole`, `getByLabel`, `getByPlaceholder`) over CSS selectors;
+  the couple of spots in `support/` that fall back to a class selector do so
+  because the element genuinely has no accessible name (e.g. the bare score
+  digits) — keep that the exception, not the pattern.
+- Tests run serially against one shared account and one shared backend
+  (`fullyParallel: false`, `workers: 1` in `playwright.config.ts`) — two
+  tests racing live-scoring mutations on the same match would be flaky by
+  construction. Keep new tests independent by creating their own match
+  rather than reusing one from another test.

--- a/agon_ui/e2e/playwright.config.ts
+++ b/agon_ui/e2e/playwright.config.ts
@@ -37,7 +37,10 @@ export default defineConfig({
   workers: 1,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? 'dot' : 'list',
+  // In CI, an HTML report is what test-ui-e2e.yml uploads as an artifact on
+  // failure, and the `github` reporter annotates failures straight onto the
+  // run. Locally, `list` is just nicer to watch scroll by.
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['github']] : 'list',
   timeout: 60_000,
   use: {
     baseURL,

--- a/agon_ui/e2e/playwright.config.ts
+++ b/agon_ui/e2e/playwright.config.ts
@@ -1,0 +1,66 @@
+import { defineConfig, devices } from '@playwright/test'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+// `agon_ui` is an ESM package ("type": "module" in package.json), so this
+// config has no `__dirname` — derive it from `import.meta.url` instead.
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Full end-to-end tests: a real browser drives the real UI (real Supabase
+ * login, real API calls, real DynamoDB/Meilisearch on the far end), unlike
+ * `agon_tests`, which talks to the API directly via the generated client and
+ * bypasses the browser and Supabase entirely. See `e2e/README.md` for how the
+ * two suites complement each other and how to configure a target environment.
+ *
+ * Two things point this at a target:
+ *   - `E2E_BASE_URL` — the UI to test. Unset by default, which starts the
+ *     local Vite dev server (see the `webServer` block below) — it already
+ *     proxies `/api` to staging (see `vite.config.ts`), so `npm run test:e2e`
+ *     works with nothing beyond a configured `.env`. Set it to test a
+ *     deployed UI (e.g. a preview/staging URL) instead of spawning a local
+ *     server.
+ *   - `E2E_TEST_EMAIL` / `E2E_TEST_PASSWORD` — the fixed Supabase test
+ *     account the `setup` project logs in as (see `e2e/tests/auth.setup.ts`).
+ */
+const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:5173'
+const usingLocalDevServer = !process.env.E2E_BASE_URL
+
+const authFile = path.join(__dirname, '.auth/user.json')
+
+export default defineConfig({
+  testDir: './tests',
+  // Every test signs in as the same fixed account and mutates real shared
+  // state (matches, live scores) against one backend — running in parallel
+  // would let tests race each other's data, so keep it to one worker.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'dot' : 'list',
+  timeout: 60_000,
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  webServer: usingLocalDevServer
+    ? {
+        command: 'npm run dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 60_000,
+      }
+    : undefined,
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+    },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: authFile },
+      dependencies: ['setup'],
+    },
+  ],
+})

--- a/agon_ui/e2e/support/liveScoring.ts
+++ b/agon_ui/e2e/support/liveScoring.ts
@@ -1,0 +1,81 @@
+import { type Page, type Locator, expect } from '@playwright/test'
+
+/** Opens a match from the feed by the name it was logged under (see
+ *  `logFootballMatch`) and lands on its detail page. */
+export async function openMatchFromFeed(page: Page, matchName: string): Promise<void> {
+  await page.goto('/feed')
+  await page.getByText(matchName, { exact: true }).first().click()
+  await expect(page).toHaveURL(/\/matches\/[^/]+$/)
+}
+
+/**
+ * From a football match's detail page, starts live scoring: "Score live" →
+ * the track-preferences setup screen → "Start scoring", which itself
+ * records the kickoff period marker (see `LiveScoringSetupPage`). Lands on
+ * `/matches/:id/live` with the clock already running (1st half).
+ */
+export async function startFootballScoring(page: Page): Promise<void> {
+  await page.getByRole('link', { name: 'Score live' }).click()
+  await expect(page).toHaveURL(/\/live\/setup$/)
+  await page.getByRole('button', { name: 'Start scoring', exact: true }).click()
+  await expect(page).toHaveURL(/\/live$/)
+  await expect(phaseLabel(page)).toContainText('1st half')
+}
+
+/** The live-scoring screen's own score box, e.g. "1–0". */
+export function liveScoreBox(page: Page): Locator {
+  return page.locator('.text-3xl.font-medium.tracking-tight')
+}
+
+/** The running-clock/phase line under the score, e.g. "12' · 1st half" or
+ *  just "Half-time" once the clock stops — see `FootballLiveScoringPage`'s
+ *  score box. */
+export function phaseLabel(page: Page): Locator {
+  return page.locator('.mt-0\\.5.text-xs.text-primary')
+}
+
+/**
+ * Opens the goal dialog from a quick-action tap, fills side/scorer/(assist),
+ * and submits — the same steps a scorer taps through live. `scorer` and
+ * `assist` are matched by the exact name shown in the roster picker (see
+ * `logFootballMatch`'s returned names).
+ */
+export async function recordGoal(
+  page: Page,
+  { side, scorer, assist }: { side: string; scorer: string; assist?: string },
+): Promise<void> {
+  await page.getByRole('button', { name: 'Goal', exact: true }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+
+  await dialog.getByRole('button', { name: side, exact: true }).click()
+  await dialog.getByRole('button', { name: scorer, exact: true }).click()
+  if (assist) {
+    await dialog.getByRole('button', { name: assist, exact: true }).click()
+  }
+  await dialog.getByRole('button', { name: 'Add goal', exact: true }).click()
+  await expect(dialog).toBeHidden()
+}
+
+/** Undo the most recently recorded live event, confirming the destructive
+ *  prompt — see `UndoLastEventButton`. */
+export async function undoLastEvent(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Undo last' }).click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog.getByRole('heading', { name: 'Undo the last event?' })).toBeVisible()
+  await dialog.getByRole('button', { name: 'Yes, undo it' }).click()
+  await expect(dialog).toBeHidden()
+}
+
+/** Taps the clock-advance tile (kickoff/half-time/full-time and their
+ *  extra-time equivalents — see `nextPhaseActionLabel`) by its current
+ *  label, e.g. "End 1st half" or "Start 2nd half". */
+export async function advanceClock(page: Page, label: string): Promise<void> {
+  await page.getByRole('button', { name: label, exact: true }).click()
+}
+
+/** Whether a goal/card/sub quick-action is currently offered — false during
+ *  a break (half-time, full-time) or before kickoff. */
+export function goalButton(page: Page): Locator {
+  return page.getByRole('button', { name: 'Goal', exact: true })
+}

--- a/agon_ui/e2e/support/liveScoring.ts
+++ b/agon_ui/e2e/support/liveScoring.ts
@@ -22,16 +22,19 @@ export async function startFootballScoring(page: Page): Promise<void> {
   await expect(phaseLabel(page)).toContainText('1st half')
 }
 
-/** The live-scoring screen's own score box, e.g. "1–0". */
+/** The live-scoring screen's own score box, e.g. "1–0" — just digits and a
+ *  dash with no accessible name to target, hence the `data-testid` (see
+ *  `LiveScoringPage`'s `live-score` element and `e2e/README.md`'s locator
+ *  guidance). */
 export function liveScoreBox(page: Page): Locator {
-  return page.locator('.text-3xl.font-medium.tracking-tight')
+  return page.getByTestId('live-score')
 }
 
 /** The running-clock/phase line under the score, e.g. "12' · 1st half" or
- *  just "Half-time" once the clock stops — see `FootballLiveScoringPage`'s
- *  score box. */
+ *  just "Half-time" once the clock stops — see `LiveScoringPage`'s
+ *  `live-phase` element. */
 export function phaseLabel(page: Page): Locator {
-  return page.locator('.mt-0\\.5.text-xs.text-primary')
+  return page.getByTestId('live-phase')
 }
 
 /**

--- a/agon_ui/e2e/support/logMatch.ts
+++ b/agon_ui/e2e/support/logMatch.ts
@@ -56,8 +56,9 @@ export async function logFootballMatch(
 
   // The signed-in user is seeded onto "Your side" as soon as their profile
   // loads — read their name back before adding anyone else, while there's
-  // still exactly one roster row on that side to disambiguate.
-  const selfRow = page.locator('.rounded-md.bg-card > span.flex-1.truncate.text-sm').first()
+  // still exactly one tagged-player row on the page to disambiguate (see
+  // `PlayerSideEditor`'s `tagged-player-name` element).
+  const selfRow = page.getByTestId('tagged-player-name').first()
   await expect(selfRow).toBeVisible()
   const selfName = (await selfRow.innerText()).trim()
 

--- a/agon_ui/e2e/support/logMatch.ts
+++ b/agon_ui/e2e/support/logMatch.ts
@@ -1,0 +1,78 @@
+import { type Page, expect } from '@playwright/test'
+
+/** A short, run-unique suffix so repeated suite runs never collide on match
+ *  names — there's no test-data cleanup step, so created matches just
+ *  accumulate in the feed like any other match would. */
+export function uniqueSuffix(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+}
+
+export interface LoggedFootballMatch {
+  name: string
+  /** Side A's custom name, as typed into the form. */
+  homeName: string
+  /** Side B's custom name, as typed into the form. */
+  opponentName: string
+  /** The signed-in test account's own display name, read back from its
+   *  auto-seeded roster entry — see the function doc comment for why this
+   *  is discovered rather than hardcoded. */
+  selfName: string
+  teammateName: string
+  awayPlayerName: string
+}
+
+/**
+ * Drives the real "Log a match" flow (`LogMatchPage`) to create a scheduled
+ * football match with a full-enough roster for live-scoring tests to record
+ * goals, an assist, and events on both sides:
+ *   - Side A ("Home"): the signed-in user (seeded automatically) plus one
+ *     guest teammate — two players, so the goal dialog's assist picker has
+ *     someone to offer (`RecordEventDialog` only shows it once
+ *     `roster.length > 1`).
+ *   - Side B (`opponentName`): one guest player, so a second-half goal can
+ *     be attributed to a real player rather than needing an own-goal.
+ *
+ * The signed-in user's own display name isn't something this suite controls
+ * (it's whatever the fixed e2e Supabase account was named on signup — see
+ * `auth.setup.ts`), so it's read back from the seeded roster row rather than
+ * assumed, for tests that need to pick them as an assist.
+ *
+ * Leaves the browser on the feed, which is where a successful submit
+ * navigates to.
+ */
+export async function logFootballMatch(
+  page: Page,
+  { opponentName }: { opponentName: string },
+): Promise<LoggedFootballMatch> {
+  const name = `E2E football ${uniqueSuffix()}`
+  const homeName = 'Home'
+  const teammateName = 'Guest Teammate'
+  const awayPlayerName = 'Away Striker'
+
+  await page.goto('/matches/new')
+
+  await page.getByRole('button', { name: 'Football' }).click()
+  await page.getByPlaceholder('e.g. Tuesday night singles').fill(name)
+
+  // The signed-in user is seeded onto "Your side" as soon as their profile
+  // loads — read their name back before adding anyone else, while there's
+  // still exactly one roster row on that side to disambiguate.
+  const selfRow = page.locator('.rounded-md.bg-card > span.flex-1.truncate.text-sm').first()
+  await expect(selfRow).toBeVisible()
+  const selfName = (await selfRow.innerText()).trim()
+
+  const sideNameInputs = page.getByPlaceholder('Name this side (optional)')
+  await sideNameInputs.nth(0).fill(homeName)
+  await sideNameInputs.nth(1).fill(opponentName)
+
+  await page.getByPlaceholder('Add a teammate…').fill(teammateName)
+  await page.getByRole('button', { name: `Add "${teammateName}" as guest` }).click()
+
+  await page.getByPlaceholder('Add an opponent…').fill(awayPlayerName)
+  await page.getByRole('button', { name: `Add "${awayPlayerName}" as guest` }).click()
+
+  await page.getByRole('button', { name: 'Post match', exact: true }).click()
+  await expect(page).toHaveURL(/\/feed$/, { timeout: 20_000 })
+
+  return { name, homeName, opponentName, selfName, teammateName, awayPlayerName }
+}

--- a/agon_ui/e2e/tests/auth.setup.ts
+++ b/agon_ui/e2e/tests/auth.setup.ts
@@ -1,0 +1,64 @@
+import { test as setup, expect } from '@playwright/test'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const authFile = path.join(__dirname, '../.auth/user.json')
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} must be set to run the e2e suite — see e2e/README.md`)
+  }
+  return value
+}
+
+/**
+ * Signs in once as the fixed e2e test account and saves the resulting
+ * storage state (Supabase persists its session in `localStorage`) for every
+ * other test to reuse — see `playwright.config.ts`'s `setup` project. Doing
+ * this once up front, rather than per-test, keeps the suite fast and avoids
+ * hammering Supabase's password-grant rate limit.
+ *
+ * Deliberately drives the real `LoginForm` email/password path (Supabase
+ * `signInWithPassword`), not Google OAuth — OAuth needs a real Google account
+ * and consent screen a headless browser can't complete, and the app already
+ * offers email/password as a first-class sign-in method (LoginForm's "Or
+ * continue with email" section), not just a test-only backdoor. This is also
+ * why these tests need a *real* Supabase test user rather than a locally
+ * minted JWT: `agon_tests` mints its own tokens against a static JWKS the
+ * service trusts (see `agon_tests/tests/api.rs`), which is a fast way to test
+ * the API, but never touches the browser's Supabase session or the
+ * login/profile-gate UI this suite exists to cover.
+ */
+setup('log in as the fixed e2e test user', async ({ page }) => {
+  const email = requireEnv('E2E_TEST_EMAIL')
+  const password = requireEnv('E2E_TEST_PASSWORD')
+
+  await page.goto('/')
+
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password').fill(password)
+  await page.getByRole('button', { name: 'Sign In', exact: true }).click()
+
+  // A brand-new Supabase account has no Agon profile yet — `CreateProfileForm`
+  // gates on it (see App.tsx's `AuthenticatedApp`). Only the very first sign-in
+  // of this test account anywhere hits this branch; every run after that lands
+  // straight on the feed. Handled here (not per-test) since it's a one-time
+  // account setup step, not part of what any individual test is verifying.
+  // Both the desktop sidebar and the mobile bottom nav render their own
+  // "Feed" link (only one is visible at a given viewport — see
+  // `AppSidebar`/`MobileBottomNav`), so scope to one to avoid a strict-mode
+  // violation from Playwright matching both.
+  const profileHeading = page.getByRole('heading', { name: 'Complete your profile' })
+  const feedLink = page.getByRole('link', { name: 'Feed' }).first()
+  await expect(profileHeading.or(feedLink)).toBeVisible({ timeout: 20_000 })
+
+  if (await profileHeading.isVisible()) {
+    await page.getByLabel('Display name').fill('Agon E2E Bot')
+    await page.getByRole('button', { name: 'Create profile' }).click()
+    await expect(feedLink).toBeVisible({ timeout: 20_000 })
+  }
+
+  await page.context().storageState({ path: authFile })
+})

--- a/agon_ui/e2e/tests/football-live-scoring.spec.ts
+++ b/agon_ui/e2e/tests/football-live-scoring.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+import { logFootballMatch, uniqueSuffix } from '../support/logMatch'
+import {
+  advanceClock,
+  goalButton,
+  liveScoreBox,
+  openMatchFromFeed,
+  phaseLabel,
+  recordGoal,
+  startFootballScoring,
+  undoLastEvent,
+} from '../support/liveScoring'
+
+test.describe('football live scoring', () => {
+  test('goals with an assist, undo, half-time, and finishing the match', async ({ page }) => {
+    const opponentName = `E2E Away ${uniqueSuffix()}`
+    const { name, homeName, selfName, teammateName, awayPlayerName } = await logFootballMatch(page, {
+      opponentName,
+    })
+
+    await openMatchFromFeed(page, name)
+    await startFootballScoring(page)
+
+    // --- First half: a goal with an assist, then undo it ---------------------
+    await recordGoal(page, { side: homeName, scorer: teammateName, assist: selfName })
+    await expect(liveScoreBox(page)).toHaveText(/1\s*–\s*0/)
+    await expect(page.getByText(`Goal — ${teammateName} (${selfName})`)).toBeVisible()
+
+    await undoLastEvent(page)
+    await expect(liveScoreBox(page)).toHaveText(/0\s*–\s*0/)
+    await expect(page.getByText('No events recorded yet.')).toBeVisible()
+
+    // Record it again so the rest of the match has something on the board —
+    // also exercises that a goal can be re-recorded cleanly after an undo.
+    await recordGoal(page, { side: homeName, scorer: teammateName, assist: selfName })
+    await expect(liveScoreBox(page)).toHaveText(/1\s*–\s*0/)
+
+    // --- Half-time: the clock stops and scoring is unavailable ---------------
+    await advanceClock(page, 'End 1st half')
+    await expect(phaseLabel(page)).toContainText('Half-time')
+    await expect(goalButton(page)).toHaveCount(0)
+
+    await advanceClock(page, 'Start 2nd half')
+    await expect(phaseLabel(page)).toContainText('2nd half')
+    await expect(goalButton(page)).toBeVisible()
+
+    // --- Second half: the other side equalises --------------------------------
+    await recordGoal(page, { side: opponentName, scorer: awayPlayerName })
+    await expect(liveScoreBox(page)).toHaveText(/1\s*–\s*1/)
+
+    // --- Full time, then finish the match -------------------------------------
+    await advanceClock(page, 'End match')
+    await expect(phaseLabel(page)).toContainText('Full-time')
+    await page.getByRole('button', { name: 'Finish match', exact: true }).click()
+
+    await expect(page).toHaveURL(/\/matches\/[^/]+$/)
+    await expect(page.getByText(teammateName).first()).toBeVisible()
+    await expect(page.getByText(awayPlayerName).first()).toBeVisible()
+    await expect(page.getByText(/Confirmed|Unconfirmed/).first()).toBeVisible()
+  })
+})

--- a/agon_ui/e2e/tests/match-feed.spec.ts
+++ b/agon_ui/e2e/tests/match-feed.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test'
+import { logFootballMatch, uniqueSuffix } from '../support/logMatch'
+
+test.describe('creating a match', () => {
+  test('a newly logged match appears in the feed and opens', async ({ page }) => {
+    const opponentName = `E2E Opposition ${uniqueSuffix()}`
+    const { name } = await logFootballMatch(page, { opponentName })
+
+    // LogMatchPage navigates to /feed on a successful post. The feed also
+    // shows this match instantly from a client-side overlay ahead of the
+    // async fan-out worker landing it in `GET /feed` (see
+    // `hooks/usePendingMatches`), so there's nothing to wait on here.
+    const card = page.getByText(name, { exact: true }).first()
+    await expect(card).toBeVisible()
+    await expect(page.getByText(opponentName, { exact: true }).first()).toBeVisible()
+
+    await card.click()
+    await expect(page).toHaveURL(/\/matches\/[^/]+$/)
+    await expect(page.getByText(name, { exact: true }).first()).toBeVisible()
+    await expect(page.getByText(opponentName, { exact: true }).first()).toBeVisible()
+  })
+})

--- a/agon_ui/e2e/tsconfig.json
+++ b/agon_ui/e2e/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node", "@playwright/test"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["."]
+}

--- a/agon_ui/eslint.config.js
+++ b/agon_ui/eslint.config.js
@@ -25,4 +25,16 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // e2e specs/config run under Node (via Playwright's test runner), not
+    // the browser — they need `process` in scope, and don't use the
+    // React-specific rules above.
+    files: ['e2e/**/*.ts'],
+    languageOptions: {
+      globals: globals.node,
+    },
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 )

--- a/agon_ui/package-lock.json
+++ b/agon_ui/package-lock.json
@@ -45,6 +45,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@playwright/test": "^1.62.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
@@ -2363,6 +2364,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -7843,6 +7860,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/agon_ui/package.json
+++ b/agon_ui/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "format": "eslint . --fix",
     "preview": "vite preview",
-    "generate": "openapi-typescript ../schema.json --output ./src/types/api.ts"
+    "generate": "openapi-typescript ../schema.json --output ./src/types/api.ts",
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
+    "test:e2e:ui": "playwright test --config=e2e/playwright.config.ts --ui"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -49,6 +51,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@playwright/test": "^1.62.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/agon_ui/src/components/agon/PlayerSideEditor.tsx
+++ b/agon_ui/src/components/agon/PlayerSideEditor.tsx
@@ -167,7 +167,11 @@ export function PlayerSideEditor({
                   {p.name.slice(0, 2).toUpperCase()}
                 </span>
               )}
-              <span className="flex-1 truncate text-sm">{p.name}</span>
+              {/* data-testid: a tagged player's name has no other stable
+                  accessible hook — their "Remove" button is labelled by it,
+                  but that's an action, not the name itself. See
+                  agon_ui/e2e/README.md's locator guidance. */}
+              <span className="flex-1 truncate text-sm" data-testid="tagged-player-name">{p.name}</span>
               {isYou && (
                 <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
                   you

--- a/agon_ui/src/pages/LiveScoringPage.tsx
+++ b/agon_ui/src/pages/LiveScoringPage.tsx
@@ -291,12 +291,15 @@ function FootballLiveScoringPage({ match }: { match: Match }) {
         <div className="flex items-center justify-between">
           <p className="flex-1 truncate text-sm font-medium">{nameA}</p>
           <div className="px-3 text-center">
-            <div className="text-3xl font-medium tracking-tight">
+            {/* data-testid: the score/phase here is just digits and a status
+                word with no other accessible name to hang a locator off —
+                see agon_ui/e2e/README.md's locator guidance. */}
+            <div className="text-3xl font-medium tracking-tight" data-testid="live-score">
               {goalsFor(aId)}
               <span className="text-muted-foreground">–</span>
               {goalsFor(bId)}
             </div>
-            <div className="mt-0.5 text-xs text-primary">
+            <div className="mt-0.5 text-xs text-primary" data-testid="live-phase">
               {minute !== null && `${minute}' · `}
               {phaseLabel(phase)}
             </div>


### PR DESCRIPTION
Adds a comprehensive end-to-end test suite for the Agon UI using Playwright, complementing the existing `agon_tests` API integration tests. These tests drive a real browser against a real Supabase instance and backend, catching UI-specific bugs that API tests cannot (broken forms, wrong endpoints called, auth gates).

## Key Changes

- **E2E test infrastructure** (`agon_ui/e2e/`):
  - `playwright.config.ts`: Configures Playwright to run tests serially against a single shared test account and backend (no parallelization to avoid data races)
  - `tests/auth.setup.ts`: One-time login via the real `LoginForm` email/password path, saving session state for all tests to reuse
  - `tests/match-feed.spec.ts`: Tests creating a match via the form and verifying it appears in the feed
  - `tests/football-live-scoring.spec.ts`: Full football live-scoring flow (goals with assists, undo, half-time, finishing)
  - `support/logMatch.ts` and `support/liveScoring.ts`: Reusable helpers for match creation and live-scoring operations

- **Test account provisioning** (`agon_infra/index.ts`):
  - Adds `e2eTestEmail` and `e2eTestPassword` Pulumi config values (encrypted, single source of truth)
  - Follows the same pattern as `agonTestJwtPrivateKey` — CI fetches credentials live via `pulumi config get` rather than duplicating into GitHub secrets

- **CI integration** (`.github/workflows/test-ui-e2e.yml`):
  - New workflow job that reads test credentials from Pulumi, installs Playwright, and runs the suite against a deployed UI
  - Uploads HTML report as artifact on failure
  - Integrated into `release.yml` to run after staging deployment

- **Local development** (`Makefile`):
  - `make test-ui-e2e`: Runs tests locally (reads `E2E_TEST_EMAIL`/`E2E_TEST_PASSWORD`/`E2E_BASE_URL` from environment)
  - `make test-ui-e2e-staging`: Runs against staging, pulling test account from Pulumi config

- **Documentation** (`agon_ui/e2e/README.md`):
  - Comprehensive guide explaining why these tests exist (browser-only bugs), how auth works (real Supabase account, not minted JWT), test account provisioning, running locally vs. CI, and locator best practices

- **Source code annotations**:
  - Added `data-testid` attributes to `LiveScoringPage.tsx` (`live-score`, `live-phase`) and `PlayerSideEditor.tsx` (`tagged-player-name`) for stable test selectors
  - Updated `agon_ui/eslint.config.js` to allow Node globals in e2e tests
  - Updated `agon_ui/README.md` to document the e2e suite

## Implementation Details

- **Auth strategy**: Tests use the real email/password login path (not Google OAuth, which requires interactive consent) against a fixed Supabase test account. This exercises the actual browser-side auth code (`useAuth`, profile gate, `supabase.auth.getSession()`) that API tests bypass entirely.
- **Test isolation**: Tests run serially (`workers: 1`) against one shared account and backend to avoid data races on live-scoring mutations. Each test creates its own match with a unique suffix to prevent collisions across runs.
- **Locator priority**: Tests prefer `getByRole`/`getByLabel`/`getByPlaceholder` (accessible, resilient to design changes) over CSS selectors, with `data-testid` only for elements with no accessible name.
- **No cleanup**: Created matches accumulate in the feed (named `E2E football …` / `E2E Opposition …` for easy spotting), matching real user behavior.

https://claude.ai/code/session_01NGcwBYyLY25Ri8X266U1eB