### PR TITLE
Fix live event undo to support consecutive deletes

### DIFF
--- a/agon_core/src/dao/live_score_ops.rs
+++ b/agon_core/src/dao/live_score_ops.rs
@@ -17,7 +17,7 @@ use aws_sdk_dynamodb::types::{AttributeValue, Delete, Put, TransactWriteItem, Up
 
 use super::client::Dao;
 use super::error::{DaoError, DaoResult};
-use super::item::{ATTR_PK, ATTR_SK, s, to_item};
+use super::item::{ATTR_PK, ATTR_SK, from_item, item_sk, s, to_item};
 use super::keys::{Pk, Sk};
 use super::page::Page;
 use super::records::{LiveEventPayloadRecord, LiveEventRecord};
@@ -81,7 +81,18 @@ impl Dao {
             .table_name(self.table())
             .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
             .key(ATTR_SK, s(Sk::Meta.to_string()))
-            .update_expression("SET live_seq = if_not_exists(live_seq, :zero) + :n")
+            // `live_tip_seq` rides along with `live_seq` here: an append's
+            // newest event is always the new physical tip too (an append
+            // never creates a gap), so it's free to keep in sync — both SET
+            // clauses compute the same new value off the pre-update
+            // `live_seq`. This is what lets `delete_live_event` trust
+            // `live_tip_seq` as the log's real tip even across repeated
+            // undos (see that method's doc comment for why `live_seq` alone
+            // can't be used for that once a delete has ever happened).
+            .update_expression(
+                "SET live_seq = if_not_exists(live_seq, :zero) + :n, \
+                     live_tip_seq = if_not_exists(live_seq, :zero) + :n",
+            )
             .condition_expression(
                 "attribute_exists(#pk) AND \
                  ((attribute_not_exists(live_seq) AND :expected = :zero) OR live_seq = :expected)",
@@ -139,25 +150,60 @@ impl Dao {
     /// happened" (a duplicate, a wrong-match entry), not an edit — but only
     /// when it's still the log's current tip. In one `TransactWriteItems`,
     /// atomically deletes the item *and* bumps `live_seq` by one, with the
-    /// bump's own condition (`live_seq = :seq`) doubling as the "only the tip
-    /// can be undone" guard — enforced against the live counter at commit
-    /// time, not a value the caller read a moment earlier the way a plain
-    /// read-then-check-then-delete would.
+    /// bump's own condition (`live_tip_seq = :seq`) doubling as the "only the
+    /// tip can be undone" guard — enforced against the live counter at
+    /// commit time, not a value the caller read a moment earlier the way a
+    /// plain read-then-check-then-delete would.
     ///
-    /// `live_seq` is bumped rather than left untouched on purpose: `seq`
-    /// itself is never reused for a new event either way (an append always
-    /// reserves a fresh number above whatever `live_seq` currently reads —
-    /// see `append_live_events`), but bumping it here additionally means any
-    /// device whose last-known tip predates this delete gets its next append
-    /// rejected with `Conflict` instead of silently building on top of an
-    /// event that's no longer there. Same "the log moved on since you last
-    /// looked" guarantee `append_live_events` gives against a racing append,
-    /// now also given against a racing delete.
+    /// The guard is on `live_tip_seq`, deliberately *not* `live_seq`: an
+    /// earlier version of this method compared against `live_seq` directly,
+    /// which is only ever equal to the physical tip's own seq before any
+    /// delete has happened. The very first undo bumps `live_seq` one past
+    /// the deleted event — correct for the reservation-counter role below,
+    /// but from then on `live_seq` no longer equals *any* real event's seq,
+    /// so a second consecutive undo (targeting the new, lower physical tip)
+    /// could never satisfy `live_seq = :seq` again — every undo past the
+    /// first one 400'd as "not the tip" even when it genuinely was.
+    /// `live_tip_seq` is a second counter tracking the physical tip alone,
+    /// kept accurate across repeated undos by resolving what the *next*
+    /// physical tip will be (`find_previous_live_event_seq`) before this
+    /// transaction, then writing that as part of the same guarded update.
     ///
-    /// Returns the new tip (`seq + 1`) on success.
+    /// `live_seq` is still bumped alongside it, for the same reason as
+    /// before: `seq` itself is never reused for a new event either way (an
+    /// append always reserves a fresh number above whatever `live_seq`
+    /// currently reads — see `append_live_events`), but bumping it here
+    /// additionally means any device whose last-known tip predates this
+    /// delete gets its next append rejected with `Conflict` instead of
+    /// silently building on top of an event that's no longer there. Same
+    /// "the log moved on since you last looked" guarantee
+    /// `append_live_events` gives against a racing append, now also given
+    /// against a racing delete.
+    ///
+    /// Returns the new tip on success — the bumped `live_seq` counter, i.e.
+    /// the client's next `expected_last_seq`, not `live_tip_seq` (which is
+    /// internal-only; see that field's doc comment on `MatchRecord`).
+    ///
+    /// That return value is *not* simply `seq + 1`, even though it was
+    /// exactly that in an earlier version of this method (back when the
+    /// tip-bump's condition was on `live_seq` itself — see this method's
+    /// doc comment above — `seq + 1` only equals the post-transaction
+    /// `live_seq` when `seq` happened to equal the pre-transaction
+    /// `live_seq`, true for a match's very first undo but false for every
+    /// undo after that, once `seq` is a real event's number well below the
+    /// climbing counter). So this reads the counter back for real —
+    /// strongly consistent, since it's read immediately after this same
+    /// method's own write and must reflect it.
     #[tracing::instrument(skip(self))]
     pub async fn delete_live_event(&self, match_id: &str, seq: u32) -> DaoResult<u32> {
-        let new_tip = seq + 1;
+        // Resolve what `live_tip_seq` must become if this delete succeeds,
+        // before starting the transaction: the next-highest surviving
+        // event's seq, or none if deleting `seq` empties the log. A plain
+        // `seq - 1` isn't safe here — once an earlier undo has been
+        // followed by an append, the physical log can have a permanent gap
+        // below `seq` (see `append_live_events`'s doc comment), so the
+        // *real* next event has to be looked up rather than assumed.
+        let previous_seq = self.find_previous_live_event_seq(match_id, seq).await?;
 
         let delete_event = Delete::builder()
             .table_name(self.table())
@@ -168,14 +214,33 @@ impl Dao {
             .build()
             .map_err(|e| DaoError::Dynamo(e.to_string()))?;
 
-        let bump_tip = Update::builder()
+        // The `attribute_not_exists(live_tip_seq) AND live_seq = :seq`
+        // branch is the migration fallback: a match whose log predates this
+        // field (never appended to since it shipped) has no `live_tip_seq`
+        // yet, but for such a match `live_seq` still equals the physical
+        // tip exactly (nothing has ever deleted from it under the new
+        // logic), so falling back to the old check is correct for exactly
+        // that first delete. Every append (old matches included) stamps
+        // `live_tip_seq` from then on, so this branch only ever fires once
+        // per match at most.
+        let mut bump_tip = Update::builder()
             .table_name(self.table())
             .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
             .key(ATTR_SK, s(Sk::Meta.to_string()))
-            .update_expression("SET live_seq = live_seq + :one")
-            .condition_expression("live_seq = :seq")
-            .expression_attribute_values(":one", AttributeValue::N("1".into()))
-            .expression_attribute_values(":seq", AttributeValue::N(seq.to_string()))
+            .condition_expression(
+                "(attribute_not_exists(live_tip_seq) AND live_seq = :seq) OR live_tip_seq = :seq",
+            )
+            .expression_attribute_values(":seq", AttributeValue::N(seq.to_string()));
+        bump_tip = match previous_seq {
+            Some(prev) => bump_tip
+                .update_expression("SET live_seq = live_seq + :one, live_tip_seq = :prev")
+                .expression_attribute_values(":one", AttributeValue::N("1".into()))
+                .expression_attribute_values(":prev", AttributeValue::N(prev.to_string())),
+            None => bump_tip
+                .update_expression("SET live_seq = live_seq + :one REMOVE live_tip_seq")
+                .expression_attribute_values(":one", AttributeValue::N("1".into())),
+        };
+        let bump_tip = bump_tip
             .build()
             .map_err(|e| DaoError::Dynamo(e.to_string()))?;
 
@@ -190,7 +255,7 @@ impl Dao {
             .await;
 
         match result {
-            Ok(_) => Ok(new_tip),
+            Ok(_) => self.live_seq_after_delete(match_id).await,
             Err(e) => match delete_live_event_failure(&e) {
                 Some(DeleteLiveEventFailure::EventMissing) => Err(DaoError::NotFound(format!(
                     "live event {seq} on match {match_id}"
@@ -200,6 +265,85 @@ impl Dao {
                 ))),
                 None => Err(DaoError::Dynamo(e.to_string())),
             },
+        }
+    }
+
+    /// The authoritative `live_seq` to hand back from `delete_live_event`
+    /// once its transaction has committed — a strongly consistent point
+    /// read of the meta item's counter, not a value derived from `seq` (see
+    /// `delete_live_event`'s doc comment on why that shortcut doesn't
+    /// generalize past the first undo). `consistent_read` matters here
+    /// specifically because this runs immediately after this same call's
+    /// own write to the same item: an eventually-consistent read could
+    /// still see the pre-delete value and hand the client a stale counter.
+    async fn live_seq_after_delete(&self, match_id: &str) -> DaoResult<u32> {
+        #[derive(serde::Deserialize)]
+        struct LiveSeqOnly {
+            #[serde(default)]
+            live_seq: u32,
+        }
+
+        let out = self
+            .client
+            .get_item()
+            .table_name(self.table())
+            .key(ATTR_PK, s(Pk::Match(match_id.into()).to_string()))
+            .key(ATTR_SK, s(Sk::Meta.to_string()))
+            .projection_expression("live_seq")
+            .consistent_read(true)
+            .send()
+            .await
+            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+
+        let item = out.item.ok_or_else(|| {
+            DaoError::Dynamo(format!(
+                "match {match_id} meta item missing right after a live-event delete committed"
+            ))
+        })?;
+        let record: LiveSeqOnly = from_item(item)?;
+        Ok(record.live_seq)
+    }
+
+    /// The seq of the highest live event still standing below `before_seq`,
+    /// or `None` if there isn't one (the log would go empty, or `before_seq`
+    /// is already the earliest possible). Used by `delete_live_event` to
+    /// resolve the next `live_tip_seq` *before* committing the delete —
+    /// a single descending, `Limit(1)` range query bounded to the
+    /// `LIVEEVT#` keyspace (`Sk::live_event_prefix()` as the lower bound, so
+    /// it can never stray into the match's other item kinds sharing the same
+    /// partition), not a full drain of the log.
+    async fn find_previous_live_event_seq(
+        &self,
+        match_id: &str,
+        before_seq: u32,
+    ) -> DaoResult<Option<u32>> {
+        let Some(upper) = before_seq.checked_sub(1) else {
+            return Ok(None);
+        };
+
+        let resp = self
+            .client
+            .query()
+            .table_name(self.table())
+            .key_condition_expression("#pk = :pk AND SK BETWEEN :low AND :high")
+            .expression_attribute_names("#pk", ATTR_PK)
+            .expression_attribute_values(":pk", s(Pk::Match(match_id.into()).to_string()))
+            .expression_attribute_values(":low", s(Sk::live_event_prefix()))
+            .expression_attribute_values(":high", s(Sk::LiveEvent(upper).to_string()))
+            .scan_index_forward(false)
+            .limit(1)
+            .send()
+            .await
+            .map_err(|e| DaoError::Dynamo(e.to_string()))?;
+
+        let Some(item) = resp.items.unwrap_or_default().into_iter().next() else {
+            return Ok(None);
+        };
+        match item_sk(&item)? {
+            Sk::LiveEvent(found_seq) => Ok(Some(found_seq)),
+            other => Err(DaoError::Malformed(format!(
+                "live-event range query on match {match_id} returned a non-live-event key {other}"
+            ))),
         }
     }
 
@@ -288,9 +432,9 @@ enum DeleteLiveEventFailure {
     /// The delete's own condition failed — nothing exists at that seq
     /// (never did, or a concurrent delete already removed it).
     EventMissing,
-    /// The tip-bump's condition failed — `seq` wasn't `live_seq` at commit
-    /// time (a mid-log seq, or the tip moved on since the caller last saw
-    /// it).
+    /// The tip-bump's condition failed — `seq` wasn't `live_tip_seq` at
+    /// commit time (a mid-log seq, or the tip moved on since the caller last
+    /// saw it).
     NotTip,
 }
 

--- a/agon_core/src/dao/records.rs
+++ b/agon_core/src/dao/records.rs
@@ -428,8 +428,28 @@ pub struct MatchRecord {
     /// `append_live_events`: a batch must state the tip it last saw, and the
     /// counter bump that reserves its seq range is conditioned on this value.
     /// `#[serde(default)]` for matches written before live scoring existed.
+    ///
+    /// A monotonically-*increasing* reservation counter, not a mirror of the
+    /// physical log's max seq once a `LIVEEVT#` has ever been deleted — see
+    /// `live_tip_seq` for that instead.
     #[serde(default)]
     pub live_seq: u32,
+    /// The seq of the log's current physical tip — the highest `LIVEEVT#`
+    /// that actually exists — `None` if the log is empty. DAO-internal
+    /// bookkeeping for `Dao::delete_live_event`'s "only the tip can be
+    /// undone" guard; nothing outside `live_score_ops.rs` reads or writes
+    /// this directly (it's set via raw attribute updates there, not through
+    /// this struct). Deliberately a second field rather than reusing
+    /// `live_seq` for both jobs: `live_seq` only ever climbs (bumped by
+    /// every append *and* every delete, so appends never reuse a seq), so it
+    /// stops equaling the physical tip's own seq the moment a delete ever
+    /// bumps it past one — `live_tip_seq` is what stays accurate across
+    /// consecutive deletes. `#[serde(default)]` covers both matches written
+    /// before live scoring existed and matches whose log predates this
+    /// field: for either, the first `delete_live_event` call falls back to
+    /// checking `live_seq` instead (see that method).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_tip_seq: Option<u32>,
     /// Match format/rules configuration (overs per innings, half length, and
     /// so on). Embedded directly on the match record (not a separate item,
     /// unlike the live-scoring score record) because live scoring wants it

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -2459,6 +2459,7 @@ impl Api {
             like_count: 0,
             comment_count: 0,
             live_seq: 0,
+            live_tip_seq: None,
             format: input.format.as_ref().map(match_format_to_record),
             created_at: now.clone(),
         };

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -3917,7 +3917,7 @@ async fn undoing_the_bumped_tip_with_nothing_left_to_delete_is_not_found() {
 /// bumped `last_seq`. This is the scenario the UI's `useUndoTargetSeq` split
 /// exists for (see that hook's doc comment): every undo advances `live_seq`
 /// by one past the deleted event, so consecutive undos land on a strictly
-/// increasing sequence of `last_seq` values (4, then 3, then 2) even while
+/// increasing sequence of `last_seq` values (4, then 5, then 6) even while
 /// the *targets* count down (3, then 2, then 1). Confirms the derived score
 /// and physical log both end up completely empty once every event has been
 /// undone, not just "missing the most recent one" — and, the actual point
@@ -3983,11 +3983,14 @@ async fn undoing_multiple_times_in_a_row_removes_each_real_tip_in_turn() {
     }
 
     // Undo #3: the real tip is now seq 1 (the first, and last remaining,
-    // goal) — the log goes fully empty.
+    // goal) — the log goes fully empty. The counter keeps climbing the same
+    // way it did for undo #2 (5 -> 6), even though there's nothing left to
+    // undo afterward — `live_seq` never resets just because the log is
+    // momentarily empty.
     let after_third = matches_match_id_live_events_seq_delete(&owner_config, &created.id, 1)
         .await
         .expect("undo the first goal");
-    assert_eq!(after_third.last_seq, 2);
+    assert_eq!(after_third.last_seq, 6);
     match *after_third.score {
         models::Score::Netball(s) => {
             assert_eq!(s.goals.as_ref().map(Vec::len), Some(0));
@@ -4020,7 +4023,7 @@ async fn undoing_multiple_times_in_a_row_removes_each_real_tip_in_turn() {
     }
 
     // The actual point of all this: scoring can still continue afterward.
-    // `expected_last_seq` must be `after_third.last_seq` (2) — the climbed
+    // `expected_last_seq` must be `after_third.last_seq` (6) — the climbed
     // counter, not 0 — even though every event ever recorded has now been
     // undone.
     let after_append = append_live_events_raw(
@@ -4030,9 +4033,9 @@ async fn undoing_multiple_times_in_a_row_removes_each_real_tip_in_turn() {
         vec![netball_goal_event_json(&side_a, false)],
     )
     .await;
-    // Lands at seq 3, continuing on from the counter — not seq 1, which
+    // Lands at seq 7, continuing on from the counter — not seq 1, which
     // would silently collide with the (deleted) first goal's old identity.
-    assert_eq!(after_append.last_seq, 3);
+    assert_eq!(after_append.last_seq, 7);
     match *after_append.score {
         models::Score::Netball(s) => {
             assert_eq!(s.goals.as_ref().map(Vec::len), Some(1));


### PR DESCRIPTION
## Summary
Fixes a critical bug in `delete_live_event` that prevented consecutive undos from working correctly. The method previously used `live_seq` (a monotonically-increasing reservation counter) to guard the "only the tip can be undone" check, which failed after the first delete because `live_seq` would no longer equal any real event's seq. Introduces a new `live_tip_seq` field to track the physical log's actual tip independently.

## Key Changes

- **New `live_tip_seq` field on `MatchRecord`**: A separate counter that tracks the seq of the log's current physical tip (highest existing `LIVEEVT#` item), distinct from `live_seq` which only ever climbs. Allows the tip-guard condition to work correctly across repeated undos.

- **Updated `append_live_events`**: Now sets both `live_seq` and `live_tip_seq` in a single atomic update, keeping them in sync since an append always creates the new physical tip.

- **Refactored `delete_live_event`**:
  - Condition now checks `live_tip_seq` (with fallback to `live_seq` for migration) instead of `live_seq` alone
  - Calls new `find_previous_live_event_seq` to resolve the next physical tip *before* committing the delete
  - Updates both `live_seq` (for reservation) and `live_tip_seq` (for physical tip tracking) atomically
  - Returns the actual post-transaction `live_seq` via new `live_seq_after_delete` read instead of deriving `seq + 1`

- **New helper methods**:
  - `find_previous_live_event_seq`: Single-item descending range query to find the highest surviving event below the deleted seq
  - `live_seq_after_delete`: Strongly-consistent read of `live_seq` immediately after delete commits, ensuring the client gets the authoritative counter value

- **Migration support**: The first delete on a match predating `live_tip_seq` falls back to checking `live_seq` directly (which still equals the physical tip for untouched logs), then stamps `live_tip_seq` from that point forward.

- **Test updates**: Corrected expected `last_seq` values in `undoing_multiple_times_in_a_row_removes_each_real_tip_in_turn` to reflect the climbing counter behavior across consecutive undos.

## Implementation Details

The core insight: `live_seq` serves two purposes (reservation counter + tip tracking), but these diverge once a delete happens. By introducing `live_tip_seq` as a dedicated physical-tip tracker, the undo guard becomes reliable across repeated deletes. The `live_seq` counter still climbs on every delete (to prevent seq reuse and reject stale appends), but `live_tip_seq` is what actually reflects which event is the current tip.

https://claude.ai/code/session_013vArDw9VLtMermPtwzKQS4