### PR TITLE
Drop 'kudos' label from match card button, keep icon + count

### DIFF
--- a/agon_ui/src/components/agon/MatchCard.tsx
+++ b/agon_ui/src/components/agon/MatchCard.tsx
@@ -477,7 +477,7 @@ export function MatchCard({
           )}
         >
           <Flame className={cn('size-3.5', i_liked && 'fill-current')} />{' '}
-          {like_count} kudos
+          {like_count}
         </button>
         <button
           type="button"


### PR DESCRIPTION
The kudos button now just shows the flame icon and count, matching
the comments button's icon+count style. Accessibility label text is
unchanged.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019vNkZ8kQmGMfBFBZdN64wX