### PR TITLE
Always run deploy/test/test-ui-e2e regardless of what changed

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -10,9 +10,6 @@ on:
       ui:
         description: 'agon_ui changed'
         value: ${{ jobs.changes.outputs.ui }}
-      infra:
-        description: 'agon_infra (pulumi stack config/program) changed'
-        value: ${{ jobs.changes.outputs.infra }}
 
 jobs:
   changes:
@@ -21,7 +18,6 @@ jobs:
       service: ${{ steps.filter.outputs.service }}
       worker: ${{ steps.filter.outputs.worker }}
       ui: ${{ steps.filter.outputs.ui }}
-      infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
 
@@ -46,5 +42,3 @@ jobs:
               - 'agon_worker/**'
             ui:
               - 'agon_ui/**'
-            infra:
-              - 'agon_infra/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,20 +46,19 @@ jobs:
     uses: JElgar/agon/.github/workflows/docker-ui.yml@main
     secrets: inherit
 
-  # Runs whenever any image was (re)published, OR agon_infra itself changed
-  # (a pulumi program/config edit with no image to rebuild still needs a
-  # `pulumi up` to take effect). Skipped images pass an empty string through,
-  # and deploy.yml leaves that image's pulumi config alone — so e.g. a
-  # UI-only change updates agonUiImage and redeploys, without touching (or
+  # Always runs, regardless of what (if anything) changed: `pulumi up` is
+  # idempotent/cheap when there's no diff, and deploy/test/test-ui-e2e also
+  # serve as a continuous check of the live staging environment, not just of
+  # this push. `always()` is required because some of the needs above are
+  # routinely skipped (see the note on `build-service`/`build-ui`) — without
+  # it, GitHub's default "all needs must succeed" gate would skip this job
+  # too. publish-service/worker/ui pass an empty image string through when
+  # skipped, and deploy.yml leaves that image's pulumi config alone — so
+  # e.g. a UI-only change updates agonUiImage, without touching (or
   # rebuilding) the service/worker images at all.
   deploy:
     needs: [changes, publish-service, publish-worker, publish-ui]
-    if: |
-      always() &&
-      (needs.publish-service.result == 'success' ||
-       needs.publish-worker.result == 'success' ||
-       needs.publish-ui.result == 'success' ||
-       needs.changes.outputs.infra == 'true')
+    if: always()
     uses: JElgar/agon/.github/workflows/deploy.yml@main
     secrets: inherit
     with:
@@ -70,7 +69,6 @@ jobs:
 
   test:
     needs: deploy
-    if: needs.deploy.result == 'success'
     uses: JElgar/agon/.github/workflows/test.yml@main
     with:
       agon-service-url: ${{ needs.deploy.outputs.agon-url }}/api
@@ -80,7 +78,6 @@ jobs:
 
   test-ui-e2e:
     needs: deploy
-    if: needs.deploy.result == 'success'
     uses: JElgar/agon/.github/workflows/test-ui-e2e.yml@main
     with:
       base-url: ${{ needs.deploy.outputs.agon-url }}


### PR DESCRIPTION
## Summary
Follow-up to #93. That PR gated `deploy`/`test`/`test-ui-e2e` in `release.yml` on whether a publish job actually ran, which turned out fragile — an `agon_infra`-only change made all three `publish-*` jobs skip, which in turn skipped `deploy` (and therefore the tests) entirely, since nothing had been "published". A one-off `infra` path filter patched that specific case, but the same class of gap could recur for anything else that isn't image source but still needs a deploy or a staging check.

## Change
- `deploy` now always runs (`if: always()`, unconditionally) instead of requiring a publish to have succeeded. `pulumi up` is idempotent/cheap when there's no diff to apply.
- `test`/`test-ui-e2e` drop their explicit `if: needs.deploy.result == 'success'` — now that `deploy` is never skipped, the default "needs must succeed" behavior does the same job without a special case, and they also serve as a continuous check of the live staging environment on every push to `main`, not just pushes that happened to rebuild an image.
- Removed the now-unused `infra` filter/output from `changes.yml`.

The conditional gating from #93 stays as-is for the actually expensive steps: `build-service`/`build-ui` and the three `publish-*` jobs still only run for the component(s) that changed.

https://claude.ai/code/session_01J4SrX7qvVnA7AbR4CD6STw

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4SrX7qvVnA7AbR4CD6STw)_