### PR TITLE
Install rustls crypto provider in telemetry init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "rustls 0.23.28",
  "serde",
  "serde_dynamo",
  "serde_json",

--- a/agon_core/Cargo.toml
+++ b/agon_core/Cargo.toml
@@ -41,3 +41,7 @@ opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "trace", "metrics", "logs"] }
 opentelemetry-appender-tracing = "0.32"
+# Only for `crypto::ring::default_provider().install_default()` in
+# `telemetry::init` — see its doc comment. `ring` (not `aws-lc-rs`) to match
+# what the Temporal SDK / reqwest's `rustls-tls` already pull in.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/agon_core/src/telemetry.rs
+++ b/agon_core/src/telemetry.rs
@@ -77,6 +77,19 @@ impl Drop for Telemetry {
 /// installed and the returned guard is inert — so local runs and tests behave
 /// exactly as before this module existed.
 pub fn init(service_name: &'static str) -> Telemetry {
+    // rustls 0.23 no longer auto-selects a crypto backend when a process's
+    // dependency graph pulls in more than one (here: `ring`, via the Temporal
+    // SDK / reqwest's `rustls-tls`, and `aws-lc-rs`, via the AWS SDK crates) —
+    // without an explicit process-wide default, the *first* real TLS client
+    // construction anywhere (OTLP export, Meilisearch, FCM push, Temporal's
+    // gRPC client, ...) panics with "no process-level CryptoProvider
+    // available". `init` is the first thing both binaries' `main` calls, so
+    // install it here, once, before anything else can race to construct a
+    // TLS client. `install_default` errors if a provider is already
+    // installed (e.g. a second `init()` call within one process, such as in
+    // tests) — that's fine, the first installation already won.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let filter = || EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     // Always emit JSON logs to stdout. In the cluster these are still captured


### PR DESCRIPTION
## Summary
Adds explicit rustls crypto provider initialization to prevent panics when multiple TLS backends are present in the dependency graph. This resolves a rustls 0.23 requirement where a process-level CryptoProvider must be installed before any TLS client construction.

## Changes
- **telemetry.rs**: Install rustls's `ring`-based crypto provider at the start of `init()`, before any other code can construct a TLS client (OTLP export, Meilisearch, FCM, Temporal gRPC, etc.)
- **Cargo.toml**: Add `rustls` 0.23 with `ring` feature to match the crypto backend already pulled in by the Temporal SDK and reqwest's `rustls-tls`

## Implementation Details
- The `init()` function is called first in both binaries' `main()`, making it the ideal place to install the provider once, before any race conditions
- Uses `let _ = ...install_default()` to safely ignore errors from repeated calls (e.g., in tests), since the first installation already wins
- Includes detailed comment explaining the rustls 0.23 behavior and why this is necessary
- Selects `ring` (not `aws-lc-rs`) to match existing transitive dependencies from the Temporal SDK and reqwest

https://claude.ai/code/session_01DrbZTgBNRZ1b1oJxL4Sofe