### PR TITLE
Add PWA push notification support (Firebase Web SDK)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,10 @@ AGON_ASSETS_BUCKET=agon-assets
 # local dev); set it to the verbatim JSON of a GCP service-account key with the
 # "Firebase Cloud Messaging API Admin" role to enable it.
 # AGON_FCM_SERVICE_ACCOUNT_JSON={"type":"service_account","project_id":"...","private_key":"...","client_email":"..."}
+# The web app's public URL, used to build the link a push notification opens
+# (e.g. https://agon.staging.get-agon.com/matches/abc123). Optional — unset
+# just means push notifications open the app with no deep link.
+# AGON_UI_URL=https://agon.staging.get-agon.com
 
 # Observability (OTLP export of logs, traces, metrics). See docs/observability.md.
 # Leave OTEL_EXPORTER_OTLP_ENDPOINT UNSET for local dev — the apps then log JSON

--- a/agon_core/src/push.rs
+++ b/agon_core/src/push.rs
@@ -7,7 +7,9 @@
 //! Shared by the worker (which sends a push whenever a `NotificationRecord`
 //! is created — see `agon_worker/src/handlers/push.rs`).
 
-use google_fcm1::api::{Message, Notification, SendMessageRequest};
+use std::collections::HashMap;
+
+use google_fcm1::api::{Message, SendMessageRequest};
 use google_fcm1::hyper_rustls::{self, HttpsConnector};
 use google_fcm1::hyper_util::client::legacy::connect::HttpConnector;
 use google_fcm1::hyper_util::{self, client::legacy::Client as HyperClient};
@@ -65,16 +67,38 @@ impl PushClient {
         })
     }
 
-    /// Send one push notification to a device's registration token.
-    pub async fn send(&self, push_token: &str, title: &str, body: &str) -> PushResult<PushOutcome> {
+    /// Send one push notification to a device's registration token, optionally
+    /// carrying a `link` to open (a full URL — see `agon_worker::handlers::push`
+    /// for how it's built) when the notification is clicked.
+    ///
+    /// Deliberately sent as a **data-only** message (everything — including
+    /// title/body — in `data`, `notification` left unset) rather than FCM's
+    /// `notification` field: on web, a message with a `notification` payload
+    /// is auto-displayed by the browser using its own default handling
+    /// whenever the page isn't in the foreground, which bypasses our service
+    /// worker's `onBackgroundMessage` entirely — so a click on it can't carry
+    /// our `link` anywhere. Data-only messages always reach
+    /// `onBackgroundMessage`, giving us full control over both the display
+    /// and the click behavior. See public/firebase-messaging-sw.js.
+    pub async fn send(
+        &self,
+        push_token: &str,
+        title: &str,
+        body: &str,
+        link: Option<&str>,
+    ) -> PushResult<PushOutcome> {
+        let mut data = HashMap::from([
+            ("title".to_string(), title.to_string()),
+            ("body".to_string(), body.to_string()),
+        ]);
+        if let Some(link) = link {
+            data.insert("link".to_string(), link.to_string());
+        }
+
         let request = SendMessageRequest {
             message: Some(Message {
                 token: Some(push_token.to_string()),
-                notification: Some(Notification {
-                    title: Some(title.to_string()),
-                    body: Some(body.to_string()),
-                    image: None,
-                }),
+                data: Some(data),
                 ..Default::default()
             }),
             validate_only: None,

--- a/agon_infra/Pulumi.staging.yaml
+++ b/agon_infra/Pulumi.staging.yaml
@@ -14,6 +14,7 @@ config:
   agon_infra:agonUiImage: ghcr.io/jelgar/agon_ui:sha-aabc4ad
   agon_infra:supabaseAnonKey: sb_publishable_snWJggcOaut2Cce4srqJ2w_CqJhHTRx
   agon_infra:supabaseUrl: https://gkebmzhvdbsktamfdsil.supabase.co
+  agon_infra:firebaseVapidKey: BONN6WrqpQJwhM8QwzMcCnia4an9KBsQmH1EWndMSdYvqlWCV6OW0PfPlD70L80rHl9W-vx4h8oe9FETSbeT-fo
   aws:region: eu-west-1
   aws:accessKey:
     secure: AAABAJBgfjzGVypxRD8oOluoYaZ6+rkRuJ0dvGpKYNzyRxepovpRkwDZli9rYS40frNSJg==

--- a/agon_infra/index.ts
+++ b/agon_infra/index.ts
@@ -10,6 +10,11 @@ import * as tls from "@pulumi/tls";
 const config = new pulumi.Config();
 const subdomainPrefix = pulumi.getStack();
 const baseDomain = `${subdomainPrefix}.get-agon.com`;
+// The UI's public URL — same host as `fullDomain` further down (kept as a
+// separate constant: that one's a bare hostname for the Ingress `host`
+// field, this is a full URL the worker uses to build push-notification deep
+// links, needed up here since it's declared well before `fullDomain` is).
+const agonUiUrl = `https://agon.${baseDomain}`;
 
 // pulumi config set --secret privateKeyBase64 "$(cat ~/.ssh/pulumi_agon_key | base64)"
 const privateKeyBase64 = config.requireSecret("privateKeyBase64");
@@ -1735,6 +1740,12 @@ new k8s.apps.v1.Deployment("agon-worker-deployment", {
 										key: "AGON_FCM_SERVICE_ACCOUNT_JSON",
 									}
 								},
+							},
+							// The UI's public URL, so push notifications can carry a full
+							// deep-link (see handlers::push::push_link in agon_worker).
+							{
+								name: "AGON_UI_URL",
+								value: agonUiUrl,
 							},
 							// Temporal connection. The SDK config loader reads these
 							// (TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE); it otherwise defaults to

--- a/agon_infra/index.ts
+++ b/agon_infra/index.ts
@@ -1778,6 +1778,44 @@ new k8s.apps.v1.Deployment("agon-ui-deployment", {
 								name: "VITE_SUPABASE_ANON_KEY",
 								value: config.get("supabaseAnonKey"),
 							},
+							// Firebase Web SDK config for push notifications — all
+							// public/client-safe values, pulled straight from the
+							// firebaseWebApp / firebaseWebConfig resources above rather
+							// than copy-pasted, same spirit as the Supabase pair (just
+							// not manual, since these ARE automatable).
+							{
+								name: "VITE_FIREBASE_API_KEY",
+								value: firebaseWebConfig.apply(c => c.apiKey),
+							},
+							{
+								name: "VITE_FIREBASE_AUTH_DOMAIN",
+								value: firebaseWebConfig.apply(c => c.authDomain),
+							},
+							{
+								name: "VITE_FIREBASE_PROJECT_ID",
+								value: gcpProjectId,
+							},
+							{
+								name: "VITE_FIREBASE_STORAGE_BUCKET",
+								value: firebaseWebConfig.apply(c => c.storageBucket),
+							},
+							{
+								name: "VITE_FIREBASE_MESSAGING_SENDER_ID",
+								value: firebaseWebConfig.apply(c => c.messagingSenderId),
+							},
+							{
+								name: "VITE_FIREBASE_APP_ID",
+								value: firebaseWebApp.appId,
+							},
+							// The one piece that isn't automatable (see the VAPID-key
+							// comment above firebaseWebConfig) — unset until someone
+							// pastes it in via `pulumi config set firebaseVapidKey`, which
+							// just leaves push notifications disabled client-side (see
+							// isFirebaseConfigured in agon_ui/src/lib/firebase.ts).
+							{
+								name: "VITE_FIREBASE_VAPID_KEY",
+								value: config.get("firebaseVapidKey"),
+							},
 						],
 					},
 				],

--- a/agon_ui/.env.example
+++ b/agon_ui/.env.example
@@ -1,2 +1,18 @@
 VITE_SUPABASE_URL=your_supabase_project_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# Firebase Web SDK config for push notifications (see src/lib/firebase.ts).
+# All public/client-safe values — pull them from the `firebaseWebConfig` /
+# `firebaseWebApp` Pulumi outputs in agon_infra (or Firebase Console → Project
+# Settings → General → Your apps → the "agon-pwa" web app). Leave unset to
+# develop with push notifications disabled — everything else works fine.
+VITE_FIREBASE_API_KEY=your_firebase_api_key
+VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your_gcp_project_id
+VITE_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+VITE_FIREBASE_APP_ID=your_firebase_app_id
+# The *public* half of the Web Push key pair — Console → Project Settings →
+# Cloud Messaging → Web configuration → Generate key pair. Not automatable
+# (no Google API for it); see agon_infra/index.ts for details.
+VITE_FIREBASE_VAPID_KEY=your_web_push_vapid_key

--- a/agon_ui/package-lock.json
+++ b/agon_ui/package-lock.json
@@ -29,6 +29,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.6.0",
+        "firebase": "^12.18.0",
         "lucide-react": "^0.513.0",
         "openapi-fetch": "^0.14.0",
         "openapi-react-query": "^0.5.0",
@@ -2154,6 +2155,640 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.15.0.tgz",
+      "integrity": "sha512-Aj7TbFdAIWZdkX8JfdDStERpR35g6WNs+7XhNPtFLFOizUotj6k4N/D8HJkR45165HhnMJBe4hjOeeaxnnn56Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.24.tgz",
+      "integrity": "sha512-OfIAcIIwoqXjBzS+DnUQpOZ7i3ePaNFg83KPpDWjBZUKJmqMwzzAtLJqmKZOkQnW8im6vFR6f2I3M/9hxVd+QA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.30.tgz",
+      "integrity": "sha512-uVZEKlLaW4AHAhv8zoN9cTmveX6v86AVqcJ4LCaRCMTChTH8/NsjbisTq1lpBfWCLWS1spqwSHB4vol/YSCdMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.24",
+        "@firebase/analytics-types": "0.8.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.5.tgz",
+      "integrity": "sha512-kdnooE7Bis2jEnsqcerRwn/UQpH5D3uvHpku7OdUM9TJN3omlu6iYtbyAQ6XkAJRgJtO0aNf9OOkW8J6D59oCA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.16.1.tgz",
+      "integrity": "sha512-tjUEorFyKrurH7PbLWv9zDHRuU4mLefgD/yY38D584ziorIRlQz/PVjx4c/SCGyCuUlmyzt72mK+Lh+COAywNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.13.1.tgz",
+      "integrity": "sha512-l8y3dmnhodXks/APAwx4tWqRl3tk8b9874KF1FJyKg1DIU+kMD0l52iz7S9/MW+eK8k6cjJg0G0iJ5KQAsQpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.7.tgz",
+      "integrity": "sha512-fBb/xSMyIKv1nDmccfzz3IAGBzx/cQOxmZai66rJzifb1hMMkztf824Xx7LhpTUe7HNUbXwY90IvJ66fi8q6yg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.13.1",
+        "@firebase/app-check-types": "0.5.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.5.tgz",
+      "integrity": "sha512-qId34pVZ2CXTmtu4ofW5leiI93DvnOvIcr/5GT7MZPw5WXAi6nZoU+g9cNRgl7K90UJSbK0cXxten4meYMPyZg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.5.tgz",
+      "integrity": "sha512-+DF4gzFrlwGFyky38o4T/YN/r51l70yCtJ2HTkwmRj8FCMwPjm4hLH4fQbj6BUvzkiFqliBkitFsRpf1/YZkWA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.17.tgz",
+      "integrity": "sha512-5GdJWobqs6jbNYOnaQiSa4Ng8gnFerhqr7nY+v5jlnT7o9QbEeIZRLPQpnLe0TxYSWfRV2lAMbyR0kbXeIos9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.16.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.6.tgz",
+      "integrity": "sha512-yPLahy7Esfu2w/yme3msVK4xTkDXQqq6szfQn8yVOQpCKiT5GVFjqNpLbuz6NkX0WuTwUidkmPewW3r4xkvpeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.2"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.5.tgz",
+      "integrity": "sha512-1AXoBJqBVD8WL8FZYo3S2GmJF9YUoom6Y6ngMxOSkzzhW5sT83pLchb6TGFgxes91dfXx8s/VYc5VrLDNqpLog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.10.tgz",
+      "integrity": "sha512-Bvklg2nL7BrBFCAqdsleW8fse9Jh0fARqJPlJmA40uermfWx1bJiO7dnKyZN3J39d2TFVd4VJXtg3i6Wg92/YQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.5",
+        "@firebase/auth-types": "0.13.2",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.6.tgz",
+      "integrity": "sha512-FgwZqDrBqgK0BHI70QTv1v/5wmuDF9f8fsJFvKSxoRlK2PPfSQtZAk2jhXu4pe9BZzFi/e4UYusU/bEQHdf6Qg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.2.tgz",
+      "integrity": "sha512-OU+miuoSxIWYN7GT291d2ylVJBL3k/OePo7/JDSoQtkFQoEiGBc4AHuMjj/seqFIsHrqnjrAfRCk4pfufoJolQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.5.tgz",
+      "integrity": "sha512-vuFDcL91Q+2ZuBJkyOh86T4q0B4ffNTDjc/A38tybO56odQABxRTFLTIowCWqAKeIcgo37GowWMVgFF73gD8Qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.4.tgz",
+      "integrity": "sha512-su1aGWlzhxb+xtggCUSsufJn1FDa06SBDK71y+fpQ+g2zMhMExik6FUv/odkKzOF/xfWVjabCbWBcjJY3MceDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.5.tgz",
+      "integrity": "sha512-/JGpvszLoNXNgzilRXocigGfFF4hbcPA9wN1i1kjJx6oKkXgkHteZYl3lQs1lJX3ETDf6bv7zI15lPMVUp4sAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.7.tgz",
+      "integrity": "sha512-lBq9sJm8MnJINKJnkAKSOj2MbC66xGoSVCcGkPtstl+lkoKEBtD46qHLbuDgW/WbLPoKVm17RIN8BxHj+Z2F2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/database": "1.1.5",
+        "@firebase/database-types": "1.0.22",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      },
+      "peerDependenciesMeta": {
+        "@firebase/app": {
+          "optional": true
+        },
+        "@firebase/app-compat": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.22.tgz",
+      "integrity": "sha512-YAZNXsjY9EQQ+pKw/3ax8n5FgolHC7Qew7EY5RceYdl0R2ZP+kCv1O0DkKlcceue8uQCOreHCNN7PWVFpY1Nug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.6",
+        "@firebase/util": "1.15.3"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.17.1.tgz",
+      "integrity": "sha512-8lqPNf2w10CtYG+tayVjZO1pSyQpnhztQRudeD109VtXDzNbASTaYdO43sj5PMsDcWq0aOYY3RmJOUlXu9++jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "@firebase/webchannel-wrapper": "1.0.7",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "re2js": "^2.8.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.13.tgz",
+      "integrity": "sha512-l9dCewxMzzLOIhcwTjERCKxrWOn1kZ9JvwOQq9zZNq4I/Nbvb/B9njT230V61uvQ9qZ3/qpUG758D8DDTEFXnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/firestore": "4.17.1",
+        "@firebase/firestore-types": "3.0.5",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.5.tgz",
+      "integrity": "sha512-dbdMAQkMd5dwWc48eupz/Y6/E9ruat3+gY5lhVKscvvT/HnDBEEMzJW38zdKhgdnglZHGk2vUsJMOHAphMHGMA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.14.0.tgz",
+      "integrity": "sha512-DhuYFr0eMhp+s/PNEk6SiMsYkc00+XVOUeKbrl8MOzQNZI3SKQpqoDR1d+keNDAutwmHRWTUAdXBoVPD+xxVUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/messaging-interop-types": "0.2.6",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.5.0.tgz",
+      "integrity": "sha512-T3BDIToESZUHt7438wyKYMkRjKg3m1xAIux5fVpNvTRQlDOFLukWniQWBDhJ2znpU9kxMTR6+e31TVo8P15PZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/functions": "0.14.0",
+        "@firebase/functions-types": "0.6.5",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.5.tgz",
+      "integrity": "sha512-Zc0pURjthHXzSj54ZivCkzKDSV1r/wIpnmHdhq82q2yFFPVoncG/ZJjnVMiANvQfeww/QnElhzODpfwUucVwdA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.24",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.24.tgz",
+      "integrity": "sha512-Ui52ey8wHoWqkBbXRKJEKYWylI0JZogZmoLS+o8Anh1bxWtK27ZYjLla1UJAAdC5DCKLJ2qAp0VpJOjg8VOX1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.24.tgz",
+      "integrity": "sha512-8M5nlcWwYt881x83COP2odq5vgf+NgwJh+RMd4LRSv8JI1pxwDfgrDJOERrjTgfC9J5Z0vnQX4b1pdN914e0Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/installations-types": "0.5.5",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.5.tgz",
+      "integrity": "sha512-e9UYcju3puDl1vdrcKIi5dExzHLameOT/Tc61Q48PYwxtsM1NzZh/ikGbdBQTsbRgg0EMZqdPr0/m5ODUBobrg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.2.tgz",
+      "integrity": "sha512-J2VO4NFTc0xQFrxV1B/lm5balicm9cwuX2acR9Yn41fN8KgUeQFo+VJV222IqW2FPSXKDu9uo5WdQFWf9TPbYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.2.tgz",
+      "integrity": "sha512-KcZoqUu2ih4sLH91dW9tmyHjCR0IQyNzSLZunX5uq7cLeImXb4uO2I0wq5FACduO2I+FoTeWa2BtUv7Jpowqdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/messaging-interop-types": "0.2.6",
+        "@firebase/util": "1.15.3",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.29.tgz",
+      "integrity": "sha512-8Twe4CeYvAx8AzjBxyyQFKzinaMGGt13hPQBqaARQ2QZjagrEaqSVBe+Zy6F4L/vT8DV168yRgRu7W/RK7p+4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/messaging": "0.13.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.6.tgz",
+      "integrity": "sha512-MVzvkKe2V4H2dHu5oOxRfeKQcfTwWmCgnzsC4V1q3ixun5iiL8riCZ2qI35rDhCL4glPGiu0jHxDbpVNuTKfow==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.14.tgz",
+      "integrity": "sha512-9PH1XEZVHErxGdbXluvGz4Uyjw4W955H8v7Mv9rHIybRrg5F2Ac2tvf5+mSf5EtnxWNmxrD2WLnvMFaZP4sMrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.27.tgz",
+      "integrity": "sha512-O/ozTf/EbChN94Pk7bd1eUC0PAC36726AwsaiJyC0bZzSBWfLGSWASGPH5pebUWXQPJtGxIJYRkkbX5l0Qa+Hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/performance": "0.7.14",
+        "@firebase/performance-types": "0.2.5",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.5.tgz",
+      "integrity": "sha512-PRzOgB+/M+6AKlEkY8a9xy5Ff5SfZPIh4iShXhn2WAcL/euSbK7bdLqWysHduunNJhGFsXa22Ag3ixqL6rQtYg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.2.tgz",
+      "integrity": "sha512-Rii93DkXjM+RE/ytHdYa7EIiQLJbdBr+W8EEiqd/vbLCOC+1FdkDuRiumJBp6t3yewHGbdqbpjB3fk3z0cZ+8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.29.tgz",
+      "integrity": "sha512-mY7JtTISK6F4g4T0x3kVepr5cp0NXL7f5yjIUXXGaTrg4qUlFBWRbENaHaqZ78dwmNcLm24h/yPsOVRlDXEXhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/remote-config": "0.9.2",
+        "@firebase/remote-config-types": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.2.tgz",
+      "integrity": "sha512-i8k1omVfoAnaT1ZPv2FFjxMZrATYsO/GnFgHEj5+7fAJLzi8wLnGGv1WK06oEAD6ltrWXSO1HzeNyajn/NjMWw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.5.tgz",
+      "integrity": "sha512-r2tozN/BlEewLi70tJNUQPzWwbex9GM7NgXZsamHKQrjKEfcR0i4jGgHBKAKA4hbwiPE9eNMb3hcxWnDpeJZwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.5.tgz",
+      "integrity": "sha512-vO0tFPxXbKDKdlTu8tYT08S9t9ezUTJYEdLCULpWxWq2aq6zojwN1QmAB+1a50AI/g47GlWUJn1XPncm/PDZsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/storage": "0.14.5",
+        "@firebase/storage-types": "0.8.5",
+        "@firebase/util": "1.15.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.5.tgz",
+      "integrity": "sha512-GEDs5P+rNUfNcS+wxIdOLAHficife2YXtvTJnyi3ssrX11AAtBg+nDUdbYh8vuBzWehVQZPmztGUUnud4L+4yg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.3.tgz",
+      "integrity": "sha512-c/z/gaIlaaLZEuGbE6sLUuJ61tskg1JghvhcNQzW948ASBinbVBBRnZTC4b4yt4LaEtJQkYlyzqLHcutFwEIvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.7.tgz",
+      "integrity": "sha512-phBFwieDLvkZGYN9CE9ZFNEIoBVksprzsnCzQejCmCHtgwCXReeuRpoEGN9C4EbhONztv8NRV1tau6Rb9pONwQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
@@ -2191,6 +2826,37 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.16",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+      "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2381,6 +3047,63 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
@@ -4777,6 +5500,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -5168,6 +5900,20 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -5514,6 +6260,12 @@
       "peerDependencies": {
         "embla-carousel": "8.6.0"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",
@@ -5978,6 +6730,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6049,6 +6813,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.18.0.tgz",
+      "integrity": "sha512-XaL6tlE5Xd20ZDhckqOMIw+JJTET+wTdeZPxQ7ihc42oxRb7kWUyn/j1LO5V9dH1xq8Rv5R71Pv1fBCdIkt9Rw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.15.0",
+        "@firebase/analytics": "0.10.24",
+        "@firebase/analytics-compat": "0.2.30",
+        "@firebase/app": "0.16.1",
+        "@firebase/app-check": "0.13.1",
+        "@firebase/app-check-compat": "0.4.7",
+        "@firebase/app-compat": "0.5.17",
+        "@firebase/app-types": "0.9.6",
+        "@firebase/auth": "1.13.5",
+        "@firebase/auth-compat": "0.6.10",
+        "@firebase/data-connect": "0.7.4",
+        "@firebase/database": "1.1.5",
+        "@firebase/database-compat": "2.1.7",
+        "@firebase/firestore": "4.17.1",
+        "@firebase/firestore-compat": "0.4.13",
+        "@firebase/functions": "0.14.0",
+        "@firebase/functions-compat": "0.5.0",
+        "@firebase/installations": "0.6.24",
+        "@firebase/installations-compat": "0.2.24",
+        "@firebase/messaging": "0.13.2",
+        "@firebase/messaging-compat": "0.2.29",
+        "@firebase/performance": "0.7.14",
+        "@firebase/performance-compat": "0.2.27",
+        "@firebase/remote-config": "0.9.2",
+        "@firebase/remote-config-compat": "0.2.29",
+        "@firebase/storage": "0.14.5",
+        "@firebase/storage-compat": "0.4.5",
+        "@firebase/util": "1.15.3"
       }
     },
     "node_modules/flat-cache": {
@@ -6216,6 +7016,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -6461,6 +7270,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -6713,6 +7528,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -7392,6 +8216,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7410,6 +8240,12 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7984,6 +8820,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -8027,6 +8886,15 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/re2js": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-2.8.6.tgz",
+      "integrity": "sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/react": {
@@ -8293,6 +9161,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -8723,6 +9600,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -8818,6 +9709,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-comments": {
@@ -9515,11 +10418,40 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
@@ -9965,6 +10897,23 @@
         "workbox-core": "7.3.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -9992,6 +10941,15 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -10005,11 +10963,28 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/agon_ui/package.json
+++ b/agon_ui/package.json
@@ -35,6 +35,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
+    "firebase": "^12.18.0",
     "lucide-react": "^0.513.0",
     "openapi-fetch": "^0.14.0",
     "openapi-react-query": "^0.5.0",

--- a/agon_ui/public/firebase-messaging-sw.js
+++ b/agon_ui/public/firebase-messaging-sw.js
@@ -27,23 +27,29 @@ const messaging = firebase.messaging();
 // foreground case is handled in-app via `onMessage` (see
 // usePushNotifications.tsx), which just refreshes the notification queries
 // instead of popping a duplicate system notification.
+//
+// The backend (agon_core::push::PushClient::send) deliberately sends a
+// data-only message — title/body/link all under `payload.data`, nothing
+// under `payload.notification` — because a `notification` payload gets
+// auto-displayed by the browser using its own default handling whenever the
+// page isn't foregrounded, bypassing this handler entirely (so a click on it
+// couldn't carry `link` anywhere). Data-only always reaches us here.
 messaging.onBackgroundMessage((payload) => {
-  const { title, body } = payload.notification || {};
+  const { title, body, link } = payload.data || {};
   if (!title) return;
   self.registration.showNotification(title, {
     body,
     icon: '/pwa-192x192.png',
+    // Read back in notificationclick below. `link` is absent when the
+    // backend has no AGON_UI_URL configured — falls back to the app root.
+    data: { link },
   });
 });
 
-// Focus an existing tab, or open one, on click. Always lands on the app root
-// and lets it route from there — the backend's push payload only carries
-// title/body today (see agon_worker/src/handlers/push.rs), no deep link.
-// Follow-up: have push.rs's FCM `send()` attach a `data.link` (mirroring
-// NotificationsPage's `describe()`.href) and read it here instead of '/'.
+// Focus an existing tab already on that link, or open one, on click.
 self.addEventListener('notificationclick', (event) => {
   event.notification.close();
-  const url = self.location.origin + '/';
+  const url = event.notification.data?.link || self.location.origin + '/';
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
       for (const client of clients) {

--- a/agon_ui/public/firebase-messaging-sw.js
+++ b/agon_ui/public/firebase-messaging-sw.js
@@ -1,0 +1,55 @@
+// FCM background-message handler, registered at a custom scope
+// ('/firebase-cloud-messaging-push-scope') so it can coexist with the PWA's
+// own workbox-managed service worker at the root scope — Firebase's
+// documented approach for apps that already have another SW controlling '/'.
+// See src/hooks/usePushNotifications.tsx for the registration call.
+//
+// This is a plain static asset (not bundled by Vite), so it can't import
+// src/lib/firebase.ts's runtime env. Instead it reads the (public,
+// client-safe) Firebase config back off its own registration URL — passed as
+// a query string by the code that calls `serviceWorkerRegistration.register`.
+importScripts('https://www.gstatic.com/firebasejs/12.3.0/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/12.3.0/firebase-messaging-compat.js');
+
+const params = new URLSearchParams(self.location.search);
+firebase.initializeApp({
+  apiKey: params.get('apiKey'),
+  authDomain: params.get('authDomain'),
+  projectId: params.get('projectId'),
+  storageBucket: params.get('storageBucket'),
+  messagingSenderId: params.get('messagingSenderId'),
+  appId: params.get('appId'),
+});
+
+const messaging = firebase.messaging();
+
+// Only fires while the app isn't in the foreground (tab hidden/closed) — the
+// foreground case is handled in-app via `onMessage` (see
+// usePushNotifications.tsx), which just refreshes the notification queries
+// instead of popping a duplicate system notification.
+messaging.onBackgroundMessage((payload) => {
+  const { title, body } = payload.notification || {};
+  if (!title) return;
+  self.registration.showNotification(title, {
+    body,
+    icon: '/pwa-192x192.png',
+  });
+});
+
+// Focus an existing tab, or open one, on click. Always lands on the app root
+// and lets it route from there — the backend's push payload only carries
+// title/body today (see agon_worker/src/handlers/push.rs), no deep link.
+// Follow-up: have push.rs's FCM `send()` attach a `data.link` (mirroring
+// NotificationsPage's `describe()`.href) and read it here instead of '/'.
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = self.location.origin + '/';
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+      for (const client of clients) {
+        if (client.url === url && 'focus' in client) return client.focus();
+      }
+      if (self.clients.openWindow) return self.clients.openWindow(url);
+    }),
+  );
+});

--- a/agon_ui/src/App.tsx
+++ b/agon_ui/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-router-dom'
 import { Bell, Search } from 'lucide-react'
 import { AuthProvider, useAuth } from '@/hooks/useAuth'
+import { PushNotificationsProvider } from '@/hooks/usePushNotifications'
 import { LoginForm } from '@/components/auth/LoginForm'
 import { CreateProfileForm } from '@/components/auth/CreateProfileForm'
 import { InvitePreviewBanner } from '@/components/auth/InvitePreviewBanner'
@@ -238,7 +239,11 @@ function AuthenticatedApp() {
     )
   }
 
-  return <AppShell email={user.email || ''} onSignOut={signOut} />
+  return (
+    <PushNotificationsProvider>
+      <AppShell email={user.email || ''} onSignOut={signOut} />
+    </PushNotificationsProvider>
+  )
 }
 
 function App() {

--- a/agon_ui/src/components/agon/PushNotificationsBanner.tsx
+++ b/agon_ui/src/components/agon/PushNotificationsBanner.tsx
@@ -1,0 +1,56 @@
+import { Bell, BellOff, Loader2 } from 'lucide-react'
+import { usePushNotifications } from '@/hooks/usePushNotifications'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Opt-in prompt for push notifications on this device. Renders nothing when
+ * push isn't available (unconfigured Firebase, unsupported browser) or is
+ * already on — once enabled this makes room for a small "Turn off" control
+ * instead, so the nudge doesn't linger after it's been acted on.
+ */
+export function PushNotificationsBanner() {
+  const { status, error, enable, disable } = usePushNotifications()
+
+  if (status === 'unsupported') return null
+
+  if (status === 'on' || status === 'disabling') {
+    return (
+      <div className="mb-3 flex items-center justify-between gap-3 rounded-xl border bg-card px-4 py-2 text-sm text-muted-foreground">
+        <span className="flex items-center gap-2">
+          <Bell className="size-4" /> Push notifications are on for this device.
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={status === 'disabling'}
+          onClick={disable}
+        >
+          {status === 'disabling' && <Loader2 className="size-4 animate-spin" />}
+          Turn off
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-3 flex items-center justify-between gap-3 rounded-xl border bg-card px-4 py-3">
+      <div className="flex items-center gap-3">
+        <BellOff className="size-5 shrink-0 text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium">Get notified on this device</p>
+          <p className="text-xs text-muted-foreground">
+            {error ?? 'Invites, comments and more, even when Agon isn’t open.'}
+          </p>
+        </div>
+      </div>
+      <Button
+        size="sm"
+        disabled={status === 'enabling'}
+        onClick={enable}
+      >
+        {status === 'enabling' && <Loader2 className="size-4 animate-spin" />}
+        Enable
+      </Button>
+    </div>
+  )
+}

--- a/agon_ui/src/hooks/usePushNotifications.tsx
+++ b/agon_ui/src/hooks/usePushNotifications.tsx
@@ -1,0 +1,211 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import {
+  deleteToken,
+  getMessaging,
+  getToken,
+  isSupported,
+  onMessage,
+  type Messaging,
+} from 'firebase/messaging'
+import { fetchClient } from '@/lib/api-client'
+import {
+  firebaseConfig,
+  getFirebaseApp,
+  isFirebaseConfigured,
+  vapidKey,
+} from '@/lib/firebase'
+
+/**
+ * Whether this device has (or is getting) a registered FCM token.
+ *  - `unsupported`: no Firebase config shipped (e.g. the VAPID key hasn't
+ *    been generated yet), or the browser can't do FCM (missing SW/Notification
+ *    APIs, or firebase's own `isSupported()` check — Safari private mode etc).
+ *  - `off`: supported, but not registered on this device.
+ *  - `enabling` / `disabling`: a permission prompt or (un)registration is in flight.
+ *  - `on`: registered — this device receives push notifications.
+ *  - `error`: the last enable/disable attempt failed (see `error`).
+ */
+export type PushStatus = 'unsupported' | 'off' | 'enabling' | 'disabling' | 'on' | 'error'
+
+interface PushNotificationsContextType {
+  status: PushStatus
+  error: string | null
+  enable: () => void
+  disable: () => void
+}
+
+const PushNotificationsContext = createContext<PushNotificationsContextType | undefined>(
+  undefined,
+)
+
+/** localStorage flag distinguishing "never enabled" from "explicitly turned
+ *  off" — `Notification.permission` alone can't tell them apart (it can't be
+ *  un-requested via JS, so it stays 'granted' either way), and we only want to
+ *  silently re-register on app load in the former case. */
+const ENABLED_KEY = 'agon-push-enabled'
+
+/** Scopes the FCM service worker to its own path so it can coexist with the
+ *  PWA's workbox-managed service worker at the root scope — Firebase's own
+ *  documented approach for apps that already have another SW controlling '/'.
+ *  See public/firebase-messaging-sw.js for the other half of this. */
+const SW_SCOPE = '/firebase-cloud-messaging-push-scope'
+
+function swUrl(): string {
+  // firebase-messaging-sw.js is a plain static asset, not bundled by Vite, so
+  // it can't import src/lib/firebase.ts — pass the (public, client-safe)
+  // config on the URL instead; it reads these back off its own registration.
+  const params = new URLSearchParams(firebaseConfig)
+  return `/firebase-messaging-sw.js?${params.toString()}`
+}
+
+async function registerAndGetToken(): Promise<{ messaging: Messaging; token: string }> {
+  const registration = await navigator.serviceWorker.register(swUrl(), { scope: SW_SCOPE })
+  const messaging = getMessaging(getFirebaseApp())
+  // getToken/deleteToken are marked deprecated in favor of the newer
+  // register()/onRegistered() FID-based API, but that's a different
+  // registration-token model — ours (and the backend's push_token column)
+  // is the plain FCM registration token these calls still fully support.
+  const token = await getToken(messaging, { vapidKey, serviceWorkerRegistration: registration })
+  if (!token) throw new Error('No registration token available')
+  return { messaging, token }
+}
+
+async function postDevice(token: string): Promise<void> {
+  const { error } = await fetchClient.POST('/devices', {
+    body: { push_token: token, platform: 'web' },
+  })
+  if (error) throw new Error('Failed to register this device for push notifications')
+}
+
+async function unregisterDevice(token: string): Promise<void> {
+  const { error, response } = await fetchClient.POST('/devices/unregister', {
+    body: { push_token: token },
+  })
+  // 404 means it's already gone server-side — the end state we want either way.
+  if (error && response.status !== 404) {
+    throw new Error('Failed to unregister this device')
+  }
+}
+
+/**
+ * Owns the FCM registration lifecycle for this browser: silently re-registers
+ * on load if this device was previously enabled, exposes `enable`/`disable`
+ * for an explicit opt-in/out UI (see NotificationsPage), and refreshes the
+ * notification queries when a push arrives while the app is in the
+ * foreground (background pushes are handled entirely by the service worker —
+ * see public/firebase-messaging-sw.js).
+ *
+ * Mount once (in AuthenticatedApp, alongside AuthProvider) — consumers read
+ * state via `usePushNotifications()`.
+ */
+export function PushNotificationsProvider({ children }: { children: React.ReactNode }) {
+  const queryClient = useQueryClient()
+  const [status, setStatus] = useState<PushStatus>('off')
+  const [error, setError] = useState<string | null>(null)
+  const messagingRef = useRef<Messaging | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function init() {
+      if (!isFirebaseConfigured()) return setStatus('unsupported')
+      if (!('serviceWorker' in navigator) || !('Notification' in window)) {
+        return setStatus('unsupported')
+      }
+      if (!(await isSupported())) return setStatus('unsupported')
+      if (cancelled) return
+
+      if (localStorage.getItem(ENABLED_KEY) !== 'true' || Notification.permission !== 'granted') {
+        return setStatus('off')
+      }
+
+      try {
+        const { messaging, token } = await registerAndGetToken()
+        await postDevice(token)
+        if (cancelled) return
+        messagingRef.current = messaging
+        setStatus('on')
+      } catch {
+        // Config/browser looked fine but registration failed (offline, FCM
+        // hiccup, revoked permission out of sync with our flag, ...). Fall
+        // back to 'off' rather than 'error' — this is a silent background
+        // retry, not a user-initiated action, so there's nothing to surface.
+        if (!cancelled) setStatus('off')
+      }
+    }
+
+    init()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Foreground messages: the backend already wrote the NotificationRecord the
+  // push is about, so just refresh the same queries the in-app read paths
+  // invalidate after any notification change (see NotificationsPage).
+  useEffect(() => {
+    const messaging = messagingRef.current
+    if (status !== 'on' || !messaging) return
+    return onMessage(messaging, () => {
+      queryClient.invalidateQueries({ queryKey: ['notifications'] })
+      queryClient.invalidateQueries({ queryKey: ['notifications-unread-count'] })
+    })
+  }, [status, queryClient])
+
+  const enable = useCallback(() => {
+    setStatus('enabling')
+    setError(null)
+    void (async () => {
+      try {
+        const permission = await Notification.requestPermission()
+        if (permission !== 'granted') {
+          setStatus('off')
+          return
+        }
+        const { messaging, token } = await registerAndGetToken()
+        await postDevice(token)
+        messagingRef.current = messaging
+        localStorage.setItem(ENABLED_KEY, 'true')
+        setStatus('on')
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to enable push notifications')
+        setStatus('error')
+      }
+    })()
+  }, [])
+
+  const disable = useCallback(() => {
+    const messaging = messagingRef.current
+    if (!messaging) return
+    setStatus('disabling')
+    setError(null)
+    void (async () => {
+      try {
+        const token = await getToken(messaging, { vapidKey })
+        if (token) await unregisterDevice(token)
+        await deleteToken(messaging)
+        localStorage.setItem(ENABLED_KEY, 'false')
+        messagingRef.current = null
+        setStatus('off')
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to turn off push notifications')
+        setStatus('error')
+      }
+    })()
+  }, [])
+
+  return (
+    <PushNotificationsContext.Provider value={{ status, error, enable, disable }}>
+      {children}
+    </PushNotificationsContext.Provider>
+  )
+}
+
+export function usePushNotifications() {
+  const context = useContext(PushNotificationsContext)
+  if (context === undefined) {
+    throw new Error('usePushNotifications must be used within a PushNotificationsProvider')
+  }
+  return context
+}

--- a/agon_ui/src/lib/firebase.ts
+++ b/agon_ui/src/lib/firebase.ts
@@ -1,0 +1,50 @@
+import { initializeApp, type FirebaseApp } from 'firebase/app'
+import { getRuntimeEnv } from '@/utils/runtime-env'
+
+const env = getRuntimeEnv()
+
+/** Firebase Web SDK config — all public, client-safe identifiers (Firebase
+ *  ships these into every web app's bundle by design). Sourced from the
+ *  `firebaseWebConfig` / `firebaseWebApp` Pulumi outputs in agon_infra. */
+export const firebaseConfig = {
+  apiKey: env.VITE_FIREBASE_API_KEY,
+  authDomain: env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: env.VITE_FIREBASE_APP_ID,
+}
+
+/** The public half of the Web Push (VAPID) key pair FCM's `getToken()` needs.
+ *  Console-only to generate — see agon_infra/index.ts for why. */
+export const vapidKey = env.VITE_FIREBASE_VAPID_KEY
+
+/** True if a value is present and isn't an un-substituted `${VAR}` template —
+ *  the state runtime-env.ts values are left in if the container's entrypoint
+ *  never got that env var (or, in a dev build, if .env just doesn't set it). */
+function isSet(value: string | undefined): boolean {
+  return !!value && !value.startsWith('${')
+}
+
+/**
+ * Whether enough Firebase config is present to attempt push registration.
+ * Mirrors the backend's "absent config means not configured, not a failure"
+ * convention for `AGON_FCM_SERVICE_ACCOUNT_JSON` — until the VAPID key is
+ * generated and wired through, push notifications just stay off.
+ */
+export function isFirebaseConfigured(): boolean {
+  return Object.values(firebaseConfig).every(isSet) && isSet(vapidKey)
+}
+
+let app: FirebaseApp | undefined
+
+/** Lazily initializes (once) and returns the Firebase app. Only call this
+ *  after `isFirebaseConfigured()` — `initializeApp` doesn't validate its
+ *  input, so calling it first just moves the failure somewhere more
+ *  confusing, inside `getMessaging()`/`getToken()`. */
+export function getFirebaseApp(): FirebaseApp {
+  if (!app) {
+    app = initializeApp(firebaseConfig)
+  }
+  return app
+}

--- a/agon_ui/src/pages/NotificationsPage.tsx
+++ b/agon_ui/src/pages/NotificationsPage.tsx
@@ -19,6 +19,7 @@ import { FollowButton } from '@/components/agon/FollowButton'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { InvitationResponseDialog } from '@/components/agon/InvitationResponseDialog'
+import { PushNotificationsBanner } from '@/components/agon/PushNotificationsBanner'
 
 type NotificationPage = components['schemas']['NotificationPage']
 type Notification = components['schemas']['Notification']
@@ -118,18 +119,22 @@ export function NotificationsPage() {
 
   if (items.length === 0) {
     return (
-      <div className="py-16 text-center">
-        <Bell className="mx-auto mb-3 size-8 text-muted-foreground" />
-        <h2 className="mb-1 text-lg font-medium">No notifications yet</h2>
-        <p className="text-sm text-muted-foreground">
-          Match invites, follows, likes and comments show up here.
-        </p>
+      <div className="mx-auto max-w-xl">
+        <PushNotificationsBanner />
+        <div className="py-16 text-center">
+          <Bell className="mx-auto mb-3 size-8 text-muted-foreground" />
+          <h2 className="mb-1 text-lg font-medium">No notifications yet</h2>
+          <p className="text-sm text-muted-foreground">
+            Match invites, follows, likes and comments show up here.
+          </p>
+        </div>
       </div>
     )
   }
 
   return (
     <div className="mx-auto flex max-w-xl flex-col">
+      <PushNotificationsBanner />
       <div className="mb-2 flex items-center justify-between">
         <h1 className="text-xl font-semibold">Notifications</h1>
         {hasUnread && (

--- a/agon_ui/src/utils/runtime-env.ts
+++ b/agon_ui/src/utils/runtime-env.ts
@@ -2,6 +2,20 @@
 const runtimeEnv = {
   VITE_SUPABASE_URL: '${VITE_SUPABASE_URL}',
   VITE_SUPABASE_ANON_KEY: '${VITE_SUPABASE_ANON_KEY}',
+  // Firebase Web SDK config for push notifications (see src/lib/firebase.ts).
+  // All of these are the public, client-safe identifiers Firebase's own docs
+  // ship straight into the bundle — nothing here is a secret. VAPID_KEY is the
+  // *public* half of the Web Push key pair (Console → Project Settings →
+  // Cloud Messaging → Web configuration), which currently has to be generated
+  // by hand; until it's set, push registration stays disabled (see
+  // isFirebaseConfigured in src/lib/firebase.ts).
+  VITE_FIREBASE_API_KEY: '${VITE_FIREBASE_API_KEY}',
+  VITE_FIREBASE_AUTH_DOMAIN: '${VITE_FIREBASE_AUTH_DOMAIN}',
+  VITE_FIREBASE_PROJECT_ID: '${VITE_FIREBASE_PROJECT_ID}',
+  VITE_FIREBASE_STORAGE_BUCKET: '${VITE_FIREBASE_STORAGE_BUCKET}',
+  VITE_FIREBASE_MESSAGING_SENDER_ID: '${VITE_FIREBASE_MESSAGING_SENDER_ID}',
+  VITE_FIREBASE_APP_ID: '${VITE_FIREBASE_APP_ID}',
+  VITE_FIREBASE_VAPID_KEY: '${VITE_FIREBASE_VAPID_KEY}',
 }
 
 type RuntimeEnv = typeof runtimeEnv;
@@ -11,6 +25,13 @@ export function getRuntimeEnv(): RuntimeEnv {
     return {
       VITE_SUPABASE_URL: import.meta.env.VITE_SUPABASE_URL,
       VITE_SUPABASE_ANON_KEY: import.meta.env.VITE_SUPABASE_ANON_KEY,
+      VITE_FIREBASE_API_KEY: import.meta.env.VITE_FIREBASE_API_KEY,
+      VITE_FIREBASE_AUTH_DOMAIN: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+      VITE_FIREBASE_PROJECT_ID: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+      VITE_FIREBASE_STORAGE_BUCKET: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+      VITE_FIREBASE_MESSAGING_SENDER_ID: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+      VITE_FIREBASE_APP_ID: import.meta.env.VITE_FIREBASE_APP_ID,
+      VITE_FIREBASE_VAPID_KEY: import.meta.env.VITE_FIREBASE_VAPID_KEY,
     };
   }
 

--- a/agon_worker/src/config.rs
+++ b/agon_worker/src/config.rs
@@ -30,6 +30,13 @@ pub struct Config {
     /// not a startup failure. If set, it must parse — a broken credential is a
     /// real misconfiguration, not an intentional opt-out.
     pub fcm_service_account_json: Option<String>,
+    /// The web app's public base URL (`AGON_UI_URL`, e.g.
+    /// `https://agon.staging.get-agon.com`), used to build the full deep-link
+    /// URL attached to a push notification (see
+    /// `handlers::push::push_link`). Optional like the FCM credential above:
+    /// unset just means push notifications open the app with no deep link
+    /// rather than failing to send at all.
+    pub ui_base_url: Option<String>,
     /// Max messages to pull per SQS receive (1..=10).
     pub batch_size: i32,
     /// SQS long-poll wait time in seconds (0..=20).
@@ -52,6 +59,9 @@ impl Config {
             meili_url: required("MEILI_URL")?,
             meili_key: required("MEILI_MASTER_KEY")?,
             fcm_service_account_json: env::var("AGON_FCM_SERVICE_ACCOUNT_JSON").ok(),
+            ui_base_url: env::var("AGON_UI_URL")
+                .ok()
+                .map(|v| v.trim_end_matches('/').to_string()),
             batch_size: optional_parsed("AGON_WORKER_BATCH_SIZE", 10)?,
             wait_time_seconds: optional_parsed("AGON_WORKER_WAIT_SECONDS", 20)?,
             visibility_timeout_seconds: optional_parsed("AGON_WORKER_VISIBILITY_SECONDS", 60)?,

--- a/agon_worker/src/consumer.rs
+++ b/agon_worker/src/consumer.rs
@@ -158,7 +158,15 @@ impl Consumer {
         let event = ChangeEvent::from_envelope(&envelope)?;
 
         let now = Utc::now().to_rfc3339();
-        handlers::route(&self.dao, &self.search, self.push.as_ref(), &event, &now).await?;
+        handlers::route(
+            &self.dao,
+            &self.search,
+            self.push.as_ref(),
+            self.config.ui_base_url.as_deref(),
+            &event,
+            &now,
+        )
+        .await?;
 
         // Multi-step work: start the relevant Temporal workflow (idempotent via
         // deterministic ids). A start failure is transient, so the message is left

--- a/agon_worker/src/handlers/mod.rs
+++ b/agon_worker/src/handlers/mod.rs
@@ -34,12 +34,13 @@ pub async fn route(
     dao: &Dao,
     search: &SearchClient,
     push: Option<&PushClient>,
+    ui_base_url: Option<&str>,
     ev: &ChangeEvent,
     now: &str,
 ) -> WorkerResult<()> {
     index::handle(dao, search, ev).await?;
     notify::handle(dao, ev, now).await?;
-    push::handle(dao, push, ev).await?;
+    push::handle(dao, push, ui_base_url, ev).await?;
     stats::handle(dao, ev).await?;
     Ok(())
 }

--- a/agon_worker/src/handlers/push.rs
+++ b/agon_worker/src/handlers/push.rs
@@ -17,13 +17,20 @@
 use agon_core::dao::Dao;
 use agon_core::dao::error::DaoError;
 use agon_core::dao::keys::{Pk, Sk};
-use agon_core::dao::records::{NotificationKindRecord, NotificationRecord};
+use agon_core::dao::records::{
+    InvitationContextRecord, NotificationKindRecord, NotificationRecord,
+};
 use agon_core::push::{PushClient, PushOutcome};
 
 use crate::error::WorkerResult;
 use crate::event::{ChangeEvent, ChangeKind};
 
-pub async fn handle(dao: &Dao, push: Option<&PushClient>, ev: &ChangeEvent) -> WorkerResult<()> {
+pub async fn handle(
+    dao: &Dao,
+    push: Option<&PushClient>,
+    ui_base_url: Option<&str>,
+    ev: &ChangeEvent,
+) -> WorkerResult<()> {
     // Not configured (e.g. local dev without a GCP project) — nothing to do.
     let Some(push) = push else {
         return Ok(());
@@ -39,8 +46,12 @@ pub async fn handle(dao: &Dao, push: Option<&PushClient>, ev: &ChangeEvent) -> W
     };
 
     let (title, body) = push_text(&notif.kind);
+    let link = ui_base_url.map(|base| push_link(base, &notif.kind));
     for device in dao.list_devices(user_id).await? {
-        match push.send(&device.push_token, &title, &body).await? {
+        match push
+            .send(&device.push_token, &title, &body, link.as_deref())
+            .await?
+        {
             PushOutcome::Sent => {}
             // FCM rejected the token itself (unregistered/not found) — the
             // device is gone (app uninstalled, service worker replaced, etc.);
@@ -54,6 +65,33 @@ pub async fn handle(dao: &Dao, push: Option<&PushClient>, ev: &ChangeEvent) -> W
         }
     }
     Ok(())
+}
+
+/// Where clicking this notification should land — a full URL (`ui_base_url`
+/// plus a path), not a relative one: the same field also has to make sense
+/// once Android/iOS apps exist, and a bare `https://` URL is what App Links /
+/// Universal Links route to the native app if installed, falling back to this
+/// same web page otherwise. No third-party dynamic-link service needed (and
+/// Firebase Dynamic Links, which used to be that service, was shut down by
+/// Google in August 2025). Mirrors `describe().href` in
+/// agon_ui/src/pages/NotificationsPage.tsx — keep the two in sync.
+fn push_link(ui_base_url: &str, kind: &NotificationKindRecord) -> String {
+    let path = match kind {
+        NotificationKindRecord::MatchInvitation { match_id, .. } => format!("/matches/{match_id}"),
+        NotificationKindRecord::TeamInvitation { team_id, .. } => format!("/teams/{team_id}"),
+        NotificationKindRecord::InvitationAccepted { context, .. } => match context {
+            InvitationContextRecord::Match { match_id, .. } => format!("/matches/{match_id}"),
+            InvitationContextRecord::Team { team_id, .. } => format!("/teams/{team_id}"),
+        },
+        NotificationKindRecord::Follow { actor_user_id } => format!("/users/{actor_user_id}"),
+        NotificationKindRecord::Like { match_id, .. } => format!("/matches/{match_id}"),
+        NotificationKindRecord::Comment { match_id, .. } => format!("/matches/{match_id}"),
+        NotificationKindRecord::Reply { match_id, .. } => format!("/matches/{match_id}"),
+        NotificationKindRecord::ScoreSubmitted { match_id, .. } => format!("/matches/{match_id}"),
+        NotificationKindRecord::ScoreConfirmed { match_id, .. } => format!("/matches/{match_id}"),
+    };
+    // Config::from_env already strips any trailing slash from AGON_UI_URL.
+    format!("{ui_base_url}{path}")
 }
 
 /// Generic push copy for one notification. Built only from fields already
@@ -108,15 +146,12 @@ fn push_text(kind: &NotificationKindRecord) -> (String, String) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agon_core::dao::records::InvitationContextRecord;
 
-    /// `push_text` produces non-empty copy for every current notification kind
-    /// (mirrors every `NotificationKindRecord` variant, so a new variant that
-    /// forgets to update this match arm fails to compile, not silently ships
-    /// blank push copy).
-    #[test]
-    fn push_text_covers_every_kind() {
-        let kinds = [
+    /// One of each `NotificationKindRecord` variant (`ScoreSubmitted` twice,
+    /// for both values of `needs_confirmation`), shared by the `push_text` and
+    /// `push_link` coverage tests below.
+    fn sample_kinds() -> Vec<NotificationKindRecord> {
+        vec![
             NotificationKindRecord::MatchInvitation {
                 actor_user_id: "u1".into(),
                 invitation_id: "i1".into(),
@@ -178,7 +213,16 @@ mod tests {
                 match_name: "Sunday Tennis".into(),
                 submission_id: "s1".into(),
             },
-        ];
+        ]
+    }
+
+    /// `push_text` produces non-empty copy for every current notification kind
+    /// (mirrors every `NotificationKindRecord` variant, so a new variant that
+    /// forgets to update this match arm fails to compile, not silently ships
+    /// blank push copy).
+    #[test]
+    fn push_text_covers_every_kind() {
+        let kinds = sample_kinds();
 
         for kind in &kinds {
             let (title, body) = push_text(kind);
@@ -191,5 +235,21 @@ mod tests {
         let (_, needs_confirm_body) = push_text(&kinds[7]);
         let (_, informational_body) = push_text(&kinds[8]);
         assert_ne!(needs_confirm_body, informational_body);
+    }
+
+    /// `push_link` produces a URL under `ui_base_url` for every kind (again,
+    /// exhaustive match ⇒ a new variant fails to compile here, not silently
+    /// ships a dead-end link), and never double/drops the slash between the
+    /// base and the path regardless of whether the base carries a trailing one.
+    #[test]
+    fn push_link_covers_every_kind() {
+        let base = "https://agon.example.com";
+        for kind in &sample_kinds() {
+            let link = push_link(base, kind);
+            assert!(
+                link.len() > format!("{base}/").len() && link.starts_with(&format!("{base}/")),
+                "link {link} for {kind:?} doesn't extend the base URL with a real path"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
Wires the frontend up to the FCM backend from #18: registers/unregisters this browser's device via the existing `/devices` endpoints, and receives push notifications both in the foreground and in the background. Also sets the staging Firebase Web Push (VAPID) key now that it's been generated in Firebase Console.

## Key Changes

**Client push registration**
- `src/lib/firebase.ts`: Firebase Web SDK config from runtime env, with an `isFirebaseConfigured()` guard so an incomplete config (e.g. VAPID key not set yet) just leaves the feature off rather than breaking anything.
- `src/hooks/usePushNotifications.tsx`: a context provider (mirrors `useAuth.tsx`) owning the FCM registration lifecycle — auto re-registers on load if previously enabled on this device, exposes `enable()`/`disable()`, and refreshes the notifications/unread-count queries when a push arrives while the tab is open.
- `public/firebase-messaging-sw.js`: background-message handler, registered at its own scope (`/firebase-cloud-messaging-push-scope`) so it coexists with the PWA's existing workbox service worker at `/`. Reads its Firebase config off its own registration URL query string, since it's a static asset the Vite build doesn't process.

**UI**
- `src/components/agon/PushNotificationsBanner.tsx` + `NotificationsPage.tsx`: an opt-in/opt-out banner ("Get notified on this device" → Enable / Turn off).

**Config plumbing**
- `runtime-env.ts` / `.env.example`: new `VITE_FIREBASE_*` vars, following the existing Supabase runtime-env pattern (container entrypoint `envsubst`).
- `agon_infra/index.ts`: wires the six non-secret Firebase web config values straight from the existing `firebaseWebApp`/`firebaseWebConfig` Pulumi outputs into the `agon-ui` deployment's env — nothing to copy-paste.
- `agon_infra/Pulumi.staging.yaml`: sets `firebaseVapidKey` (the public half of the Web Push key pair, generated in Firebase Console — not automatable, not secret).

## Verification
- `tsc -b`, `eslint .`, and a full `vite build` all pass clean (including the PWA plugin picking up the new static service worker correctly).
- `pulumi up --stack staging` has been run with this config; the deployed `agon-ui` should now have `VITE_FIREBASE_VAPID_KEY` set end to end.

https://claude.ai/code/session_01GqKeCqzmVioRJ2w5fFMhG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqKeCqzmVioRJ2w5fFMhG5)_