### PR TITLE
Collect first and last name separately in the UI

### DIFF
--- a/agon_ui/src/components/agon/EditProfileDialog.tsx
+++ b/agon_ui/src/components/agon/EditProfileDialog.tsx
@@ -14,6 +14,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { ImageUploadField } from './ImageUploadField'
+import { joinName, splitName } from '@/lib/names'
 
 type UserProfile = components['schemas']['UserProfile']
 
@@ -23,26 +24,31 @@ export interface EditProfileDialogProps {
 }
 
 /**
- * Edit the current user's own profile: display name + profile picture. The
- * picture is uploaded via the Asset API (see `ImageUploadField`); on save we
- * PATCH `/users/me` with the new name and, if a new image was uploaded, its
+ * Edit the current user's own profile: first/last name + profile picture.
+ * The API only stores a single `name` string, so the stored name is split
+ * into first/last for editing and joined back before saving. The picture is
+ * uploaded via the Asset API (see `ImageUploadField`); on save we PATCH
+ * `/users/me` with the new name and, if a new image was uploaded, its
  * `profile_image_asset_id`. Invalidates the cached profile so the header
  * re-renders with the new image/name.
  */
 export function EditProfileDialog({ profile, children }: EditProfileDialogProps) {
   const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
-  const [name, setName] = useState(profile.name)
+  const [firstName, setFirstName] = useState(() => splitName(profile.name).firstName)
+  const [lastName, setLastName] = useState(() => splitName(profile.name).lastName)
   const [assetId, setAssetId] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const canSave = firstName.trim() !== '' && lastName.trim() !== ''
+
   const handleSave = async () => {
-    if (!name.trim()) return
+    if (!canSave) return
     setSaving(true)
     setError(null)
     try {
-      const body: components['schemas']['UpdateUserInput'] = { name: name.trim() }
+      const body: components['schemas']['UpdateUserInput'] = { name: joinName(firstName, lastName) }
       if (assetId) body.profile_image_asset_id = assetId
       const { error: patchErr } = await fetchClient.PATCH('/users/me', { body })
       if (patchErr) throw new Error('Could not save your profile')
@@ -60,7 +66,9 @@ export function EditProfileDialog({ profile, children }: EditProfileDialogProps)
     setOpen(next)
     if (next) {
       // Reset to current values each time it opens.
-      setName(profile.name)
+      const split = splitName(profile.name)
+      setFirstName(split.firstName)
+      setLastName(split.lastName)
       setAssetId(null)
       setError(null)
     }
@@ -86,14 +94,26 @@ export function EditProfileDialog({ profile, children }: EditProfileDialogProps)
             />
           </div>
 
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="edit-name">Display name</Label>
-            <Input
-              id="edit-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="Your name"
-            />
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-first-name">First name</Label>
+              <Input
+                id="edit-first-name"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="First name"
+              />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-last-name">Last name</Label>
+              <Input
+                id="edit-last-name"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                placeholder="Last name"
+              />
+            </div>
           </div>
 
           {error && <p className="text-sm text-destructive">{error}</p>}
@@ -107,7 +127,7 @@ export function EditProfileDialog({ profile, children }: EditProfileDialogProps)
           >
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={saving || !name.trim()}>
+          <Button onClick={handleSave} disabled={saving || !canSave}>
             {saving ? 'Saving…' : 'Save'}
           </Button>
         </DialogFooter>

--- a/agon_ui/src/components/auth/CreateProfileForm.tsx
+++ b/agon_ui/src/components/auth/CreateProfileForm.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { $api } from '@/lib/api-client'
 import { useAuth } from '@/hooks/useAuth'
+import { joinName, splitName } from '@/lib/names'
 
 interface CreateProfileFormProps {
   /** The verified account email (from Supabase). Shown read-only; the API takes
@@ -12,18 +13,23 @@ interface CreateProfileFormProps {
   onProfileCreated: () => void
 }
 
-/** Best-effort display name from the Supabase identity (Google OAuth etc.). */
-function suggestedName(user: ReturnType<typeof useAuth>['user']): string {
+/** Best-effort first/last name from the Supabase identity (Google OAuth etc.). */
+function suggestedName(user: ReturnType<typeof useAuth>['user']): { firstName: string; lastName: string } {
   const profileData = {
     ...user?.user_metadata,
     ...user?.identities?.[0]?.identity_data,
   }
-  return profileData.name || profileData.full_name || ''
+  if (profileData.given_name || profileData.family_name) {
+    return { firstName: profileData.given_name || '', lastName: profileData.family_name || '' }
+  }
+  const fullName = profileData.name || profileData.full_name || ''
+  return splitName(fullName)
 }
 
 export function CreateProfileForm({ email, onProfileCreated }: CreateProfileFormProps) {
   const { user } = useAuth()
-  const [name, setName] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
 
   const createUser = $api.useMutation('post', '/users', {
     onSuccess: () => onProfileCreated(),
@@ -32,13 +38,16 @@ export function CreateProfileForm({ email, onProfileCreated }: CreateProfileForm
   // Pre-fill the name from the OAuth identity, if present.
   useEffect(() => {
     const suggestion = suggestedName(user)
-    if (suggestion) setName(suggestion)
+    if (suggestion.firstName) setFirstName(suggestion.firstName)
+    if (suggestion.lastName) setLastName(suggestion.lastName)
   }, [user])
+
+  const canSubmit = firstName.trim() !== '' && lastName.trim() !== ''
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    if (!name.trim()) return
-    createUser.mutate({ body: { name: name.trim() } })
+    if (!canSubmit) return
+    createUser.mutate({ body: { name: joinName(firstName, lastName) } })
   }
 
   return (
@@ -46,7 +55,7 @@ export function CreateProfileForm({ email, onProfileCreated }: CreateProfileForm
       <div className="text-center mb-6">
         <h2 className="text-2xl font-bold mb-2">Complete your profile</h2>
         <p className="text-muted-foreground">
-          Choose the display name others will see.
+          Tell us your name so others can recognize you.
         </p>
       </div>
 
@@ -62,16 +71,30 @@ export function CreateProfileForm({ email, onProfileCreated }: CreateProfileForm
           />
         </div>
 
-        <div>
-          <Label htmlFor="name">Display name</Label>
-          <Input
-            id="name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Enter your name"
-            required
-          />
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="first-name">First name</Label>
+            <Input
+              id="first-name"
+              type="text"
+              value={firstName}
+              onChange={(e) => setFirstName(e.target.value)}
+              placeholder="First name"
+              required
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="last-name">Last name</Label>
+            <Input
+              id="last-name"
+              type="text"
+              value={lastName}
+              onChange={(e) => setLastName(e.target.value)}
+              placeholder="Last name"
+              required
+            />
+          </div>
         </div>
 
         {createUser.isError && (
@@ -84,7 +107,7 @@ export function CreateProfileForm({ email, onProfileCreated }: CreateProfileForm
 
         <Button
           type="submit"
-          disabled={createUser.isPending || !name.trim()}
+          disabled={createUser.isPending || !canSubmit}
           className="w-full"
         >
           {createUser.isPending ? 'Creating profile…' : 'Create profile'}

--- a/agon_ui/src/lib/names.ts
+++ b/agon_ui/src/lib/names.ts
@@ -1,0 +1,24 @@
+/**
+ * The API only stores a single `name` string (see CLAUDE.md — backend is not
+ * being changed). The UI collects first/last name separately for a better
+ * signup/edit experience, then joins them into that one field before
+ * sending anything to the API, and splits it back apart when displaying
+ * an existing name in an editable form.
+ */
+
+/** Join first + last name into the single string the API expects. */
+export function joinName(firstName: string, lastName: string): string {
+  return [firstName.trim(), lastName.trim()].filter(Boolean).join(' ')
+}
+
+/**
+ * Split a stored full name back into first/last name for editing.
+ * Best-effort: everything up to the first space is the first name, the
+ * remainder (if any) is the last name.
+ */
+export function splitName(fullName: string): { firstName: string; lastName: string } {
+  const trimmed = fullName.trim()
+  if (!trimmed) return { firstName: '', lastName: '' }
+  const [firstName, ...rest] = trimmed.split(/\s+/)
+  return { firstName, lastName: rest.join(' ') }
+}


### PR DESCRIPTION
The API still stores a single name string, so the sign-up form and
edit-profile dialog now collect first/last name and join them into
one string before sending it to the API, splitting a stored name
back apart when populating the edit form. No backend or generated
API-client changes.