### PR TITLE
Add iOS install support: standalone meta tags + manual A2HS banner

### DIFF
--- a/agon_ui/index.html
+++ b/agon_ui/index.html
@@ -7,6 +7,18 @@
     <link rel="mask-icon" href="/masked-icon.svg" color="#2563EB" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      iOS Safari has no `beforeinstallprompt`/install-banner API (unlike
+      Chrome/Android) and ignores the web manifest's `display: standalone`.
+      Without this tag, a page added via Share -> Add to Home Screen still
+      opens inside Safari's browser chrome instead of as a standalone app.
+      `mobile-web-app-capable` is the non-prefixed standard other engines
+      (and iOS 17.4+) read; keep the `apple-` one too for older iOS.
+    -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Agon" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/agon_ui/src/App.tsx
+++ b/agon_ui/src/App.tsx
@@ -13,6 +13,7 @@ import { PushNotificationsProvider } from '@/hooks/usePushNotifications'
 import { LoginForm } from '@/components/auth/LoginForm'
 import { CreateProfileForm } from '@/components/auth/CreateProfileForm'
 import { InvitePreviewBanner } from '@/components/auth/InvitePreviewBanner'
+import { IosInstallBanner } from '@/components/IosInstallBanner'
 import { AppSidebar } from '@/components/AppSidebar'
 import { MobileBottomNav } from '@/components/MobileBottomNav'
 import { Logo } from '@/components/agon/Logo'
@@ -91,6 +92,7 @@ function AppShell({ email, onSignOut }: { email: string; onSignOut: () => void }
         </header>
 
         <main className="container mx-auto px-4 py-8 pb-28 md:pb-8">
+          <IosInstallBanner />
           <Routes>
           <Route path="/" element={<HomeRedirect />} />
           <Route path="/feed" element={<FeedPage />} />

--- a/agon_ui/src/components/IosInstallBanner.tsx
+++ b/agon_ui/src/components/IosInstallBanner.tsx
@@ -1,0 +1,41 @@
+import { Share, X } from 'lucide-react'
+import { useIosAddToHomeScreenPrompt } from '@/hooks/useIosAddToHomeScreenPrompt'
+import { Button } from '@/components/ui/button'
+
+/**
+ * Chrome/Android gets the native "Install app?" popup for free via
+ * `beforeinstallprompt`. iOS Safari has no equivalent event — Apple simply
+ * doesn't expose one — so the only install path there is the user manually
+ * tapping Share -> "Add to Home Screen". This banner is the in-app stand-in
+ * for that missing native prompt: shown once (per browser) to iOS Safari
+ * visitors who haven't installed yet, dismissible for good.
+ */
+export function IosInstallBanner() {
+  const { show, dismiss } = useIosAddToHomeScreenPrompt()
+
+  if (!show) return null
+
+  return (
+    <div className="mb-6 flex items-center gap-3 rounded-xl border bg-card p-4 text-left">
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Share className="size-5" />
+      </div>
+      <div className="min-w-0 flex-1 text-sm">
+        <p className="font-medium">Install Agon on your device</p>
+        <p className="text-muted-foreground">
+          Tap <Share className="inline size-3.5 align-text-bottom" strokeWidth={2.5} /> in
+          Safari, then "Add to Home Screen"
+        </p>
+      </div>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="shrink-0"
+        onClick={dismiss}
+        aria-label="Dismiss"
+      >
+        <X className="size-4" />
+      </Button>
+    </div>
+  )
+}

--- a/agon_ui/src/hooks/useIosAddToHomeScreenPrompt.ts
+++ b/agon_ui/src/hooks/useIosAddToHomeScreenPrompt.ts
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+
+/** Remembers that the user dismissed the banner, so it only nags once. */
+const DISMISSED_KEY = 'agon-ios-a2hs-dismissed'
+
+function isIosDevice(): boolean {
+  const ua = window.navigator.userAgent
+  if (/iphone|ipad|ipod/i.test(ua)) return true
+  // iPadOS 13+ reports a desktop Safari UA (masquerading as macOS), but a
+  // real Mac has no touch points to speak of.
+  return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1
+}
+
+function isSafari(): boolean {
+  const ua = window.navigator.userAgent
+  // Chrome/Firefox/Edge on iOS are all required to use WebKit under the
+  // hood and their UA still contains "Safari", but they carry their own
+  // token too — and only the real Safari can install a home-screen app.
+  return /safari/i.test(ua) && !/crios|fxios|edgios|opios/i.test(ua)
+}
+
+function isStandalone(): boolean {
+  // iOS Safari exposes this non-standard property once launched from a
+  // home-screen icon; other engines report it via the media query instead.
+  return (
+    (window.navigator as { standalone?: boolean }).standalone === true ||
+    window.matchMedia('(display-mode: standalone)').matches
+  )
+}
+
+/**
+ * iOS Safari never fires `beforeinstallprompt` — Apple has no equivalent API
+ * — so there's no way to trigger a native install prompt there like on
+ * Chrome/Android. The only install path is the user manually tapping
+ * Share -> "Add to Home Screen", which can't be triggered from JS either.
+ * This just detects "installable but not yet installed, on the one browser
+ * that supports it" so the UI can show instructions instead.
+ */
+export function useIosAddToHomeScreenPrompt(): { show: boolean; dismiss: () => void } {
+  const [dismissed, setDismissed] = useState(
+    () => localStorage.getItem(DISMISSED_KEY) === 'true',
+  )
+
+  const show = !dismissed && isIosDevice() && isSafari() && !isStandalone()
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, 'true')
+    setDismissed(true)
+  }
+
+  return { show, dismiss }
+}


### PR DESCRIPTION
Chrome/Android gets the native "Install app?" popup via
beforeinstallprompt, which the manifest/icons/service worker already
satisfy. iOS Safari has no equivalent event at all — Apple doesn't
expose one — so there's nothing to hook a prompt into there, and the
missing apple-mobile-web-app-capable meta tag meant a manual
Add to Home Screen would still open inside Safari's chrome instead of
standalone.

- index.html: add apple-mobile-web-app-capable (+ the non-prefixed
  mobile-web-app-capable, status-bar-style, and title) so a home
  screen install actually launches standalone.
- useIosAddToHomeScreenPrompt: detects iOS Safari, not yet installed,
  not previously dismissed (persisted via localStorage).
- IosInstallBanner: dismissible in-app banner shown to those visitors
  with Share -> Add to Home Screen instructions, since that's the only
  install path iOS supports and it can't be triggered from JS.