### PR TITLE
Fix append token going stale on refresh after an undo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,28 @@ generate-schema:
 	cargo run -p agon_service -- generate-schema
 	openapi-generator-cli generate -i schema.json -g rust -o openapi_client
 	echo "disable_all_formatting = true" > openapi_client/.rustfmt.toml
-	# Post-process: for discriminated unions the enum is `#[serde(tag = "type")]`
-	# (serde consumes `type` to pick the variant), but the generator ALSO emits a
-	# required `type` field on each variant struct — so deserializing fails with
-	# "missing field `type`". Add `#[serde(default)]` so the (single-valued,
-	# already-correct) field defaults when absent. See docs/openapi-client.md.
+	# Post-process: for a discriminated union whose variants are flat objects
+	# (not another nested union — see the `LiveEventInput` fix below for
+	# that case), the enum is `#[serde(tag = "<name>")]` (serde consumes
+	# `<name>` to pick the variant), but the generator ALSO emits a required
+	# `<name>` field on each variant struct — so deserializing can fail
+	# (`missing field`, or — once the variant has enough other fields that
+	# the same broken reconstruction misaligns a *different*, non-optional
+	# one instead — a spurious type-mismatch on that field, e.g. "invalid
+	# type: null, expected a string" on a plain required `side_id: String`
+	# that was never actually null on the wire). Add `#[serde(default)]` so
+	# the (single-valued, already-correct) discriminator field defaults
+	# when the reconstruction doesn't see it. This API uses three such
+	# discriminator names: `type` (e.g. `Score`), `sport` (`MatchFormat`),
+	# and `kind` (the football/cricket/netball live-event unions nested
+	# inside `LiveEventInput`) — all three need the same fix, not just
+	# `type`. See docs/openapi-client.md.
 	find openapi_client/src/models -name '*.rs' -exec \
 		perl -0pi -e 's/#\[serde\(rename = "type"\)\]\n(\s*)pub r#type: Type,/#[serde(rename = "type", default)]\n$1pub r#type: Type,/g' {} +
+	find openapi_client/src/models -name '*.rs' -exec \
+		perl -0pi -e 's/#\[serde\(rename = "sport"\)\]\n(\s*)pub sport: Sport,/#[serde(rename = "sport", default)]\n$1pub sport: Sport,/g' {} +
+	find openapi_client/src/models -name '*.rs' -exec \
+		perl -0pi -e 's/#\[serde\(rename = "kind"\)\]\n(\s*)pub kind: Kind,/#[serde(rename = "kind", default)]\n$1pub kind: Kind,/g' {} +
 	# Post-process: `LiveEventInput` nests a second discriminated union (each
 	# sport's own `kind`-tagged event union) inside its own `sport`-tagged
 	# variants. The generator handles that inner `oneOf` correctly wherever

--- a/agon_service/src/main.rs
+++ b/agon_service/src/main.rs
@@ -1407,6 +1407,27 @@ struct LiveEventPage {
     next_cursor: Option<String>,
 }
 
+/// The match's current live-scoring counter — `GET
+/// /matches/:match_id/live/seq`. A client with no cached mutation response
+/// to seed `expected_last_seq` from (a fresh page load, a different device)
+/// needs this: the physical event log's own max seq (`GET
+/// /matches/:match_id/live/events`) is *not* a safe substitute once any
+/// event has ever been undone — it permanently understates the true
+/// counter from that point on (see `Dao::delete_live_event`'s doc comment).
+#[derive(Object)]
+struct LiveSeq {
+    last_seq: u32,
+}
+
+#[derive(ApiResponse)]
+enum GetLiveSeqResponse {
+    #[oai(status = 200)]
+    Ok(Json<LiveSeq>),
+
+    #[oai(status = 404)]
+    NotFound(PlainText<String>),
+}
+
 #[derive(ApiResponse)]
 enum ListLiveEventsResponse {
     #[oai(status = 200)]
@@ -3374,6 +3395,38 @@ impl Api {
             last_seq: new_last_seq,
             score,
         }))
+    }
+
+    /// The match's current live-scoring counter — what a client with no
+    /// cached mutation response should seed `expected_last_seq` from (a
+    /// fresh page load, or a device that's never scored this match before).
+    /// Reads `MatchRecord.live_seq` directly off the same `get_match` call
+    /// every other match read already makes — no extra table read beyond
+    /// that. Deliberately *not* derived from the physical event log's max
+    /// seq the way `GET /matches/:match_id/live/events` would suggest:
+    /// once any event has ever been undone, `live_seq` permanently outruns
+    /// that log's own max (see `Dao::delete_live_event`'s doc comment), so
+    /// a client that seeded its append token from the log instead would
+    /// send a stale `expected_last_seq` on every append from then on and
+    /// get rejected with `Conflict` forever.
+    #[oai(path = "/matches/:match_id/live/seq", method = "get")]
+    async fn get_live_seq(
+        &self,
+        Data(dao): Data<&dao::Dao>,
+        AuthSchema(_jwt_data): AuthSchema,
+        Path(match_id): Path<String>,
+    ) -> Result<GetLiveSeqResponse> {
+        let agg = match dao.get_match(&match_id).await.map_err(dao_internal)? {
+            Some(a) => a,
+            None => {
+                return Ok(GetLiveSeqResponse::NotFound(PlainText(
+                    "match not found".into(),
+                )));
+            }
+        };
+        Ok(GetLiveSeqResponse::Ok(Json(LiveSeq {
+            last_seq: agg.match_.live_seq,
+        })))
     }
 
     /// The raw live event log, oldest first — for reconstructing the full

--- a/agon_tests/tests/api.rs
+++ b/agon_tests/tests/api.rs
@@ -3692,6 +3692,81 @@ async fn netball_quarter_only_scoring_uses_period_marker_score_directly() {
 // netball-specific.
 // ---------------------------------------------------------------------------
 
+/// Regression test for the bug where a UI client seeded its append token
+/// (`expected_last_seq`) from the physical event log's own max seq — fine
+/// before any undo, but permanently wrong after one, since undoing bumps the
+/// real `live_seq` counter past the deleted event without leaving a matching
+/// physical item behind (see `Dao::delete_live_event`'s doc comment). In the
+/// app this showed up as: undo an event, refresh the page (throwing away the
+/// in-session cache that had been seeded correctly from the undo's own
+/// response), and every append from then on 409s forever. `GET
+/// /matches/:id/live/seq` exists precisely so a fresh client has a correct
+/// value to seed from instead of falling back to the event log.
+#[tokio::test]
+async fn live_seq_endpoint_reflects_the_real_counter_not_the_physical_log_max() {
+    let (owner_config, _owner) = new_user().await;
+    let (_invitee_config, invitee) = new_user().await;
+
+    let created = matches_post(&owner_config, netball_match_input(&invitee.profile.id))
+        .await
+        .expect("create match");
+    let side_a = created.sides[0].id.clone();
+
+    // No events yet — the counter is 0.
+    let seq = matches_match_id_live_seq_get(&owner_config, &created.id)
+        .await
+        .expect("get live seq");
+    assert_eq!(seq.last_seq, 0);
+
+    append_live_events_raw(
+        &owner_config,
+        &created.id,
+        0,
+        vec![
+            netball_goal_event_json(&side_a, false),
+            netball_goal_event_json(&side_a, false),
+        ],
+    )
+    .await;
+
+    let seq = matches_match_id_live_seq_get(&owner_config, &created.id)
+        .await
+        .expect("get live seq");
+    assert_eq!(seq.last_seq, 2);
+
+    // Undo the tip — the physical log's own max seq drops to 1, but the real
+    // counter is 3 (bumped past the deleted event). This endpoint must
+    // report the counter, not the physical max.
+    matches_match_id_live_events_seq_delete(&owner_config, &created.id, 2)
+        .await
+        .expect("undo the second goal");
+
+    let page = matches_match_id_live_events_get(&owner_config, &created.id, None, None)
+        .await
+        .expect("list live events");
+    let physical_max = page.items.iter().map(|e| e.seq).max().unwrap_or(0);
+    assert_eq!(physical_max, 1, "physical log's own max seq after the undo");
+
+    let seq = matches_match_id_live_seq_get(&owner_config, &created.id)
+        .await
+        .expect("get live seq");
+    assert_eq!(
+        seq.last_seq, 3,
+        "the real counter, not the physical log's max seq (1)"
+    );
+
+    // And it's exactly the value the very next append needs as
+    // expected_last_seq — the point of the whole endpoint.
+    let after_append = append_live_events_raw(
+        &owner_config,
+        &created.id,
+        seq.last_seq,
+        vec![netball_goal_event_json(&side_a, false)],
+    )
+    .await;
+    assert_eq!(after_append.last_seq, 4);
+}
+
 /// Regression test for the bug where undoing the tip event left the client
 /// unable to record anything else afterward.
 ///

--- a/agon_ui/src/hooks/useLiveScore.ts
+++ b/agon_ui/src/hooks/useLiveScore.ts
@@ -47,12 +47,23 @@ export function useLiveEvents(matchId: string | undefined, options?: { enabled?:
 
 /** The log's real physical tip — the highest `seq` an event actually exists
  *  at, 0 if none yet — by draining the raw event log and taking the max.
- *  Shared queryFn logic for `useLiveSeq` and `useUndoTargetSeq`, which start
- *  out reading the same value but diverge from there (see
- *  `useUndoTargetSeq`'s doc comment). */
+ *  Used by `useUndoTargetSeq` only. NOT safe for seeding `useLiveSeq`'s
+ *  append token — see that hook's doc comment for why the two are not
+ *  interchangeable once any event has ever been undone. */
 async function fetchLivePhysicalTip(matchId: string): Promise<number> {
   const events = await drainLiveEvents(matchId)
   return events.reduce((max, e) => Math.max(max, e.seq), 0)
+}
+
+/** The match's real `live_seq` counter, straight from the server —
+ *  `GET /matches/:id/live/seq`. Shared queryFn for `useLiveSeq`'s seed. */
+async function fetchLiveSeq(matchId: string): Promise<number> {
+  const { data, response } = await fetchClient.GET('/matches/{match_id}/live/seq', {
+    params: { path: { match_id: matchId } },
+  })
+  if (response.status === 404) return 0
+  if (!data) throw new Error('Failed to load live seq')
+  return data.last_seq
 }
 
 export function liveSeqQueryKey(matchId: string | undefined) {
@@ -62,10 +73,23 @@ export function liveSeqQueryKey(matchId: string | undefined) {
 /**
  * The optimistic-concurrency token for the *next append* — `expected_last_seq`
  * — not a read of the score itself (see `useMatchScore` for that; there's no
- * separate "live state" endpoint anymore). Seeded once by draining the raw
- * event log (the real physical tip, same as `useUndoTargetSeq`); every
+ * separate "live state" endpoint for scores). Seeded from `GET
+ * /matches/:id/live/seq`, the server's actual `live_seq` counter; every
  * append or undo after that updates the cached value directly from its own
  * response's `last_seq` instead of refetching.
+ *
+ * This must NOT be seeded from the physical event log's max seq the way
+ * `useUndoTargetSeq` is (regression: an earlier version of this hook did
+ * exactly that via the same `fetchLivePhysicalTip` helper). The two start
+ * out equal, but permanently diverge the moment an event is ever undone —
+ * `live_seq` counts every mutation ever made (including deletes), while the
+ * physical log's max seq only ever reflects what's still there (see
+ * `Dao::delete_live_event`'s doc comment on the backend). A device that
+ * seeds its append token from the log instead of the real counter sends a
+ * stale `expected_last_seq` on its very next append and gets rejected with
+ * `Conflict` forever after that — exactly what a page refresh right after an
+ * undo used to do, since the refresh throws away the in-session cache
+ * (populated correctly by the undo's own response) and reseeds from scratch.
  *
  * That response `last_seq` is always the match's `live_seq` counter, not
  * necessarily a seq any event still physically exists at (see
@@ -79,7 +103,7 @@ export function useLiveSeq(matchId: string | undefined, options?: { enabled?: bo
     queryKey: liveSeqQueryKey(matchId),
     enabled: !!matchId && (options?.enabled ?? true),
     staleTime: Infinity,
-    queryFn: () => fetchLivePhysicalTip(matchId!),
+    queryFn: () => fetchLiveSeq(matchId!),
   })
 }
 


### PR DESCRIPTION
Follow-up to #88.

## Problem

`useLiveSeq` (the client's `expected_last_seq` for the *next* live-scoring append) was seeded from the physical event log's own max `seq` on a fresh page load. That's correct only until the first event is ever undone: undoing bumps the real `live_seq` counter past the deleted event without leaving a matching physical item behind (see `Dao::delete_live_event`'s doc comment), so the log's own max seq permanently understates the true counter from that point on.

Within a live session this was invisible — a successful append/undo response updates the cached value directly. But a page refresh throws that cache away and reseeds from the physical log again, so every append after an undo-then-refresh sent a stale `expected_last_seq` and got rejected with a conflict forever. That's the "I can undo, but after refreshing I can't submit anymore" symptom.

## Fix

- Added `GET /matches/:match_id/live/seq`, returning the match's real `live_seq` counter directly — no extra DB read, since it's already loaded by the same `get_match` call every other match read makes.
- `useLiveSeq` now seeds from that endpoint instead of the physical event log.
- Added an integration test (`live_seq_endpoint_reflects_the_real_counter_not_the_physical_log_max`) pinning down the exact divergence: after one undo, the physical log's max seq and the new endpoint's value differ (1 vs 3 in the test), and the endpoint's value is what the next append actually needs.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, and `cargo build` all clean.
- Regenerated `schema.json` and both the TypeScript (`openapi-typescript`) and Rust (`openapi-generator-cli`) clients locally to confirm the new endpoint's types are correct and `agon_tests` compiles against it (`cargo check --manifest-path agon_tests/Cargo.toml --tests`).
- `npx tsc -b` and `npx eslint` clean on the UI side.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013vArDw9VLtMermPtwzKQS4)_