### PR TITLE
Fix live event deletion priority and OpenAPI client deserialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,23 @@ generate-schema:
 	# already-correct) field defaults when absent. See docs/openapi-client.md.
 	find openapi_client/src/models -name '*.rs' -exec \
 		perl -0pi -e 's/#\[serde\(rename = "type"\)\]\n(\s*)pub r#type: Type,/#[serde(rename = "type", default)]\n$1pub r#type: Type,/g' {} +
+	# Post-process: `LiveEventInput` nests a second discriminated union (each
+	# sport's own `kind`-tagged event union) inside its own `sport`-tagged
+	# variants. The generator handles that inner `oneOf` correctly wherever
+	# it's referenced directly (`FootballLiveEvent`/`CricketLiveEvent`/
+	# `NetballLiveEvent` each come out as a proper enum with every kind), but
+	# for the *outer* variant it instead flattens `allOf[{sport}, {$ref to
+	# the inner oneOf}]` into one struct that merges every kind's fields
+	# together and collapses the inner discriminator down to a single-value
+	# enum (whichever kind happened to be generated last) — so deserializing
+	# any other kind fails with "unknown variant". Point the outer variants
+	# at the correctly-generated standalone enums instead of the broken
+	# merged structs; serde's internally-tagged (`tag = "..."`) enums nest
+	# fine (both discriminators live on the same flat JSON object), so this
+	# is a pure type-reference swap, no behavior change beyond fixing the
+	# bug. See docs/openapi-client.md.
+	perl -pi -e 's/models::LiveEventInput(Football|Cricket|Netball)LiveEvent/models::$1LiveEvent/g' \
+		openapi_client/src/models/live_event_input.rs
 
 generate:
 	make generate-schema

--- a/agon_core/src/dao/live_score_ops.rs
+++ b/agon_core/src/dao/live_score_ops.rs
@@ -299,9 +299,16 @@ enum DeleteLiveEventFailure {
 /// them in) rather than by inspecting each reason's `item` payload, the same
 /// way `super::is_transaction_conditional_failure` treats the list
 /// elsewhere in this crate — just distinguishing *which* item failed instead
-/// of collapsing straight to a bool. `EventMissing` takes priority when both
-/// conditions failed at once: the event being gone outright is the more
-/// fundamental fact to report.
+/// of collapsing straight to a bool. `NotTip` takes priority when both
+/// conditions failed at once: whenever `seq` isn't the current tip, that's
+/// the more fundamental fact to report, even if the item at `seq` also
+/// happens to be physically gone (e.g. a retried undo replaying a seq that
+/// a previous call already deleted — the counter has moved on *and* nothing
+/// lives there any more; "not the tip" is still the right rejection, not a
+/// bare "not found" that would suggest `seq` was never valid at all).
+/// `EventMissing` alone (tip condition satisfied, delete condition failed)
+/// means `seq` genuinely is the current counter value but nothing was ever
+/// written there.
 fn delete_live_event_failure(
     err: &SdkError<TransactWriteItemsError>,
 ) -> Option<DeleteLiveEventFailure> {
@@ -317,10 +324,10 @@ fn delete_live_event_failure(
             .get(i)
             .is_some_and(|r| r.code() == Some("ConditionalCheckFailed"))
     };
-    if failed(0) {
-        Some(DeleteLiveEventFailure::EventMissing)
-    } else if failed(1) {
+    if failed(1) {
         Some(DeleteLiveEventFailure::NotTip)
+    } else if failed(0) {
+        Some(DeleteLiveEventFailure::EventMissing)
     } else {
         None
     }


### PR DESCRIPTION
## Summary
This PR fixes two issues: (1) corrects the failure-case priority when deleting live events to properly distinguish between "not the current tip" vs. "event missing", and (2) works around an OpenAPI code generator bug that breaks deserialization of nested discriminated unions in `LiveEventInput`.

## Changes

### Live Event Deletion Failure Priority (`agon_core/src/dao/live_score_ops.rs`)
- **Swapped the order of failure checks** in `delete_live_event_failure()`: now checks the "not tip" condition (index 1) before the "event missing" condition (index 0)
- **Updated documentation** to clarify the priority: when both conditions fail, "not the tip" is the more fundamental fact to report, even if the item at that sequence is also physically gone (e.g., a retried undo replaying a sequence that a previous call already deleted)
- This ensures clients receive the correct rejection reason: "not the tip" indicates the counter has moved on, while "event missing" alone means the sequence is current but nothing was written there

### OpenAPI Client Post-Processing (`Makefile`)
- **Added post-processing step** to the `generate-schema` target that fixes a code generator bug in the auto-generated `LiveEventInput` types
- The generator incorrectly flattens the outer `sport`-tagged variant (which contains an inner `kind`-tagged union) into a single struct that merges all kinds' fields and collapses the inner discriminator
- **Solution**: Replace the broken merged struct references with the correctly-generated standalone enums (`FootballLiveEvent`, `CricketLiveEvent`, `NetballLiveEvent`) in `live_event_input.rs`
- This is a pure type-reference swap with no behavior change—serde's internally-tagged enums nest correctly since both discriminators live on the same flat JSON object
- Fixes deserialization failures when the outer variant's kind doesn't match the last-generated inner kind

## Implementation Details
- The live event deletion fix ensures proper error semantics for retry logic and client error handling
- The OpenAPI client fix is a targeted workaround documented in `docs/openapi-client.md` and applied only to the affected generated file, preserving the rest of the auto-generated code

https://claude.ai/code/session_017GGZ4vKb33wUDMLbTZHEME